### PR TITLE
Initial dataset class interface

### DIFF
--- a/src/hyrax/data_sets/__init__.py
+++ b/src/hyrax/data_sets/__init__.py
@@ -1,12 +1,6 @@
-from .data_set_registry import DATA_SET_REGISTRY, hyrax_data_set
+from .data_set_registry import DATA_SET_REGISTRY, Dataset
 from .hsc_data_set import HSCDataSet
 from .hyrax_cifar_data_set import HyraxCifarDataSet
 from .inference_dataset import InferenceDataSet
 
-__all__ = [
-    "hyrax_data_set",
-    "DATA_SET_REGISTRY",
-    "HyraxCifarDataSet",
-    "HSCDataSet",
-    "InferenceDataSet",
-]
+__all__ = ["DATA_SET_REGISTRY", "HyraxCifarDataSet", "HSCDataSet", "InferenceDataSet", "Dataset"]

--- a/src/hyrax/data_sets/data_set_registry.py
+++ b/src/hyrax/data_sets/data_set_registry.py
@@ -1,29 +1,118 @@
+# ruff: noqa: D102, B027
 import logging
+from abc import ABC, abstractmethod
+from collections.abc import Generator
 
-from torch.utils.data import Dataset
+import numpy.typing as npt
 
+from hyrax.config_utils import ConfigDict
 from hyrax.plugin_utils import get_or_load_class, update_registry
 
 logger = logging.getLogger(__name__)
+DATA_SET_REGISTRY: dict[str, type["Dataset"]] = {}
 
-DATA_SET_REGISTRY: dict[str, type[Dataset]] = {}
 
-
-def hyrax_data_set(cls):
-    """Decorator to register a data loader with the registry.
-
-    Returns
-    -------
-    type
-        The original, unmodified class.
+class Dataset(ABC):
     """
-    required_methods = ["shape", "__getitem__", "__len__", "ids"]
-    for name in required_methods:
-        if not hasattr(cls, name):
-            logger.error(f"Hyrax data set {cls.__name__} missing required method {name}.")
+    How to make a hyrax dataset:
 
-    update_registry(DATA_SET_REGISTRY, cls.__name__, cls)
-    return cls
+    Start from this template and implement your functions.
+
+    ```
+    import torch.utils.data as td
+    class MyDataSet(Dataset, td.Dataset):
+        def __init__(self, config: dict):
+            super().__init__(config)
+
+        def __getitem__():
+            # Your getitem goes here
+            pass
+
+        def __len__ ():
+            # Your len function goes here
+            pass
+
+    ```
+
+    <guidance on what each function should do>
+
+    # Overriding IDs
+
+    < How to implement the ids() function as a generator of strings>
+
+    # Metadata Interface (simple)
+
+    < How to pass us a numpy rec array (or astropy table) >
+
+    # Metadata interface (complex)
+
+    <How to implement metadata() and metadata_fields()>
+
+    # Data members provided by the superclass
+
+    `self.config` This is the hyrax config nested dictionary that hyrax was launched with.
+
+    """
+
+    def __init__(self, config: ConfigDict):
+        """Overall initialization for all DataSets which saves the config"""
+        self.config = config
+
+    def __init_subclass__(cls):
+        from torch.utils.data import IterableDataset
+
+        if IterableDataset in cls.__bases__ or hasattr(cls, "__iter__"):
+            logger.error("Hyrax does not fully support iterable data sets yet. Proceed at your own risk.")
+
+        # Paranoia. Deriving from a torch dataset class should ensure this, but if an external dataset author
+        # Forgets to to do that, we tell them.
+        if (not hasattr(cls, "__iter__")) and not (hasattr(cls, "__getitem__") and hasattr(cls, "__len__")):
+            msg = f"Hyrax data set {cls.__name__} is missing required iteration functions."
+            msg += "__len__ and __getitem__ (or __iter__) must be defined. It is recommended to derive from"
+            msg += " torch.utils.data.Dataset (or torch.utils.data.IterableDataset) which will enforce this."
+            raise RuntimeError(msg)
+
+        # Ensure the class is in the registry so the config system can find it
+        update_registry(DATA_SET_REGISTRY, cls.__name__, cls)
+
+    def set_metadata_table(self, table: npt.ArrayLike):
+        # This is the function child classes can call during construction to submit their metadata table
+        # TODO implement this or make it part of __init__ above.
+        pass
+
+    @abstractmethod
+    def ids(self) -> Generator[str]:
+        # Perhaps make a default version which counts up
+        # This could be `return (str(x) for x in range(len(self)))` on map datasets and
+        # traversing the iterator and yielding increasing numbers on iterator datasets
+        pass
+
+    @abstractmethod
+    def shape(self) -> tuple:
+        # Implement using the 0th element (detect whether __iter__ or __getitem__ and do the right thing)
+        pass
+
+    @abstractmethod
+    def metadata_fields(self) -> list[str]:
+        # Implement using a numpy array passed from child
+        pass
+
+    @abstractmethod
+    def metadata(self, idxs: npt.ArrayLike, fields: list[str]) -> npt.ArrayLike:
+        # Implement using a numpy array passed from child
+        pass
+
+    @abstractmethod
+    def original_config(self) -> dict:
+        # Harder to implement generally, need to designate some configs as directories
+        # and resolve those directories.
+        #
+        # As a first pass we could hardcode these (they are already hardcoded in HSCDataSet)
+        # For future external datasets we'll need to allow datasets when they define their configs
+        # to designate "this is a path" so we know which ones to do path resolution on.
+        #
+        # For now ["general"]["data_dir"] and ["data_set"]["filter_catalog"] are known to be paths.
+        pass
 
 
 def fetch_data_set_class(runtime_config: dict) -> type[Dataset]:

--- a/src/hyrax/data_sets/hsc_data_set.py
+++ b/src/hyrax/data_sets/hsc_data_set.py
@@ -19,9 +19,9 @@ import torch
 from astropy.io import fits
 from astropy.table import Table
 from schwimmbad import MultiPool
-from torch.utils.data import Dataset
 from torchvision.transforms.v2 import CenterCrop, Compose, Lambda
 
+from hyrax.config_utils import ConfigDict
 from hyrax.download import Downloader
 from hyrax.downloadCutout.downloadCutout import (
     parse_bool,
@@ -33,19 +33,18 @@ from hyrax.downloadCutout.downloadCutout import (
     parse_type,
 )
 
-from .data_set_registry import hyrax_data_set
+from .data_set_registry import Dataset
 
 logger = logging.getLogger(__name__)
 dim_dict = dict[str, list[tuple[int, int]]]
 files_dict = dict[str, dict[str, str]]
 
 
-@hyrax_data_set
-class HSCDataSet(Dataset):
+class HSCDataSet(Dataset, torch.utils.data.Dataset):
     _called_from_test = False
 
-    def __init__(self, config: dict):
-        self.config = config
+    def __init__(self, config: ConfigDict):
+        super().__init__(config)
 
         crop_to = config["data_set"]["crop_to"]
         filters = config["data_set"]["filters"]

--- a/src/hyrax/data_sets/hyrax_cifar_data_set.py
+++ b/src/hyrax/data_sets/hyrax_cifar_data_set.py
@@ -10,13 +10,12 @@ from torchvision.datasets import CIFAR10
 
 from hyrax.config_utils import ConfigDict
 
-from .data_set_registry import hyrax_data_set
+from .data_set_registry import Dataset
 
 logger = logging.getLogger(__name__)
 
 
-@hyrax_data_set
-class HyraxCifarDataSet(CIFAR10):
+class HyraxCifarDataSet(Dataset, CIFAR10):
     """This is simply a version of CIFAR10 that has our needed shape method, and is initialized using
     Hyrax config with a transformation that works well for example code.
 
@@ -25,11 +24,13 @@ class HyraxCifarDataSet(CIFAR10):
     """
 
     def __init__(self, config: ConfigDict):
+        super().__init__(config)
         transform = transforms.Compose(
             [transforms.ToTensor(), transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5))]
         )
-        self.config = config
-        super().__init__(root=config["general"]["data_dir"], train=True, download=True, transform=transform)
+        CIFAR10.__init__(
+            self, root=config["general"]["data_dir"], train=True, download=True, transform=transform
+        )
 
     def ids(self) -> Generator[str]:
         return (str(x) for x in range(len(self)))

--- a/src/hyrax/data_sets/inference_dataset.py
+++ b/src/hyrax/data_sets/inference_dataset.py
@@ -6,20 +6,19 @@ from typing import Optional, Union
 
 import numpy as np
 import numpy.typing as npt
+import torch.utils.data as td
 from torch import Tensor, from_numpy
-from torch.utils.data import Dataset
 
 from hyrax.config_utils import find_most_recent_results_dir
 
-from .data_set_registry import hyrax_data_set
+from .data_set_registry import Dataset
 
 logger = logging.getLogger(__name__)
 
 ORIGINAL_DATASET_CONFIG_FILENAME = "original_dataset_config.toml"
 
 
-@hyrax_data_set
-class InferenceDataSet(Dataset):
+class InferenceDataSet(Dataset, td.Dataset):
     """This is a dataset class to represent the situations where we wish to treat the output of inference
     as a dataset. e.g. when performing umap/visualization operations"""
 
@@ -32,7 +31,7 @@ class InferenceDataSet(Dataset):
         from hyrax.config_utils import ConfigManager
         from hyrax.pytorch_ignite import setup_dataset
 
-        self.config = config
+        super().__init__(config)
         self.results_dir = self._resolve_results_dir(config, results_dir, verb)
 
         # Open the batch index numpy file.


### PR DESCRIPTION
This is a skeleton of a superclass for Datasets. The intent is to provide a scaffold for folks writing dataset classes such that they have:
1) Clear instructions on what functions to implement
2) "Batteries included" for the more complex features of Dataset classes that HSC relies on (metadata, original_config, etc)

The version below is a noop change to fibad's functionality, and the individual abstract methods are commented with how they would be implemented in the base class to make future dataset classes easier to write.

I'm looking for feedback on the overall interface at this point, since this code doesn't do anything at the moment 🙂 
