### PR TITLE
Move Dataset code into base classes pt1

### DIFF
--- a/src/hyrax/config_utils.py
+++ b/src/hyrax/config_utils.py
@@ -186,7 +186,7 @@ class ConfigManager:
 
     """
     Hardcoded set of config keys which definitionally contain paths, and we resolve to global paths
-    duringin itialization in ConfigManager._resolve_config_paths().
+    during initialization in ConfigManager._resolve_config_paths().
     """
     PATH_CONFIG_KEYS = [
         # TODO: external library config defaults

--- a/src/hyrax/data_sets/__init__.py
+++ b/src/hyrax/data_sets/__init__.py
@@ -1,6 +1,13 @@
-from .data_set_registry import DATA_SET_REGISTRY, Dataset
+from .data_set_registry import DATA_SET_REGISTRY, HyraxDataset
 from .hsc_data_set import HSCDataSet
 from .hyrax_cifar_data_set import HyraxCifarDataSet
 from .inference_dataset import InferenceDataSet
 
-__all__ = ["DATA_SET_REGISTRY", "HyraxCifarDataSet", "HSCDataSet", "InferenceDataSet", "Dataset"]
+__all__ = [
+    "DATA_SET_REGISTRY",
+    "HyraxCifarDataSet",
+    "HSCDataSet",
+    "InferenceDataSet",
+    "Dataset",
+    "HyraxDataset",
+]

--- a/src/hyrax/data_sets/hyrax_cifar_data_set.py
+++ b/src/hyrax/data_sets/hyrax_cifar_data_set.py
@@ -10,12 +10,12 @@ from torchvision.datasets import CIFAR10
 
 from hyrax.config_utils import ConfigDict
 
-from .data_set_registry import Dataset
+from .data_set_registry import HyraxDataset
 
 logger = logging.getLogger(__name__)
 
 
-class HyraxCifarDataSet(Dataset, CIFAR10):
+class HyraxCifarDataSet(HyraxDataset, CIFAR10):
     """This is simply a version of CIFAR10 that has our needed shape method, and is initialized using
     Hyrax config with a transformation that works well for example code.
 

--- a/src/hyrax/pytorch_ignite.py
+++ b/src/hyrax/pytorch_ignite.py
@@ -21,7 +21,7 @@ from torch.utils.data import DataLoader, Dataset
 from torch.utils.data.sampler import SubsetRandomSampler
 
 from hyrax.config_utils import ConfigDict
-from hyrax.data_sets.data_set_registry import fetch_data_set_class
+from hyrax.data_sets.data_set_registry import HyraxDataset, fetch_data_set_class
 from hyrax.models.model_registry import fetch_model_class
 
 logger = logging.getLogger(__name__)
@@ -45,11 +45,9 @@ def setup_dataset(config: ConfigDict, tensorboardx_logger: Optional[SummaryWrite
 
     # Fetch data loader class specified in config and create an instance of it
     data_set_cls = fetch_data_set_class(config)
-    data_set = data_set_cls(config)  # type: ignore[call-arg]
+    data_set: HyraxDataset = data_set_cls(config)  # type: ignore[call-arg]
 
-    # TODO base dataset class: A base class for datasets ought have this as a property defined simply
-    # to document its existance in a central location.
-    data_set.tensorboardx_logger = tensorboardx_logger  # type: ignore[attr-defined]
+    data_set.tensorboardx_logger = tensorboardx_logger
 
     return data_set
 


### PR DESCRIPTION
- Configuration subsystem now handles path resolution for a list of config keys. Hardcoded for now, but we can add as external library config interface takes shape.
- original_config removed from base class interface. Logic can live exclusively in InferenceDataset/InferenceDatasetWriter with the config subsystem handling path resolution
- Default implementation of ids() and shape() in base class
- s/Dataset/HyraxDataset to avoid clashing with torch
