### PR TITLE
Move dataset code into base class pt 2: Metadata edition

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,6 +45,15 @@ repos:
     hooks:
       - id: check-github-workflows
         args: ["--verbose"]
+  - repo: local
+    hooks:
+      - id: xcxc-check
+        name: Check for note-to-self comments (xcxc)
+        description: Grep all source files for xcxc which signifies a comment that shouldn't be checked in.
+        entry: bash -c "[[ $(grep -riI xcxc --exclude .pre-commit-config.yaml --exclude-dir _readthedocs --exclude-dir htmlcov ./* >&2 ; echo $?) == 1 ]]"
+        language: system
+        pass_filenames: false
+        always_run: true
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
     rev: v0.11.2

--- a/docs/pre_executed/visualize.ipynb
+++ b/docs/pre_executed/visualize.ipynb
@@ -37,29 +37,30 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[2025-03-26 14:59:15,311 hyrax:INFO] Runtime Config read from: /home/drew/code/fibad/src/hyrax/hyrax_default_config.toml\n",
-      "/home/drew/miniconda3/envs/fibad/lib/python3.12/site-packages/ignite/handlers/checkpoint.py:16: DeprecationWarning: `TorchScript` support for functional optimizers is deprecated and will be removed in a future PyTorch release. Consider using the `torch.compile` optimizer instead.\n",
+      "[2025-03-28 16:07:09,156 hyrax:INFO] Runtime Config read from: /Users/mtauraso/src/fibad/src/hyrax/hyrax_default_config.toml\n",
+      "/Users/mtauraso/miniforge3/envs/fibad/lib/python3.10/site-packages/ignite/handlers/checkpoint.py:16: DeprecationWarning: `TorchScript` support for functional optimizers is deprecated and will be removed in a future PyTorch release. Consider using the `torch.compile` optimizer instead.\n",
       "  from torch.distributed.optim import ZeroRedundancyOptimizer\n",
-      "[2025-03-26 14:59:18,822 hyrax.data_sets.hsc_data_set:INFO] Processed 993 objects for pruning\n",
-      "[2025-03-26 14:59:18,823 hyrax.data_sets.hsc_data_set:INFO] Checking file dimensions to determine standard cutout size...\n",
-      "[2025-03-26 14:59:18,825 hyrax.data_sets.hsc_data_set:INFO] HSC Data set loader has 993 objects\n",
-      "[2025-03-26 14:59:18,826 hyrax.data_sets.hsc_data_set:INFO] Preloading HSCDataSet cache...\n",
-      "[2025-03-26 14:59:18,863 hyrax.models.model_registry:INFO] Using criterion: torch.nn.CrossEntropyLoss with default arguments.\n",
-      "2025-03-26 14:59:18,931 ignite.distributed.auto.auto_dataloader INFO: Use data loader kwargs for dataset '<hyrax.data_sets.hsc': \n",
-      "\t{'sampler': <torch.utils.data.sampler.SubsetRandomSampler object at 0x7f76fe3df1d0>, 'batch_size': 512, 'pin_memory': True}\n",
-      "2025-03-26 14:59:18,935 ignite.distributed.auto.auto_dataloader INFO: Use data loader kwargs for dataset '<hyrax.data_sets.hsc': \n",
-      "\t{'sampler': <torch.utils.data.sampler.SubsetRandomSampler object at 0x7f76fe3dee10>, 'batch_size': 512, 'pin_memory': True}\n",
-      "/home/drew/miniconda3/envs/fibad/lib/python3.12/site-packages/ignite/handlers/tqdm_logger.py:127: TqdmExperimentalWarning: Using `tqdm.autonotebook.tqdm` in notebook mode. Use `tqdm.tqdm` instead to force console mode (e.g. in jupyter console)\n",
+      "[2025-03-28 16:07:11,497 hyrax.data_sets.hsc_data_set:INFO] Processed 993 objects for pruning\n",
+      "[2025-03-28 16:07:11,498 hyrax.data_sets.hsc_data_set:INFO] Checking file dimensions to determine standard cutout size...\n",
+      "[2025-03-28 16:07:11,499 hyrax.data_sets.hsc_data_set:INFO] HSC Data set loader has 993 objects\n",
+      "[2025-03-28 16:07:11,520 hyrax.data_sets.hsc_data_set:INFO] Preloading HSCDataSet cache...\n",
+      "[2025-03-28 16:07:11,530 hyrax.models.model_registry:INFO] Using criterion: torch.nn.CrossEntropyLoss with default arguments.\n",
+      "2025-03-28 16:07:11,544 ignite.distributed.auto.auto_dataloader INFO: Use data loader kwargs for dataset '<hyrax.data_sets.hsc': \n",
+      "\t{'sampler': <torch.utils.data.sampler.SubsetRandomSampler object at 0x16db21c60>, 'batch_size': 512, 'pin_memory': False}\n",
+      "2025-03-28 16:07:11,545 ignite.distributed.auto.auto_dataloader INFO: Use data loader kwargs for dataset '<hyrax.data_sets.hsc': \n",
+      "\t{'sampler': <torch.utils.data.sampler.SubsetRandomSampler object at 0x16dd64430>, 'batch_size': 512, 'pin_memory': False}\n",
+      "/Users/mtauraso/miniforge3/envs/fibad/lib/python3.10/site-packages/ignite/handlers/tqdm_logger.py:127: TqdmExperimentalWarning: Using `tqdm.autonotebook.tqdm` in notebook mode. Use `tqdm.tqdm` instead to force console mode (e.g. in jupyter console)\n",
       "  from tqdm.autonotebook import tqdm\n",
-      "2025/03/26 14:59:20 INFO mlflow.system_metrics.system_metrics_monitor: Started monitoring system metrics.\n",
-      "[2025-03-26 14:59:20,632 hyrax.pytorch_ignite:INFO] Training model on device: cuda\n",
-      "[2025-03-26 14:59:31,061 hyrax.data_sets.hsc_data_set:INFO] Processed 992 objects\n"
+      "2025/03/28 16:07:11 WARNING mlflow.system_metrics.system_metrics_monitor: Skip logging GPU metrics because creating `GPUMonitor` failed with error: Failed to initialize NVML, skip logging GPU metrics: NVML Shared Library Not Found.\n",
+      "2025/03/28 16:07:11 INFO mlflow.system_metrics.system_metrics_monitor: Started monitoring system metrics.\n",
+      "[2025-03-28 16:07:12,043 hyrax.pytorch_ignite:INFO] Training model on device: mps\n",
+      "[2025-03-28 16:07:14,946 hyrax.data_sets.hsc_data_set:INFO] Processed 992 objects\n"
      ]
     },
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "56df77ef91dd4f01829a5af08bbdd105",
+       "model_id": "338a8abbf3c0435fa410fdaf2241fb5d",
        "version_major": 2,
        "version_minor": 0
       },
@@ -73,7 +74,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "b08b5e14a69343b1ae0797dd450563ae",
+       "model_id": "1cdad9dde78046f682d04289f974e2e0",
        "version_major": 2,
        "version_minor": 0
       },
@@ -87,7 +88,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "1dd1e2cc6ffc457f96a6ae6ca390c0ed",
+       "model_id": "776f1b909cc04a8e88ffc5e77cb4bac3",
        "version_major": 2,
        "version_minor": 0
       },
@@ -101,7 +102,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "6916e0c73d5942ff85d63de7425329e8",
+       "model_id": "54d26d86fabd4fa5bbc7b616aa9443bc",
        "version_major": 2,
        "version_minor": 0
       },
@@ -115,7 +116,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "bd0f32e38f5b4f5095f425702cfd5230",
+       "model_id": "91dd60d3b74a48eda0a2ffe7ae547aee",
        "version_major": 2,
        "version_minor": 0
       },
@@ -129,7 +130,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "64310e9101ac4f2e8b4e235505b0381b",
+       "model_id": "93399c942c8f4a1489507088da113b5c",
        "version_major": 2,
        "version_minor": 0
       },
@@ -143,7 +144,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "ddb963091139477db277b33df6ccab25",
+       "model_id": "ffe1bea4eede4b19b791bc62752ed094",
        "version_major": 2,
        "version_minor": 0
       },
@@ -157,7 +158,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "7a8dd98d3c9a4d79b51993a2c092f763",
+       "model_id": "2201cb41f6ea4c86913a67c875c6f5b1",
        "version_major": 2,
        "version_minor": 0
       },
@@ -171,7 +172,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "483c18e99d854ec4ad05447a4a73a60d",
+       "model_id": "46b1a52475bf4511b59af8f6cb14a13d",
        "version_major": 2,
        "version_minor": 0
       },
@@ -185,7 +186,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "9f6f9a83a00e41d2abb0df92018e682e",
+       "model_id": "4856558cad5e444a85127bbf259c4e32",
        "version_major": 2,
        "version_minor": 0
       },
@@ -200,13 +201,13 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[2025-03-26 14:59:37,896 hyrax.pytorch_ignite:INFO] Total training time: 17.26[s]\n",
-      "[2025-03-26 14:59:37,897 hyrax.pytorch_ignite:INFO] Latest checkpoint saved as: /home/drew/code/fibad/docs/pre_executed/results/20250326-145918-train-6jeA/checkpoint_epoch_10.pt\n",
-      "[2025-03-26 14:59:37,898 hyrax.pytorch_ignite:INFO] Best metric checkpoint saved as: /home/drew/code/fibad/docs/pre_executed/results/20250326-145918-train-6jeA/checkpoint_10_loss=-658.1955.pt\n",
-      "2025/03/26 14:59:37 INFO mlflow.system_metrics.system_metrics_monitor: Stopping system metrics monitoring...\n",
-      "2025/03/26 14:59:37 INFO mlflow.system_metrics.system_metrics_monitor: Successfully terminated system metrics monitoring!\n",
-      "[2025-03-26 14:59:37,915 hyrax.train:INFO] Finished Training\n",
-      "[2025-03-26 14:59:39,416 hyrax.model_exporters:INFO] Exported model to ONNX format: /home/drew/code/fibad/docs/pre_executed/results/20250326-145918-train-6jeA/example_model_opset_20.onnx\n"
+      "[2025-03-28 16:07:19,810 hyrax.pytorch_ignite:INFO] Total training time: 7.77[s]\n",
+      "[2025-03-28 16:07:19,811 hyrax.pytorch_ignite:INFO] Latest checkpoint saved as: /Users/mtauraso/src/fibad/docs/pre_executed/results/20250328-160711-train-MWGA/checkpoint_epoch_10.pt\n",
+      "[2025-03-28 16:07:19,811 hyrax.pytorch_ignite:INFO] Best metric checkpoint saved as: /Users/mtauraso/src/fibad/docs/pre_executed/results/20250328-160711-train-MWGA/checkpoint_8_loss=-813.8177.pt\n",
+      "2025/03/28 16:07:19 INFO mlflow.system_metrics.system_metrics_monitor: Stopping system metrics monitoring...\n",
+      "2025/03/28 16:07:19 INFO mlflow.system_metrics.system_metrics_monitor: Successfully terminated system metrics monitoring!\n",
+      "[2025-03-28 16:07:19,828 hyrax.train:INFO] Finished Training\n",
+      "[2025-03-28 16:07:21,684 hyrax.model_exporters:INFO] Exported model to ONNX format: /Users/mtauraso/src/fibad/docs/pre_executed/results/20250328-160711-train-MWGA/example_model_opset_20.onnx\n"
      ]
     }
    ],
@@ -245,19 +246,19 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[2025-03-26 14:59:40,011 hyrax.data_sets.hsc_data_set:INFO] Processed 993 objects for pruning\n",
-      "[2025-03-26 14:59:40,013 hyrax.data_sets.hsc_data_set:INFO] Checking file dimensions to determine standard cutout size...\n",
-      "[2025-03-26 14:59:40,016 hyrax.data_sets.hsc_data_set:INFO] HSC Data set loader has 993 objects\n",
-      "[2025-03-26 14:59:40,018 hyrax.data_sets.hsc_data_set:INFO] Preloading HSCDataSet cache...\n",
-      "[2025-03-26 14:59:40,094 hyrax.models.model_registry:INFO] Using criterion: torch.nn.CrossEntropyLoss with default arguments.\n",
-      "[2025-03-26 14:59:40,102 hyrax.infer:INFO] data set has length 993\n",
-      "2025-03-26 14:59:40,110 ignite.distributed.auto.auto_dataloader INFO: Use data loader kwargs for dataset '<hyrax.data_sets.hsc': \n",
-      "\t{'sampler': None, 'batch_size': 512, 'pin_memory': True}\n",
-      "[2025-03-26 14:59:42,281 hyrax.pytorch_ignite:INFO] Evaluating model on device: cuda\n",
-      "[2025-03-26 14:59:42,291 hyrax.pytorch_ignite:INFO] Total epochs: 1\n",
-      "[2025-03-26 14:59:54,419 hyrax.data_sets.hsc_data_set:INFO] Processed 992 objects\n",
-      "[2025-03-26 14:59:55,285 hyrax.pytorch_ignite:INFO] Total evaluation time: 13.00[s]\n",
-      "[2025-03-26 14:59:55,339 hyrax.infer:INFO] Inference results saved in: /home/drew/code/fibad/docs/pre_executed/results/20250326-145939-infer-JQig\n"
+      "[2025-03-28 16:07:21,923 hyrax.data_sets.hsc_data_set:INFO] Processed 993 objects for pruning\n",
+      "[2025-03-28 16:07:21,923 hyrax.data_sets.hsc_data_set:INFO] Checking file dimensions to determine standard cutout size...\n",
+      "[2025-03-28 16:07:21,924 hyrax.data_sets.hsc_data_set:INFO] HSC Data set loader has 993 objects\n",
+      "[2025-03-28 16:07:21,946 hyrax.data_sets.hsc_data_set:INFO] Preloading HSCDataSet cache...\n",
+      "[2025-03-28 16:07:21,958 hyrax.models.model_registry:INFO] Using criterion: torch.nn.CrossEntropyLoss with default arguments.\n",
+      "[2025-03-28 16:07:21,959 hyrax.infer:INFO] data set has length 993\n",
+      "2025-03-28 16:07:21,961 ignite.distributed.auto.auto_dataloader INFO: Use data loader kwargs for dataset '<hyrax.data_sets.hsc': \n",
+      "\t{'sampler': None, 'batch_size': 512, 'pin_memory': False}\n",
+      "[2025-03-28 16:07:22,709 hyrax.pytorch_ignite:INFO] Evaluating model on device: mps\n",
+      "[2025-03-28 16:07:22,709 hyrax.pytorch_ignite:INFO] Total epochs: 1\n",
+      "[2025-03-28 16:07:25,536 hyrax.data_sets.hsc_data_set:INFO] Processed 992 objects\n",
+      "[2025-03-28 16:07:25,771 hyrax.pytorch_ignite:INFO] Total evaluation time: 3.06[s]\n",
+      "[2025-03-28 16:07:25,812 hyrax.infer:INFO] Inference results saved in: /Users/mtauraso/src/fibad/docs/pre_executed/results/20250328-160721-infer-1nKY\n"
      ]
     }
    ],
@@ -274,21 +275,22 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[2025-03-26 14:59:58,897 hyrax.data_sets.inference_dataset:INFO] Using most recent results dir /home/drew/code/fibad/docs/pre_executed/results/20250326-145939-infer-JQig for lookup. Use the [results] inference_dir config to set a directory or pass it to this verb.\n",
-      "[2025-03-26 14:59:59,191 hyrax.config_utils:WARNING] Cannot find default_config.toml for torch.\n",
-      "[2025-03-26 14:59:59,192 hyrax.config_utils:WARNING] Cannot find default_config.toml for torch.\n",
-      "[2025-03-26 14:59:59,193 hyrax.config_utils:WARNING] Cannot find default_config.toml for umap.\n",
-      "[2025-03-26 14:59:59,217 hyrax.data_sets.hsc_data_set:INFO] Processed 993 objects for pruning\n",
-      "[2025-03-26 14:59:59,218 hyrax.data_sets.hsc_data_set:INFO] Checking file dimensions to determine standard cutout size...\n",
-      "[2025-03-26 14:59:59,220 hyrax.data_sets.hsc_data_set:INFO] HSC Data set loader has 993 objects\n",
-      "[2025-03-26 14:59:59,221 hyrax.data_sets.hsc_data_set:INFO] Preloading HSCDataSet cache...\n",
-      "[2025-03-26 14:59:59,226 hyrax.verbs.umap:INFO] Saving UMAP results to /home/drew/code/fibad/docs/pre_executed/results/20250326-145959-umap-g1wY\n"
+      "[2025-03-28 16:07:28,221 hyrax.data_sets.inference_dataset:INFO] Using most recent results dir /Users/mtauraso/src/fibad/docs/pre_executed/results/20250328-160721-infer-1nKY for lookup. Use the [results] inference_dir config to set a directory or pass it to this verb.\n",
+      "[2025-03-28 16:07:28,243 hyrax.config_utils:WARNING] Cannot find default_config.toml for torch.\n",
+      "[2025-03-28 16:07:28,243 hyrax.config_utils:WARNING] Cannot find default_config.toml for torch.\n",
+      "[2025-03-28 16:07:28,244 hyrax.config_utils:WARNING] Cannot find default_config.toml for umap.\n",
+      "[2025-03-28 16:07:28,259 hyrax.data_sets.hsc_data_set:INFO] Processed 993 objects for pruning\n",
+      "[2025-03-28 16:07:28,260 hyrax.data_sets.hsc_data_set:INFO] Checking file dimensions to determine standard cutout size...\n",
+      "[2025-03-28 16:07:28,261 hyrax.data_sets.hsc_data_set:INFO] HSC Data set loader has 993 objects\n",
+      "[2025-03-28 16:07:28,283 hyrax.data_sets.hsc_data_set:INFO] Preloading HSCDataSet cache...\n",
+      "[2025-03-28 16:07:28,283 hyrax.verbs.umap:INFO] Saving UMAP results to /Users/mtauraso/src/fibad/docs/pre_executed/results/20250328-160728-umap-RC-F\n",
+      "OMP: Info #276: omp_set_nested routine deprecated, please use omp_set_max_active_levels instead.\n"
      ]
     },
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "086e28ce86a74d949f74d835fd0638f9",
+       "model_id": "a4e5701758494f708a986244f695d82b",
        "version_major": 2,
        "version_minor": 0
       },
@@ -303,229 +305,9 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Terminating: fork() called from a process already using GNU OpenMP, this is unsafe.\n",
-      "Terminating: fork() called from a process already using GNU OpenMP, this is unsafe.\n",
-      "[2025-03-26 15:00:13,417 hyrax.data_sets.hsc_data_set:INFO] Processed 992 objects\n",
-      "Process ForkPoolWorker-23:\n",
-      "Process ForkPoolWorker-21:\n",
-      "Process ForkPoolWorker-20:\n",
-      "Process ForkPoolWorker-18:\n",
-      "Process ForkPoolWorker-17:\n",
-      "Process ForkPoolWorker-27:\n",
-      "Process ForkPoolWorker-22:\n",
-      "Process ForkPoolWorker-19:\n",
-      "Process ForkPoolWorker-13:\n",
-      "Process ForkPoolWorker-15:\n",
-      "Process ForkPoolWorker-16:\n",
-      "Process ForkPoolWorker-24:\n",
-      "Process ForkPoolWorker-14:\n",
-      "Traceback (most recent call last):\n",
-      "Traceback (most recent call last):\n",
-      "Traceback (most recent call last):\n",
-      "Traceback (most recent call last):\n",
-      "Traceback (most recent call last):\n",
-      "Traceback (most recent call last):\n",
-      "Traceback (most recent call last):\n",
-      "Traceback (most recent call last):\n",
-      "  File \"/home/drew/miniconda3/envs/fibad/lib/python3.12/multiprocessing/process.py\", line 314, in _bootstrap\n",
-      "    self.run()\n",
-      "Traceback (most recent call last):\n",
-      "Traceback (most recent call last):\n",
-      "  File \"/home/drew/miniconda3/envs/fibad/lib/python3.12/multiprocessing/process.py\", line 314, in _bootstrap\n",
-      "    self.run()\n",
-      "  File \"/home/drew/miniconda3/envs/fibad/lib/python3.12/multiprocessing/process.py\", line 108, in run\n",
-      "    self._target(*self._args, **self._kwargs)\n",
-      "Traceback (most recent call last):\n",
-      "  File \"/home/drew/miniconda3/envs/fibad/lib/python3.12/multiprocessing/process.py\", line 314, in _bootstrap\n",
-      "    self.run()\n",
-      "Traceback (most recent call last):\n",
-      "  File \"/home/drew/miniconda3/envs/fibad/lib/python3.12/multiprocessing/process.py\", line 314, in _bootstrap\n",
-      "    self.run()\n",
-      "  File \"/home/drew/miniconda3/envs/fibad/lib/python3.12/multiprocessing/process.py\", line 314, in _bootstrap\n",
-      "    self.run()\n",
-      "  File \"/home/drew/miniconda3/envs/fibad/lib/python3.12/multiprocessing/process.py\", line 314, in _bootstrap\n",
-      "    self.run()\n",
-      "  File \"/home/drew/miniconda3/envs/fibad/lib/python3.12/multiprocessing/process.py\", line 314, in _bootstrap\n",
-      "    self.run()\n",
-      "  File \"/home/drew/miniconda3/envs/fibad/lib/python3.12/multiprocessing/process.py\", line 314, in _bootstrap\n",
-      "    self.run()\n",
-      "  File \"/home/drew/miniconda3/envs/fibad/lib/python3.12/multiprocessing/process.py\", line 314, in _bootstrap\n",
-      "    self.run()\n",
-      "  File \"/home/drew/miniconda3/envs/fibad/lib/python3.12/multiprocessing/process.py\", line 314, in _bootstrap\n",
-      "    self.run()\n",
-      "  File \"/home/drew/miniconda3/envs/fibad/lib/python3.12/multiprocessing/process.py\", line 108, in run\n",
-      "    self._target(*self._args, **self._kwargs)\n",
-      "  File \"/home/drew/miniconda3/envs/fibad/lib/python3.12/multiprocessing/process.py\", line 108, in run\n",
-      "    self._target(*self._args, **self._kwargs)\n",
-      "  File \"/home/drew/miniconda3/envs/fibad/lib/python3.12/multiprocessing/process.py\", line 314, in _bootstrap\n",
-      "    self.run()\n",
-      "  File \"/home/drew/miniconda3/envs/fibad/lib/python3.12/multiprocessing/process.py\", line 108, in run\n",
-      "    self._target(*self._args, **self._kwargs)\n",
-      "  File \"/home/drew/miniconda3/envs/fibad/lib/python3.12/multiprocessing/process.py\", line 108, in run\n",
-      "    self._target(*self._args, **self._kwargs)\n",
-      "  File \"/home/drew/miniconda3/envs/fibad/lib/python3.12/multiprocessing/process.py\", line 108, in run\n",
-      "    self._target(*self._args, **self._kwargs)\n",
-      "  File \"/home/drew/miniconda3/envs/fibad/lib/python3.12/multiprocessing/process.py\", line 108, in run\n",
-      "    self._target(*self._args, **self._kwargs)\n",
-      "  File \"/home/drew/miniconda3/envs/fibad/lib/python3.12/multiprocessing/process.py\", line 108, in run\n",
-      "    self._target(*self._args, **self._kwargs)\n",
-      "  File \"/home/drew/miniconda3/envs/fibad/lib/python3.12/multiprocessing/process.py\", line 314, in _bootstrap\n",
-      "    self.run()\n",
-      "  File \"/home/drew/miniconda3/envs/fibad/lib/python3.12/multiprocessing/pool.py\", line 114, in worker\n",
-      "    task = get()\n",
-      "           ^^^^^\n",
-      "  File \"/home/drew/miniconda3/envs/fibad/lib/python3.12/multiprocessing/pool.py\", line 114, in worker\n",
-      "    task = get()\n",
-      "           ^^^^^\n",
-      "  File \"/home/drew/miniconda3/envs/fibad/lib/python3.12/multiprocessing/pool.py\", line 114, in worker\n",
-      "    task = get()\n",
-      "           ^^^^^\n",
-      "  File \"/home/drew/miniconda3/envs/fibad/lib/python3.12/multiprocessing/process.py\", line 108, in run\n",
-      "    self._target(*self._args, **self._kwargs)\n",
-      "  File \"/home/drew/miniconda3/envs/fibad/lib/python3.12/multiprocessing/process.py\", line 108, in run\n",
-      "    self._target(*self._args, **self._kwargs)\n",
-      "  File \"/home/drew/miniconda3/envs/fibad/lib/python3.12/multiprocessing/pool.py\", line 114, in worker\n",
-      "    task = get()\n",
-      "           ^^^^^\n",
-      "  File \"/home/drew/miniconda3/envs/fibad/lib/python3.12/multiprocessing/pool.py\", line 114, in worker\n",
-      "    task = get()\n",
-      "           ^^^^^\n",
-      "  File \"/home/drew/miniconda3/envs/fibad/lib/python3.12/multiprocessing/pool.py\", line 114, in worker\n",
-      "    task = get()\n",
-      "           ^^^^^\n",
-      "  File \"/home/drew/miniconda3/envs/fibad/lib/python3.12/multiprocessing/pool.py\", line 114, in worker\n",
-      "    task = get()\n",
-      "           ^^^^^\n",
-      "  File \"/home/drew/miniconda3/envs/fibad/lib/python3.12/multiprocessing/process.py\", line 108, in run\n",
-      "    self._target(*self._args, **self._kwargs)\n",
-      "  File \"/home/drew/miniconda3/envs/fibad/lib/python3.12/multiprocessing/pool.py\", line 114, in worker\n",
-      "    task = get()\n",
-      "           ^^^^^\n",
-      "  File \"/home/drew/miniconda3/envs/fibad/lib/python3.12/multiprocessing/process.py\", line 108, in run\n",
-      "    self._target(*self._args, **self._kwargs)\n",
-      "  File \"/home/drew/miniconda3/envs/fibad/lib/python3.12/multiprocessing/queues.py\", line 386, in get\n",
-      "    with self._rlock:\n",
-      "         ^^^^^^^^^^^\n",
-      "  File \"/home/drew/miniconda3/envs/fibad/lib/python3.12/multiprocessing/pool.py\", line 114, in worker\n",
-      "    task = get()\n",
-      "           ^^^^^\n",
-      "  File \"/home/drew/miniconda3/envs/fibad/lib/python3.12/multiprocessing/queues.py\", line 386, in get\n",
-      "    with self._rlock:\n",
-      "         ^^^^^^^^^^^\n",
-      "  File \"/home/drew/miniconda3/envs/fibad/lib/python3.12/multiprocessing/queues.py\", line 386, in get\n",
-      "    with self._rlock:\n",
-      "         ^^^^^^^^^^^\n",
-      "  File \"/home/drew/miniconda3/envs/fibad/lib/python3.12/multiprocessing/queues.py\", line 386, in get\n",
-      "    with self._rlock:\n",
-      "         ^^^^^^^^^^^\n",
-      "  File \"/home/drew/miniconda3/envs/fibad/lib/python3.12/multiprocessing/synchronize.py\", line 95, in __enter__\n",
-      "    return self._semlock.__enter__()\n",
-      "           ^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/home/drew/miniconda3/envs/fibad/lib/python3.12/multiprocessing/queues.py\", line 386, in get\n",
-      "    with self._rlock:\n",
-      "         ^^^^^^^^^^^\n",
-      "  File \"/home/drew/miniconda3/envs/fibad/lib/python3.12/multiprocessing/queues.py\", line 386, in get\n",
-      "    with self._rlock:\n",
-      "         ^^^^^^^^^^^\n",
-      "  File \"/home/drew/miniconda3/envs/fibad/lib/python3.12/multiprocessing/synchronize.py\", line 95, in __enter__\n",
-      "    return self._semlock.__enter__()\n",
-      "           ^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/home/drew/miniconda3/envs/fibad/lib/python3.12/multiprocessing/synchronize.py\", line 95, in __enter__\n",
-      "    return self._semlock.__enter__()\n",
-      "           ^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/home/drew/miniconda3/envs/fibad/lib/python3.12/multiprocessing/pool.py\", line 114, in worker\n",
-      "    task = get()\n",
-      "           ^^^^^\n",
-      "  File \"/home/drew/miniconda3/envs/fibad/lib/python3.12/multiprocessing/queues.py\", line 386, in get\n",
-      "    with self._rlock:\n",
-      "         ^^^^^^^^^^^\n",
-      "  File \"/home/drew/miniconda3/envs/fibad/lib/python3.12/multiprocessing/queues.py\", line 386, in get\n",
-      "    with self._rlock:\n",
-      "         ^^^^^^^^^^^\n",
-      "KeyboardInterrupt\n",
-      "  File \"/home/drew/miniconda3/envs/fibad/lib/python3.12/multiprocessing/queues.py\", line 386, in get\n",
-      "    with self._rlock:\n",
-      "         ^^^^^^^^^^^\n",
-      "  File \"/home/drew/miniconda3/envs/fibad/lib/python3.12/multiprocessing/synchronize.py\", line 95, in __enter__\n",
-      "    return self._semlock.__enter__()\n",
-      "           ^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/home/drew/miniconda3/envs/fibad/lib/python3.12/multiprocessing/synchronize.py\", line 95, in __enter__\n",
-      "    return self._semlock.__enter__()\n",
-      "           ^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "KeyboardInterrupt\n",
-      "  File \"/home/drew/miniconda3/envs/fibad/lib/python3.12/multiprocessing/synchronize.py\", line 95, in __enter__\n",
-      "    return self._semlock.__enter__()\n",
-      "           ^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/home/drew/miniconda3/envs/fibad/lib/python3.12/multiprocessing/synchronize.py\", line 95, in __enter__\n",
-      "    return self._semlock.__enter__()\n",
-      "           ^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "KeyboardInterrupt\n",
-      "  File \"/home/drew/miniconda3/envs/fibad/lib/python3.12/multiprocessing/pool.py\", line 114, in worker\n",
-      "    task = get()\n",
-      "           ^^^^^\n",
-      "KeyboardInterrupt\n",
-      "  File \"/home/drew/miniconda3/envs/fibad/lib/python3.12/multiprocessing/queues.py\", line 387, in get\n",
-      "    res = self._reader.recv_bytes()\n",
-      "          ^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/home/drew/miniconda3/envs/fibad/lib/python3.12/multiprocessing/synchronize.py\", line 95, in __enter__\n",
-      "    return self._semlock.__enter__()\n",
-      "           ^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "KeyboardInterrupt\n",
-      "KeyboardInterrupt\n",
-      "KeyboardInterrupt\n",
-      "  File \"/home/drew/miniconda3/envs/fibad/lib/python3.12/multiprocessing/synchronize.py\", line 95, in __enter__\n",
-      "    return self._semlock.__enter__()\n",
-      "           ^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "KeyboardInterrupt\n",
-      "  File \"/home/drew/miniconda3/envs/fibad/lib/python3.12/multiprocessing/pool.py\", line 114, in worker\n",
-      "    task = get()\n",
-      "           ^^^^^\n",
-      "  File \"/home/drew/miniconda3/envs/fibad/lib/python3.12/multiprocessing/queues.py\", line 386, in get\n",
-      "    with self._rlock:\n",
-      "         ^^^^^^^^^^^\n",
-      "KeyboardInterrupt\n",
-      "  File \"/home/drew/miniconda3/envs/fibad/lib/python3.12/multiprocessing/queues.py\", line 386, in get\n",
-      "    with self._rlock:\n",
-      "         ^^^^^^^^^^^\n",
-      "  File \"/home/drew/miniconda3/envs/fibad/lib/python3.12/multiprocessing/synchronize.py\", line 95, in __enter__\n",
-      "    return self._semlock.__enter__()\n",
-      "           ^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/home/drew/miniconda3/envs/fibad/lib/python3.12/multiprocessing/connection.py\", line 216, in recv_bytes\n",
-      "    buf = self._recv_bytes(maxlength)\n",
-      "          ^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "KeyboardInterrupt\n",
-      "  File \"/home/drew/miniconda3/envs/fibad/lib/python3.12/multiprocessing/synchronize.py\", line 95, in __enter__\n",
-      "    return self._semlock.__enter__()\n",
-      "           ^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/home/drew/miniconda3/envs/fibad/lib/python3.12/multiprocessing/connection.py\", line 430, in _recv_bytes\n",
-      "    buf = self._recv(4)\n",
-      "          ^^^^^^^^^^^^^\n",
-      "  File \"/home/drew/miniconda3/envs/fibad/lib/python3.12/multiprocessing/connection.py\", line 395, in _recv\n",
-      "    chunk = read(handle, remaining)\n",
-      "            ^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "KeyboardInterrupt\n",
-      "KeyboardInterrupt\n"
-     ]
-    },
-    {
-     "ename": "KeyboardInterrupt",
-     "evalue": "",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mIndexError\u001b[0m                                Traceback (most recent call last)",
-      "File \u001b[0;32m~/miniconda3/envs/fibad/lib/python3.12/multiprocessing/pool.py:856\u001b[0m, in \u001b[0;36mIMapIterator.next\u001b[0;34m(self, timeout)\u001b[0m\n\u001b[1;32m    855\u001b[0m \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[0;32m--> 856\u001b[0m     item \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_items\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mpopleft\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    857\u001b[0m \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mIndexError\u001b[39;00m:\n",
-      "\u001b[0;31mIndexError\u001b[0m: pop from an empty deque",
-      "\nDuring handling of the above exception, another exception occurred:\n",
-      "\u001b[0;31mKeyboardInterrupt\u001b[0m                         Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[4], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m \u001b[43mh\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mumap\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\n",
-      "File \u001b[0;32m~/code/fibad/src/hyrax/verbs/umap.py:67\u001b[0m, in \u001b[0;36mUmap.run\u001b[0;34m(self, input_dir)\u001b[0m\n\u001b[1;32m     65\u001b[0m \u001b[38;5;28;01mwith\u001b[39;00m warnings\u001b[38;5;241m.\u001b[39mcatch_warnings():\n\u001b[1;32m     66\u001b[0m     warnings\u001b[38;5;241m.\u001b[39msimplefilter(action\u001b[38;5;241m=\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mignore\u001b[39m\u001b[38;5;124m\"\u001b[39m, category\u001b[38;5;241m=\u001b[39m\u001b[38;5;167;01mFutureWarning\u001b[39;00m)\n\u001b[0;32m---> 67\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_run\u001b[49m\u001b[43m(\u001b[49m\u001b[43minput_dir\u001b[49m\u001b[43m)\u001b[49m\n",
-      "File \u001b[0;32m~/code/fibad/src/hyrax/verbs/umap.py:130\u001b[0m, in \u001b[0;36mUmap._run\u001b[0;34m(self, input_dir)\u001b[0m\n\u001b[1;32m    117\u001b[0m args \u001b[38;5;241m=\u001b[39m (\n\u001b[1;32m    118\u001b[0m     (\n\u001b[1;32m    119\u001b[0m         all_ids[batch_indexes],\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    125\u001b[0m     \u001b[38;5;28;01mfor\u001b[39;00m batch_indexes \u001b[38;5;129;01min\u001b[39;00m np\u001b[38;5;241m.\u001b[39marray_split(all_indexes, num_batches)\n\u001b[1;32m    126\u001b[0m )\n\u001b[1;32m    128\u001b[0m \u001b[38;5;66;03m# iterate over the mapped results to write out the umapped points\u001b[39;00m\n\u001b[1;32m    129\u001b[0m \u001b[38;5;66;03m# imap returns results as they complete so writing should complete in parallel for large datasets\u001b[39;00m\n\u001b[0;32m--> 130\u001b[0m \u001b[43m\u001b[49m\u001b[38;5;28;43;01mfor\u001b[39;49;00m\u001b[43m \u001b[49m\u001b[43mbatch_ids\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mtransformed_batch\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;129;43;01min\u001b[39;49;00m\u001b[43m \u001b[49m\u001b[43mtqdm\u001b[49m\u001b[43m(\u001b[49m\n\u001b[1;32m    131\u001b[0m \u001b[43m    \u001b[49m\u001b[43mpool\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mimap\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_transform_batch\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43margs\u001b[49m\u001b[43m)\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    132\u001b[0m \u001b[43m    \u001b[49m\u001b[43mdesc\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mCreating lower dimensional representation using UMAP:\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\n\u001b[1;32m    133\u001b[0m \u001b[43m    \u001b[49m\u001b[43mtotal\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mnum_batches\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    134\u001b[0m \u001b[43m\u001b[49m\u001b[43m)\u001b[49m\u001b[43m:\u001b[49m\n\u001b[1;32m    135\u001b[0m \u001b[43m    \u001b[49m\u001b[43mlogger\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mdebug\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mWriting a batch out async...\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m)\u001b[49m\n\u001b[1;32m    136\u001b[0m \u001b[43m    \u001b[49m\u001b[43mumap_results\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mwrite_batch\u001b[49m\u001b[43m(\u001b[49m\u001b[43mbatch_ids\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mtransformed_batch\u001b[49m\u001b[43m)\u001b[49m\n",
-      "File \u001b[0;32m~/miniconda3/envs/fibad/lib/python3.12/site-packages/tqdm/notebook.py:250\u001b[0m, in \u001b[0;36mtqdm_notebook.__iter__\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m    248\u001b[0m \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[1;32m    249\u001b[0m     it \u001b[38;5;241m=\u001b[39m \u001b[38;5;28msuper\u001b[39m()\u001b[38;5;241m.\u001b[39m\u001b[38;5;21m__iter__\u001b[39m()\n\u001b[0;32m--> 250\u001b[0m \u001b[43m    \u001b[49m\u001b[38;5;28;43;01mfor\u001b[39;49;00m\u001b[43m \u001b[49m\u001b[43mobj\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;129;43;01min\u001b[39;49;00m\u001b[43m \u001b[49m\u001b[43mit\u001b[49m\u001b[43m:\u001b[49m\n\u001b[1;32m    251\u001b[0m \u001b[43m        \u001b[49m\u001b[38;5;66;43;03m# return super(tqdm...) will not catch exception\u001b[39;49;00m\n\u001b[1;32m    252\u001b[0m \u001b[43m        \u001b[49m\u001b[38;5;28;43;01myield\u001b[39;49;00m\u001b[43m \u001b[49m\u001b[43mobj\u001b[49m\n\u001b[1;32m    253\u001b[0m \u001b[38;5;66;03m# NB: except ... [ as ...] breaks IPython async KeyboardInterrupt\u001b[39;00m\n",
-      "File \u001b[0;32m~/miniconda3/envs/fibad/lib/python3.12/site-packages/tqdm/std.py:1181\u001b[0m, in \u001b[0;36mtqdm.__iter__\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m   1178\u001b[0m time \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_time\n\u001b[1;32m   1180\u001b[0m \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[0;32m-> 1181\u001b[0m \u001b[43m    \u001b[49m\u001b[38;5;28;43;01mfor\u001b[39;49;00m\u001b[43m \u001b[49m\u001b[43mobj\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;129;43;01min\u001b[39;49;00m\u001b[43m \u001b[49m\u001b[43miterable\u001b[49m\u001b[43m:\u001b[49m\n\u001b[1;32m   1182\u001b[0m \u001b[43m        \u001b[49m\u001b[38;5;28;43;01myield\u001b[39;49;00m\u001b[43m \u001b[49m\u001b[43mobj\u001b[49m\n\u001b[1;32m   1183\u001b[0m \u001b[43m        \u001b[49m\u001b[38;5;66;43;03m# Update and possibly print the progressbar.\u001b[39;49;00m\n\u001b[1;32m   1184\u001b[0m \u001b[43m        \u001b[49m\u001b[38;5;66;43;03m# Note: does not call self.update(1) for speed optimisation.\u001b[39;49;00m\n",
-      "File \u001b[0;32m~/miniconda3/envs/fibad/lib/python3.12/multiprocessing/pool.py:861\u001b[0m, in \u001b[0;36mIMapIterator.next\u001b[0;34m(self, timeout)\u001b[0m\n\u001b[1;32m    859\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_pool \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;01mNone\u001b[39;00m\n\u001b[1;32m    860\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mStopIteration\u001b[39;00m \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m\n\u001b[0;32m--> 861\u001b[0m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_cond\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mwait\u001b[49m\u001b[43m(\u001b[49m\u001b[43mtimeout\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    862\u001b[0m \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[1;32m    863\u001b[0m     item \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_items\u001b[38;5;241m.\u001b[39mpopleft()\n",
-      "File \u001b[0;32m~/miniconda3/envs/fibad/lib/python3.12/threading.py:355\u001b[0m, in \u001b[0;36mCondition.wait\u001b[0;34m(self, timeout)\u001b[0m\n\u001b[1;32m    353\u001b[0m \u001b[38;5;28;01mtry\u001b[39;00m:    \u001b[38;5;66;03m# restore state no matter what (e.g., KeyboardInterrupt)\u001b[39;00m\n\u001b[1;32m    354\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m timeout \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m:\n\u001b[0;32m--> 355\u001b[0m         \u001b[43mwaiter\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43macquire\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    356\u001b[0m         gotit \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;01mTrue\u001b[39;00m\n\u001b[1;32m    357\u001b[0m     \u001b[38;5;28;01melse\u001b[39;00m:\n",
-      "\u001b[0;31mKeyboardInterrupt\u001b[0m: "
+      "[2025-03-28 16:07:34,062 hyrax.data_sets.hsc_data_set:INFO] Processed 992 objects\n",
+      "OMP: Info #276: omp_set_nested routine deprecated, please use omp_set_max_active_levels instead.\n",
+      "OMP: Info #276: omp_set_nested routine deprecated, please use omp_set_max_active_levels instead.\n"
      ]
     }
    ],
@@ -544,23 +326,261 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
-     "ename": "NameError",
-     "evalue": "name 'h' is not defined",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[1], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m \u001b[43mh\u001b[49m\u001b[38;5;241m.\u001b[39mvisualize(width\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m400\u001b[39m, height\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m400\u001b[39m)\n",
-      "\u001b[0;31mNameError\u001b[0m: name 'h' is not defined"
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[2025-03-28 16:07:40,363 hyrax.data_sets.inference_dataset:INFO] Using most recent results dir /Users/mtauraso/src/fibad/docs/pre_executed/results/20250328-160728-umap-RC-F for lookup. Use the [results] inference_dir config to set a directory or pass it to this verb.\n",
+      "[2025-03-28 16:07:40,386 hyrax.config_utils:WARNING] Cannot find default_config.toml for torch.\n",
+      "[2025-03-28 16:07:40,386 hyrax.config_utils:WARNING] Cannot find default_config.toml for torch.\n",
+      "[2025-03-28 16:07:40,386 hyrax.config_utils:WARNING] Cannot find default_config.toml for umap.\n",
+      "[2025-03-28 16:07:40,403 hyrax.data_sets.hsc_data_set:INFO] Processed 993 objects for pruning\n",
+      "[2025-03-28 16:07:40,403 hyrax.data_sets.hsc_data_set:INFO] Checking file dimensions to determine standard cutout size...\n",
+      "[2025-03-28 16:07:40,405 hyrax.data_sets.hsc_data_set:INFO] HSC Data set loader has 993 objects\n",
+      "[2025-03-28 16:07:40,426 hyrax.data_sets.hsc_data_set:INFO] Preloading HSCDataSet cache...\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<script type=\"esms-options\">{\"shimMode\": true}</script><style>*[data-root-id],\n",
+       "*[data-root-id] > * {\n",
+       "  box-sizing: border-box;\n",
+       "  font-family: var(--jp-ui-font-family);\n",
+       "  font-size: var(--jp-ui-font-size1);\n",
+       "  color: var(--vscode-editor-foreground, var(--jp-ui-font-color1));\n",
+       "}\n",
+       "\n",
+       "/* Override VSCode background color */\n",
+       ".cell-output-ipywidget-background:has(\n",
+       "    > .cell-output-ipywidget-background > .lm-Widget > *[data-root-id]\n",
+       "  ),\n",
+       ".cell-output-ipywidget-background:has(> .lm-Widget > *[data-root-id]) {\n",
+       "  background-color: transparent !important;\n",
+       "}\n",
+       "</style>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/javascript": "(function(root) {\n  function now() {\n    return new Date();\n  }\n\n  const force = true;\n  const py_version = '3.6.2'.replace('rc', '-rc.').replace('.dev', '-dev.');\n  const reloading = false;\n  const Bokeh = root.Bokeh;\n\n  // Set a timeout for this load but only if we are not already initializing\n  if (typeof (root._bokeh_timeout) === \"undefined\" || (force || !root._bokeh_is_initializing)) {\n    root._bokeh_timeout = Date.now() + 5000;\n    root._bokeh_failed_load = false;\n  }\n\n  function run_callbacks() {\n    try {\n      root._bokeh_onload_callbacks.forEach(function(callback) {\n        if (callback != null)\n          callback();\n      });\n    } finally {\n      delete root._bokeh_onload_callbacks;\n    }\n    console.debug(\"Bokeh: all callbacks have finished\");\n  }\n\n  function load_libs(css_urls, js_urls, js_modules, js_exports, callback) {\n    if (css_urls == null) css_urls = [];\n    if (js_urls == null) js_urls = [];\n    if (js_modules == null) js_modules = [];\n    if (js_exports == null) js_exports = {};\n\n    root._bokeh_onload_callbacks.push(callback);\n\n    if (root._bokeh_is_loading > 0) {\n      // Don't load bokeh if it is still initializing\n      console.debug(\"Bokeh: BokehJS is being loaded, scheduling callback at\", now());\n      return null;\n    } else if (js_urls.length === 0 && js_modules.length === 0 && Object.keys(js_exports).length === 0) {\n      // There is nothing to load\n      run_callbacks();\n      return null;\n    }\n\n    function on_load() {\n      root._bokeh_is_loading--;\n      if (root._bokeh_is_loading === 0) {\n        console.debug(\"Bokeh: all BokehJS libraries/stylesheets loaded\");\n        run_callbacks()\n      }\n    }\n    window._bokeh_on_load = on_load\n\n    function on_error(e) {\n      const src_el = e.srcElement\n      console.error(\"failed to load \" + (src_el.href || src_el.src));\n    }\n\n    const skip = [];\n    if (window.requirejs) {\n      window.requirejs.config({'packages': {}, 'paths': {}, 'shim': {}});\n      root._bokeh_is_loading = css_urls.length + 0;\n    } else {\n      root._bokeh_is_loading = css_urls.length + js_urls.length + js_modules.length + Object.keys(js_exports).length;\n    }\n\n    const existing_stylesheets = []\n    const links = document.getElementsByTagName('link')\n    for (let i = 0; i < links.length; i++) {\n      const link = links[i]\n      if (link.href != null) {\n        existing_stylesheets.push(link.href)\n      }\n    }\n    for (let i = 0; i < css_urls.length; i++) {\n      const url = css_urls[i];\n      const escaped = encodeURI(url)\n      if (existing_stylesheets.indexOf(escaped) !== -1) {\n        on_load()\n        continue;\n      }\n      const element = document.createElement(\"link\");\n      element.onload = on_load;\n      element.onerror = on_error;\n      element.rel = \"stylesheet\";\n      element.type = \"text/css\";\n      element.href = url;\n      console.debug(\"Bokeh: injecting link tag for BokehJS stylesheet: \", url);\n      document.body.appendChild(element);\n    }    var existing_scripts = []\n    const scripts = document.getElementsByTagName('script')\n    for (let i = 0; i < scripts.length; i++) {\n      var script = scripts[i]\n      if (script.src != null) {\n        existing_scripts.push(script.src)\n      }\n    }\n    for (let i = 0; i < js_urls.length; i++) {\n      const url = js_urls[i];\n      const escaped = encodeURI(url)\n      if (skip.indexOf(escaped) !== -1 || existing_scripts.indexOf(escaped) !== -1) {\n        if (!window.requirejs) {\n          on_load();\n        }\n        continue;\n      }\n      const element = document.createElement('script');\n      element.onload = on_load;\n      element.onerror = on_error;\n      element.async = false;\n      element.src = url;\n      console.debug(\"Bokeh: injecting script tag for BokehJS library: \", url);\n      document.head.appendChild(element);\n    }\n    for (let i = 0; i < js_modules.length; i++) {\n      const url = js_modules[i];\n      const escaped = encodeURI(url)\n      if (skip.indexOf(escaped) !== -1 || existing_scripts.indexOf(escaped) !== -1) {\n        if (!window.requirejs) {\n          on_load();\n        }\n        continue;\n      }\n      var element = document.createElement('script');\n      element.onload = on_load;\n      element.onerror = on_error;\n      element.async = false;\n      element.src = url;\n      element.type = \"module\";\n      console.debug(\"Bokeh: injecting script tag for BokehJS library: \", url);\n      document.head.appendChild(element);\n    }\n    for (const name in js_exports) {\n      const url = js_exports[name];\n      const escaped = encodeURI(url)\n      if (skip.indexOf(escaped) >= 0 || root[name] != null) {\n        if (!window.requirejs) {\n          on_load();\n        }\n        continue;\n      }\n      var element = document.createElement('script');\n      element.onerror = on_error;\n      element.async = false;\n      element.type = \"module\";\n      console.debug(\"Bokeh: injecting script tag for BokehJS library: \", url);\n      element.textContent = `\n      import ${name} from \"${url}\"\n      window.${name} = ${name}\n      window._bokeh_on_load()\n      `\n      document.head.appendChild(element);\n    }\n    if (!js_urls.length && !js_modules.length) {\n      on_load()\n    }\n  };\n\n  function inject_raw_css(css) {\n    const element = document.createElement(\"style\");\n    element.appendChild(document.createTextNode(css));\n    document.body.appendChild(element);\n  }\n\n  const js_urls = [\"https://cdn.holoviz.org/panel/1.5.4/dist/bundled/reactiveesm/es-module-shims@^1.10.0/dist/es-module-shims.min.js\", \"https://cdn.bokeh.org/bokeh/release/bokeh-3.6.2.min.js\", \"https://cdn.bokeh.org/bokeh/release/bokeh-gl-3.6.2.min.js\", \"https://cdn.bokeh.org/bokeh/release/bokeh-widgets-3.6.2.min.js\", \"https://cdn.bokeh.org/bokeh/release/bokeh-tables-3.6.2.min.js\", \"https://cdn.holoviz.org/panel/1.5.4/dist/panel.min.js\"];\n  const js_modules = [];\n  const js_exports = {};\n  const css_urls = [];\n  const inline_js = [    function(Bokeh) {\n      Bokeh.set_log_level(\"info\");\n    },\nfunction(Bokeh) {} // ensure no trailing comma for IE\n  ];\n\n  function run_inline_js() {\n    if ((root.Bokeh !== undefined) || (force === true)) {\n      for (let i = 0; i < inline_js.length; i++) {\n        try {\n          inline_js[i].call(root, root.Bokeh);\n        } catch(e) {\n          if (!reloading) {\n            throw e;\n          }\n        }\n      }\n      // Cache old bokeh versions\n      if (Bokeh != undefined && !reloading) {\n        var NewBokeh = root.Bokeh;\n        if (Bokeh.versions === undefined) {\n          Bokeh.versions = new Map();\n        }\n        if (NewBokeh.version !== Bokeh.version) {\n          Bokeh.versions.set(NewBokeh.version, NewBokeh)\n        }\n        root.Bokeh = Bokeh;\n      }\n    } else if (Date.now() < root._bokeh_timeout) {\n      setTimeout(run_inline_js, 100);\n    } else if (!root._bokeh_failed_load) {\n      console.log(\"Bokeh: BokehJS failed to load within specified timeout.\");\n      root._bokeh_failed_load = true;\n    }\n    root._bokeh_is_initializing = false\n  }\n\n  function load_or_wait() {\n    // Implement a backoff loop that tries to ensure we do not load multiple\n    // versions of Bokeh and its dependencies at the same time.\n    // In recent versions we use the root._bokeh_is_initializing flag\n    // to determine whether there is an ongoing attempt to initialize\n    // bokeh, however for backward compatibility we also try to ensure\n    // that we do not start loading a newer (Panel>=1.0 and Bokeh>3) version\n    // before older versions are fully initialized.\n    if (root._bokeh_is_initializing && Date.now() > root._bokeh_timeout) {\n      // If the timeout and bokeh was not successfully loaded we reset\n      // everything and try loading again\n      root._bokeh_timeout = Date.now() + 5000;\n      root._bokeh_is_initializing = false;\n      root._bokeh_onload_callbacks = undefined;\n      root._bokeh_is_loading = 0\n      console.log(\"Bokeh: BokehJS was loaded multiple times but one version failed to initialize.\");\n      load_or_wait();\n    } else if (root._bokeh_is_initializing || (typeof root._bokeh_is_initializing === \"undefined\" && root._bokeh_onload_callbacks !== undefined)) {\n      setTimeout(load_or_wait, 100);\n    } else {\n      root._bokeh_is_initializing = true\n      root._bokeh_onload_callbacks = []\n      const bokeh_loaded = root.Bokeh != null && (root.Bokeh.version === py_version || (root.Bokeh.versions !== undefined && root.Bokeh.versions.has(py_version)));\n      if (!reloading && !bokeh_loaded) {\n        if (root.Bokeh) {\n          root.Bokeh = undefined;\n        }\n        console.debug(\"Bokeh: BokehJS not loaded, scheduling load and callback at\", now());\n      }\n      load_libs(css_urls, js_urls, js_modules, js_exports, function() {\n        console.debug(\"Bokeh: BokehJS plotting callback run at\", now());\n        run_inline_js();\n      });\n    }\n  }\n  // Give older versions of the autoload script a head-start to ensure\n  // they initialize before we start loading newer version.\n  setTimeout(load_or_wait, 100)\n}(window));",
+      "application/vnd.holoviews_load.v0+json": ""
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/javascript": "\nif ((window.PyViz === undefined) || (window.PyViz instanceof HTMLElement)) {\n  window.PyViz = {comms: {}, comm_status:{}, kernels:{}, receivers: {}, plot_index: []}\n}\n\n\n    function JupyterCommManager() {\n    }\n\n    JupyterCommManager.prototype.register_target = function(plot_id, comm_id, msg_handler) {\n      if (window.comm_manager || ((window.Jupyter !== undefined) && (Jupyter.notebook.kernel != null))) {\n        var comm_manager = window.comm_manager || Jupyter.notebook.kernel.comm_manager;\n        comm_manager.register_target(comm_id, function(comm) {\n          comm.on_msg(msg_handler);\n        });\n      } else if ((plot_id in window.PyViz.kernels) && (window.PyViz.kernels[plot_id])) {\n        window.PyViz.kernels[plot_id].registerCommTarget(comm_id, function(comm) {\n          comm.onMsg = msg_handler;\n        });\n      } else if (typeof google != 'undefined' && google.colab.kernel != null) {\n        google.colab.kernel.comms.registerTarget(comm_id, (comm) => {\n          var messages = comm.messages[Symbol.asyncIterator]();\n          function processIteratorResult(result) {\n            var message = result.value;\n            console.log(message)\n            var content = {data: message.data, comm_id};\n            var buffers = []\n            for (var buffer of message.buffers || []) {\n              buffers.push(new DataView(buffer))\n            }\n            var metadata = message.metadata || {};\n            var msg = {content, buffers, metadata}\n            msg_handler(msg);\n            return messages.next().then(processIteratorResult);\n          }\n          return messages.next().then(processIteratorResult);\n        })\n      }\n    }\n\n    JupyterCommManager.prototype.get_client_comm = function(plot_id, comm_id, msg_handler) {\n      if (comm_id in window.PyViz.comms) {\n        return window.PyViz.comms[comm_id];\n      } else if (window.comm_manager || ((window.Jupyter !== undefined) && (Jupyter.notebook.kernel != null))) {\n        var comm_manager = window.comm_manager || Jupyter.notebook.kernel.comm_manager;\n        var comm = comm_manager.new_comm(comm_id, {}, {}, {}, comm_id);\n        if (msg_handler) {\n          comm.on_msg(msg_handler);\n        }\n      } else if ((plot_id in window.PyViz.kernels) && (window.PyViz.kernels[plot_id])) {\n        var comm = window.PyViz.kernels[plot_id].connectToComm(comm_id);\n        comm.open();\n        if (msg_handler) {\n          comm.onMsg = msg_handler;\n        }\n      } else if (typeof google != 'undefined' && google.colab.kernel != null) {\n        var comm_promise = google.colab.kernel.comms.open(comm_id)\n        comm_promise.then((comm) => {\n          window.PyViz.comms[comm_id] = comm;\n          if (msg_handler) {\n            var messages = comm.messages[Symbol.asyncIterator]();\n            function processIteratorResult(result) {\n              var message = result.value;\n              var content = {data: message.data};\n              var metadata = message.metadata || {comm_id};\n              var msg = {content, metadata}\n              msg_handler(msg);\n              return messages.next().then(processIteratorResult);\n            }\n            return messages.next().then(processIteratorResult);\n          }\n        }) \n        var sendClosure = (data, metadata, buffers, disposeOnDone) => {\n          return comm_promise.then((comm) => {\n            comm.send(data, metadata, buffers, disposeOnDone);\n          });\n        };\n        var comm = {\n          send: sendClosure\n        };\n      }\n      window.PyViz.comms[comm_id] = comm;\n      return comm;\n    }\n    window.PyViz.comm_manager = new JupyterCommManager();\n    \n\n\nvar JS_MIME_TYPE = 'application/javascript';\nvar HTML_MIME_TYPE = 'text/html';\nvar EXEC_MIME_TYPE = 'application/vnd.holoviews_exec.v0+json';\nvar CLASS_NAME = 'output';\n\n/**\n * Render data to the DOM node\n */\nfunction render(props, node) {\n  var div = document.createElement(\"div\");\n  var script = document.createElement(\"script\");\n  node.appendChild(div);\n  node.appendChild(script);\n}\n\n/**\n * Handle when a new output is added\n */\nfunction handle_add_output(event, handle) {\n  var output_area = handle.output_area;\n  var output = handle.output;\n  if ((output.data == undefined) || (!output.data.hasOwnProperty(EXEC_MIME_TYPE))) {\n    return\n  }\n  var id = output.metadata[EXEC_MIME_TYPE][\"id\"];\n  var toinsert = output_area.element.find(\".\" + CLASS_NAME.split(' ')[0]);\n  if (id !== undefined) {\n    var nchildren = toinsert.length;\n    var html_node = toinsert[nchildren-1].children[0];\n    html_node.innerHTML = output.data[HTML_MIME_TYPE];\n    var scripts = [];\n    var nodelist = html_node.querySelectorAll(\"script\");\n    for (var i in nodelist) {\n      if (nodelist.hasOwnProperty(i)) {\n        scripts.push(nodelist[i])\n      }\n    }\n\n    scripts.forEach( function (oldScript) {\n      var newScript = document.createElement(\"script\");\n      var attrs = [];\n      var nodemap = oldScript.attributes;\n      for (var j in nodemap) {\n        if (nodemap.hasOwnProperty(j)) {\n          attrs.push(nodemap[j])\n        }\n      }\n      attrs.forEach(function(attr) { newScript.setAttribute(attr.name, attr.value) });\n      newScript.appendChild(document.createTextNode(oldScript.innerHTML));\n      oldScript.parentNode.replaceChild(newScript, oldScript);\n    });\n    if (JS_MIME_TYPE in output.data) {\n      toinsert[nchildren-1].children[1].textContent = output.data[JS_MIME_TYPE];\n    }\n    output_area._hv_plot_id = id;\n    if ((window.Bokeh !== undefined) && (id in Bokeh.index)) {\n      window.PyViz.plot_index[id] = Bokeh.index[id];\n    } else {\n      window.PyViz.plot_index[id] = null;\n    }\n  } else if (output.metadata[EXEC_MIME_TYPE][\"server_id\"] !== undefined) {\n    var bk_div = document.createElement(\"div\");\n    bk_div.innerHTML = output.data[HTML_MIME_TYPE];\n    var script_attrs = bk_div.children[0].attributes;\n    for (var i = 0; i < script_attrs.length; i++) {\n      toinsert[toinsert.length - 1].childNodes[1].setAttribute(script_attrs[i].name, script_attrs[i].value);\n    }\n    // store reference to server id on output_area\n    output_area._bokeh_server_id = output.metadata[EXEC_MIME_TYPE][\"server_id\"];\n  }\n}\n\n/**\n * Handle when an output is cleared or removed\n */\nfunction handle_clear_output(event, handle) {\n  var id = handle.cell.output_area._hv_plot_id;\n  var server_id = handle.cell.output_area._bokeh_server_id;\n  if (((id === undefined) || !(id in PyViz.plot_index)) && (server_id !== undefined)) { return; }\n  var comm = window.PyViz.comm_manager.get_client_comm(\"hv-extension-comm\", \"hv-extension-comm\", function () {});\n  if (server_id !== null) {\n    comm.send({event_type: 'server_delete', 'id': server_id});\n    return;\n  } else if (comm !== null) {\n    comm.send({event_type: 'delete', 'id': id});\n  }\n  delete PyViz.plot_index[id];\n  if ((window.Bokeh !== undefined) & (id in window.Bokeh.index)) {\n    var doc = window.Bokeh.index[id].model.document\n    doc.clear();\n    const i = window.Bokeh.documents.indexOf(doc);\n    if (i > -1) {\n      window.Bokeh.documents.splice(i, 1);\n    }\n  }\n}\n\n/**\n * Handle kernel restart event\n */\nfunction handle_kernel_cleanup(event, handle) {\n  delete PyViz.comms[\"hv-extension-comm\"];\n  window.PyViz.plot_index = {}\n}\n\n/**\n * Handle update_display_data messages\n */\nfunction handle_update_output(event, handle) {\n  handle_clear_output(event, {cell: {output_area: handle.output_area}})\n  handle_add_output(event, handle)\n}\n\nfunction register_renderer(events, OutputArea) {\n  function append_mime(data, metadata, element) {\n    // create a DOM node to render to\n    var toinsert = this.create_output_subarea(\n    metadata,\n    CLASS_NAME,\n    EXEC_MIME_TYPE\n    );\n    this.keyboard_manager.register_events(toinsert);\n    // Render to node\n    var props = {data: data, metadata: metadata[EXEC_MIME_TYPE]};\n    render(props, toinsert[0]);\n    element.append(toinsert);\n    return toinsert\n  }\n\n  events.on('output_added.OutputArea', handle_add_output);\n  events.on('output_updated.OutputArea', handle_update_output);\n  events.on('clear_output.CodeCell', handle_clear_output);\n  events.on('delete.Cell', handle_clear_output);\n  events.on('kernel_ready.Kernel', handle_kernel_cleanup);\n\n  OutputArea.prototype.register_mime_type(EXEC_MIME_TYPE, append_mime, {\n    safe: true,\n    index: 0\n  });\n}\n\nif (window.Jupyter !== undefined) {\n  try {\n    var events = require('base/js/events');\n    var OutputArea = require('notebook/js/outputarea').OutputArea;\n    if (OutputArea.prototype.mime_types().indexOf(EXEC_MIME_TYPE) == -1) {\n      register_renderer(events, OutputArea);\n    }\n  } catch(err) {\n  }\n}\n",
+      "application/vnd.holoviews_load.v0+json": ""
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.holoviews_exec.v0+json": "",
+      "text/html": [
+       "<div id='94bcd32f-2b79-4f07-a3fa-c023c82aa117'>\n",
+       "  <div id=\"ae2e6ec2-d92b-4d08-959f-44fab1825c62\" data-root-id=\"94bcd32f-2b79-4f07-a3fa-c023c82aa117\" style=\"display: contents;\"></div>\n",
+       "</div>\n",
+       "<script type=\"application/javascript\">(function(root) {\n",
+       "  var docs_json = {\"4a6bac5d-aac1-45be-a9c3-617cbd8dff6a\":{\"version\":\"3.6.2\",\"title\":\"Bokeh Application\",\"roots\":[{\"type\":\"object\",\"name\":\"panel.models.browser.BrowserInfo\",\"id\":\"94bcd32f-2b79-4f07-a3fa-c023c82aa117\"},{\"type\":\"object\",\"name\":\"panel.models.comm_manager.CommManager\",\"id\":\"74631b3e-ad74-4ac5-a314-a1c1ebbf808f\",\"attributes\":{\"plot_id\":\"94bcd32f-2b79-4f07-a3fa-c023c82aa117\",\"comm_id\":\"6ba38ae40f464b89a0d4e694bdac69d8\",\"client_comm_id\":\"f6a8fb92bde14e2b9a38bde526c58b26\"}}],\"defs\":[{\"type\":\"model\",\"name\":\"ReactiveHTML1\"},{\"type\":\"model\",\"name\":\"FlexBox1\",\"properties\":[{\"name\":\"align_content\",\"kind\":\"Any\",\"default\":\"flex-start\"},{\"name\":\"align_items\",\"kind\":\"Any\",\"default\":\"flex-start\"},{\"name\":\"flex_direction\",\"kind\":\"Any\",\"default\":\"row\"},{\"name\":\"flex_wrap\",\"kind\":\"Any\",\"default\":\"wrap\"},{\"name\":\"gap\",\"kind\":\"Any\",\"default\":\"\"},{\"name\":\"justify_content\",\"kind\":\"Any\",\"default\":\"flex-start\"}]},{\"type\":\"model\",\"name\":\"FloatPanel1\",\"properties\":[{\"name\":\"config\",\"kind\":\"Any\",\"default\":{\"type\":\"map\"}},{\"name\":\"contained\",\"kind\":\"Any\",\"default\":true},{\"name\":\"position\",\"kind\":\"Any\",\"default\":\"right-top\"},{\"name\":\"offsetx\",\"kind\":\"Any\",\"default\":null},{\"name\":\"offsety\",\"kind\":\"Any\",\"default\":null},{\"name\":\"theme\",\"kind\":\"Any\",\"default\":\"primary\"},{\"name\":\"status\",\"kind\":\"Any\",\"default\":\"normalized\"}]},{\"type\":\"model\",\"name\":\"GridStack1\",\"properties\":[{\"name\":\"mode\",\"kind\":\"Any\",\"default\":\"warn\"},{\"name\":\"ncols\",\"kind\":\"Any\",\"default\":null},{\"name\":\"nrows\",\"kind\":\"Any\",\"default\":null},{\"name\":\"allow_resize\",\"kind\":\"Any\",\"default\":true},{\"name\":\"allow_drag\",\"kind\":\"Any\",\"default\":true},{\"name\":\"state\",\"kind\":\"Any\",\"default\":[]}]},{\"type\":\"model\",\"name\":\"drag1\",\"properties\":[{\"name\":\"slider_width\",\"kind\":\"Any\",\"default\":5},{\"name\":\"slider_color\",\"kind\":\"Any\",\"default\":\"black\"},{\"name\":\"value\",\"kind\":\"Any\",\"default\":50}]},{\"type\":\"model\",\"name\":\"click1\",\"properties\":[{\"name\":\"terminal_output\",\"kind\":\"Any\",\"default\":\"\"},{\"name\":\"debug_name\",\"kind\":\"Any\",\"default\":\"\"},{\"name\":\"clears\",\"kind\":\"Any\",\"default\":0}]},{\"type\":\"model\",\"name\":\"FastWrapper1\",\"properties\":[{\"name\":\"object\",\"kind\":\"Any\",\"default\":null},{\"name\":\"style\",\"kind\":\"Any\",\"default\":null}]},{\"type\":\"model\",\"name\":\"NotificationAreaBase1\",\"properties\":[{\"name\":\"js_events\",\"kind\":\"Any\",\"default\":{\"type\":\"map\"}},{\"name\":\"position\",\"kind\":\"Any\",\"default\":\"bottom-right\"},{\"name\":\"_clear\",\"kind\":\"Any\",\"default\":0}]},{\"type\":\"model\",\"name\":\"NotificationArea1\",\"properties\":[{\"name\":\"js_events\",\"kind\":\"Any\",\"default\":{\"type\":\"map\"}},{\"name\":\"notifications\",\"kind\":\"Any\",\"default\":[]},{\"name\":\"position\",\"kind\":\"Any\",\"default\":\"bottom-right\"},{\"name\":\"_clear\",\"kind\":\"Any\",\"default\":0},{\"name\":\"types\",\"kind\":\"Any\",\"default\":[{\"type\":\"map\",\"entries\":[[\"type\",\"warning\"],[\"background\",\"#ffc107\"],[\"icon\",{\"type\":\"map\",\"entries\":[[\"className\",\"fas fa-exclamation-triangle\"],[\"tagName\",\"i\"],[\"color\",\"white\"]]}]]},{\"type\":\"map\",\"entries\":[[\"type\",\"info\"],[\"background\",\"#007bff\"],[\"icon\",{\"type\":\"map\",\"entries\":[[\"className\",\"fas fa-info-circle\"],[\"tagName\",\"i\"],[\"color\",\"white\"]]}]]}]}]},{\"type\":\"model\",\"name\":\"Notification\",\"properties\":[{\"name\":\"background\",\"kind\":\"Any\",\"default\":null},{\"name\":\"duration\",\"kind\":\"Any\",\"default\":3000},{\"name\":\"icon\",\"kind\":\"Any\",\"default\":null},{\"name\":\"message\",\"kind\":\"Any\",\"default\":\"\"},{\"name\":\"notification_type\",\"kind\":\"Any\",\"default\":null},{\"name\":\"_destroyed\",\"kind\":\"Any\",\"default\":false}]},{\"type\":\"model\",\"name\":\"TemplateActions1\",\"properties\":[{\"name\":\"open_modal\",\"kind\":\"Any\",\"default\":0},{\"name\":\"close_modal\",\"kind\":\"Any\",\"default\":0}]},{\"type\":\"model\",\"name\":\"BootstrapTemplateActions1\",\"properties\":[{\"name\":\"open_modal\",\"kind\":\"Any\",\"default\":0},{\"name\":\"close_modal\",\"kind\":\"Any\",\"default\":0}]},{\"type\":\"model\",\"name\":\"TemplateEditor1\",\"properties\":[{\"name\":\"layout\",\"kind\":\"Any\",\"default\":[]}]},{\"type\":\"model\",\"name\":\"MaterialTemplateActions1\",\"properties\":[{\"name\":\"open_modal\",\"kind\":\"Any\",\"default\":0},{\"name\":\"close_modal\",\"kind\":\"Any\",\"default\":0}]},{\"type\":\"model\",\"name\":\"ReactiveESM1\",\"properties\":[{\"name\":\"esm_constants\",\"kind\":\"Any\",\"default\":{\"type\":\"map\"}}]},{\"type\":\"model\",\"name\":\"JSComponent1\",\"properties\":[{\"name\":\"esm_constants\",\"kind\":\"Any\",\"default\":{\"type\":\"map\"}}]},{\"type\":\"model\",\"name\":\"ReactComponent1\",\"properties\":[{\"name\":\"esm_constants\",\"kind\":\"Any\",\"default\":{\"type\":\"map\"}}]},{\"type\":\"model\",\"name\":\"AnyWidgetComponent1\",\"properties\":[{\"name\":\"esm_constants\",\"kind\":\"Any\",\"default\":{\"type\":\"map\"}}]},{\"type\":\"model\",\"name\":\"request_value1\",\"properties\":[{\"name\":\"fill\",\"kind\":\"Any\",\"default\":\"none\"},{\"name\":\"_synced\",\"kind\":\"Any\",\"default\":null},{\"name\":\"_request_sync\",\"kind\":\"Any\",\"default\":0}]}]}};\n",
+       "  var render_items = [{\"docid\":\"4a6bac5d-aac1-45be-a9c3-617cbd8dff6a\",\"roots\":{\"94bcd32f-2b79-4f07-a3fa-c023c82aa117\":\"ae2e6ec2-d92b-4d08-959f-44fab1825c62\"},\"root_ids\":[\"94bcd32f-2b79-4f07-a3fa-c023c82aa117\"]}];\n",
+       "  var docs = Object.values(docs_json)\n",
+       "  if (!docs) {\n",
+       "    return\n",
+       "  }\n",
+       "  const py_version = docs[0].version.replace('rc', '-rc.').replace('.dev', '-dev.')\n",
+       "  async function embed_document(root) {\n",
+       "    var Bokeh = get_bokeh(root)\n",
+       "    await Bokeh.embed.embed_items_notebook(docs_json, render_items);\n",
+       "    for (const render_item of render_items) {\n",
+       "      for (const root_id of render_item.root_ids) {\n",
+       "\tconst id_el = document.getElementById(root_id)\n",
+       "\tif (id_el.children.length && id_el.children[0].hasAttribute('data-root-id')) {\n",
+       "\t  const root_el = id_el.children[0]\n",
+       "\t  root_el.id = root_el.id + '-rendered'\n",
+       "\t  for (const child of root_el.children) {\n",
+       "            // Ensure JupyterLab does not capture keyboard shortcuts\n",
+       "            // see: https://jupyterlab.readthedocs.io/en/4.1.x/extension/notebook.html#keyboard-interaction-model\n",
+       "\t    child.setAttribute('data-lm-suppress-shortcuts', 'true')\n",
+       "\t  }\n",
+       "\t}\n",
+       "      }\n",
+       "    }\n",
+       "  }\n",
+       "  function get_bokeh(root) {\n",
+       "    if (root.Bokeh === undefined) {\n",
+       "      return null\n",
+       "    } else if (root.Bokeh.version !== py_version) {\n",
+       "      if (root.Bokeh.versions === undefined || !root.Bokeh.versions.has(py_version)) {\n",
+       "\treturn null\n",
+       "      }\n",
+       "      return root.Bokeh.versions.get(py_version);\n",
+       "    } else if (root.Bokeh.version === py_version) {\n",
+       "      return root.Bokeh\n",
+       "    }\n",
+       "    return null\n",
+       "  }\n",
+       "  function is_loaded(root) {\n",
+       "    var Bokeh = get_bokeh(root)\n",
+       "    return (Bokeh != null && Bokeh.Panel !== undefined)\n",
+       "  }\n",
+       "  if (is_loaded(root)) {\n",
+       "    embed_document(root);\n",
+       "  } else {\n",
+       "    var attempts = 0;\n",
+       "    var timer = setInterval(function(root) {\n",
+       "      if (is_loaded(root)) {\n",
+       "        clearInterval(timer);\n",
+       "        embed_document(root);\n",
+       "      } else if (document.readyState == \"complete\") {\n",
+       "        attempts++;\n",
+       "        if (attempts > 200) {\n",
+       "          clearInterval(timer);\n",
+       "\t  var Bokeh = get_bokeh(root)\n",
+       "\t  if (Bokeh == null || Bokeh.Panel == null) {\n",
+       "            console.warn(\"Panel: ERROR: Unable to run Panel code because Bokeh or Panel library is missing\");\n",
+       "\t  } else {\n",
+       "\t    console.warn(\"Panel: WARNING: Attempting to render but not all required libraries could be resolved.\")\n",
+       "\t    embed_document(root)\n",
+       "\t  }\n",
+       "        }\n",
+       "      }\n",
+       "    }, 25, root)\n",
+       "  }\n",
+       "})(window);</script>"
+      ]
+     },
+     "metadata": {
+      "application/vnd.holoviews_exec.v0+json": {
+       "id": "94bcd32f-2b79-4f07-a3fa-c023c82aa117"
+      }
+     },
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "<div class=\"logo-block\">\n",
+       "<img src='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAYAAACqaXHeAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\n",
+       "AAAB+wAAAfsBxc2miwAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9yZ5vuPBoAAA6zSURB\n",
+       "VHic7ZtpeFRVmsf/5966taWqUlUJ2UioBBJiIBAwCZtog9IOgjqACsogKtqirT2ttt069nQ/zDzt\n",
+       "tI4+CrJIREFaFgWhBXpUNhHZQoKBkIUASchWla1S+3ar7r1nPkDaCAnZKoQP/D7mnPOe9/xy76n3\n",
+       "nFSAW9ziFoPFNED2LLK5wcyBDObkb8ZkxuaoSYlI6ZcOKq1eWFdedqNzGHQBk9RMEwFAASkk0Xw3\n",
+       "ETacDNi2vtvc7L0ROdw0AjoSotQVkKSvHQz/wRO1lScGModBFbDMaNRN1A4tUBCS3lk7BWhQkgpD\n",
+       "lG4852/+7DWr1R3uHAZVQDsbh6ZPN7CyxUrCzJMRouusj0ipRwD2uKm0Zn5d2dFwzX1TCGhnmdGo\n",
+       "G62Nna+isiUqhkzuKrkQaJlPEv5mFl2fvGg2t/VnzkEV8F5ioioOEWkLG86fvbpthynjdhXYZziQ\n",
+       "x1hC9J2NFyi8vCTt91Fh04KGip0AaG9zuCk2wQCVyoNU3Hjezee9bq92duzzTmxsRJoy+jEZZZYo\n",
+       "GTKJ6SJngdJqAfRzpze0+jHreUtPc7gpBLQnIYK6BYp/uGhw9YK688eu7v95ysgshcg9qSLMo3JC\n",
+       "4jqLKQFBgdKDPoQ+Pltb8dUyQLpeDjeVgI6EgLIQFT5tEl3rn2losHVsexbZ3EyT9wE1uGdkIPcy\n",
+       "BGxn8QUq1QrA5nqW5i2tLqvrrM9NK6AdkVIvL9E9bZL/oyfMVd/jqvc8LylzRBKDJSzIExwhQzuL\n",
+       "QYGQj4rHfFTc8mUdu3E7yoLtbTe9gI4EqVgVkug2i5+uXGo919ixbRog+3fTbQ8qJe4ZOYNfMoTI\n",
+       "OoshUNosgO60AisX15aeI2PSIp5KiFLI9ubb1vV3Qb2ltwLakUCDAkWX7/nHKRmmGIl9VgYsUhJm\n",
+       "2NXjKYADtM1ygne9QQDIXlk49FBstMKx66D1v4+XuQr7vqTe0VcBHQlRWiOCbmmSYe2SqtL6q5rJ\n",
+       "zsTb7lKx3FKOYC4DoqyS/B5bvLPxvD9Qtf6saxYLQGJErmDOdOMr/zo96km1nElr8bmPOBwI9COv\n",
+       "HnFPRIwmkSOv9kcAS4heRsidOkpeWBgZM+UBrTFAXNYL5Vf2ii9c1trNzpYdaoVil3WIc+wdk+gQ\n",
+       "noie3ecCcxt9ITcLAPWt/laGEO/9U6PmzZkenTtsSMQ8uYywJVW+grCstAvCIaAdArAsIWkRDDs/\n",
+       "KzLm2YcjY1Lv0UdW73HabE9n6V66cxSzfEmuJssTpKGVp+0vHq73FwL46eOjpMpbRAnNmJFrGJNu\n",
+       "Ukf9Yrz+3rghiumCKNXXWPhLYcjxGsIpoCMsIRoFITkW8AuyM8jC1+/QLx4bozCEJIq38+1rtpR6\n",
+       "V/yzb8eBlRb3fo5l783N0CWolAzJHaVNzkrTzlEp2bQ2q3TC5gn6wpnoQAmwSiGh2GitnTmVMc5O\n",
+       "UyfKWUKCIsU7+fZDKwqdT6DDpvkzAX4/+AMFjk0tDp5GRXLpQ2MUmhgDp5gxQT8+Y7hyPsMi8uxF\n",
+       "71H0oebujHALECjFKaW9Lm68n18wXp2kVzIcABytD5iXFzg+WVXkegpAsOOYziqo0OkK76GyquC3\n",
+       "ltZAzMhhqlSNmmWTE5T6e3IN05ITFLM4GdN0vtZ3ob8Jh1NAKXFbm5PtLU/eqTSlGjkNAJjdgn/N\n",
+       "aedXa0tdi7+t9G0FIF49rtMSEgAs1kDLkTPO7ebm4IUWeyh1bKomXqlgMG6kJmHcSM0clYLJ8XtR\n",
+       "1GTnbV3F6I5wCGikAb402npp1h1s7LQUZZSMIfALFOuL3UUrfnS8+rez7v9qcold5tilgHbO1fjK\n",
+       "9ubb17u9oshxzMiUBKXWqJNxd+fqb0tLVs4lILFnK71H0Ind7uiPgACVcFJlrb0tV6DzxqqTIhUM\n",
+       "CwDf1/rrVhTa33/3pGPxJYdQ2l2cbgVcQSosdx8uqnDtbGjh9SlDVSMNWhlnilfqZk42Th2ZpLpf\n",
+       "xrHec5e815zrr0dfBZSwzkZfqsv+1FS1KUknUwPARVvItfKUY+cn57yP7qv07UE3p8B2uhUwLk09\n",
+       "e0SCOrK+hbdYHYLjRIl71wWzv9jpEoeOHhGRrJAzyEyNiJuUqX0g2sBN5kGK6y2Blp5M3lsB9Qh4\n",
+       "y2Ja6x6+i0ucmKgwMATwhSjdUu49tKrQ/pvN5d53ml2CGwCmJipmKjgmyuaXzNeL2a0AkQ01Th5j\n",
+       "2DktO3Jyk8f9vcOBQHV94OK+fPumJmvQHxJoWkaKWq9Vs+yUsbq0zGT1I4RgeH2b5wef7+c7bl8F\n",
+       "eKgoHVVZa8ZPEORzR6sT1BzDUAD/d9F78e2Tzv99v8D+fLVTqAKAsbGamKey1Mt9Ann4eH3gTXTz\n",
+       "idWtAJ8PQWOk7NzSeQn/OTHDuEikVF1R4z8BQCy+6D1aWRfY0tTGG2OM8rRoPaeIj5ZHzJxszElN\n",
+       "VM8K8JS5WOfv8mzRnQAKoEhmt8gyPM4lU9SmBK1MCQBnW4KONT86v1hZ1PbwSXPw4JWussVjtH9Y\n",
+       "NCoiL9UoH/6PSu8jFrfY2t36erQHXLIEakMi1SydmzB31h3GGXFDFNPaK8Rme9B79Ixrd0WN+1ij\n",
+       "NRQ/doRmuFLBkHSTOm5GruG+pFjFdAmorG4IXH1Qua6ASniclfFtDYt+oUjKipPrCQB7QBQ2lrgP\n",
+       "fFzm+9XWUtcqJ3/5vDLDpJ79XHZk3u8nGZ42qlj1+ydtbxysCezrydp6ugmipNJ7WBPB5tydY0jP\n",
+       "HaVNzs3QzeE4ZpTbI+ZbnSFPbVOw9vsfnVvqWnirPyCNGD08IlqtYkh2hjZ5dErEQzoNm+6ykyOt\n",
+       "Lt5/PQEuSRRKo22VkydK+vvS1XEKlhCJAnsqvcVvH7f/ZU2R67eXbMEGAMiIV5oWZWiWvz5Fv2xG\n",
+       "sjqNJQRvn3Rs2lji/lNP19VjAQDgD7FHhujZB9OGqYxRkZxixgRDVlqS6uEOFaJUVu0rPFzctrnF\n",
+       "JqijImVp8dEKVWyUXDk92zAuMZ6bFwpBU1HrOw6AdhQgUooChb0+ItMbWJitSo5Ws3IAOGEOtL53\n",
+       "0vHZih9sC4vtofZ7Qu6523V/fmGcds1TY3V36pUsBwAbSlxnVh2xLfAD/IAIMDf7XYIkNmXfpp2l\n",
+       "18rkAJAy9HKFaIr/qULkeQQKy9zf1JgDB2uaeFNGijo5QsUyacNUUTOnGO42xSnv4oOwpDi1zYkc\n",
+       "efUc3I5Gk6PhyTuVKaOGyLUAYPGIoY9Pu/atL/L92+4q9wbflRJ2Trpm/jPjdBtfnqB/dIThcl8A\n",
+       "KG7hbRuKnb8qsQsVvVlTrwQAQMUlf3kwJI24Z4JhPMtcfng5GcH49GsrxJpGvvHIaeem2ma+KSjQ\n",
+       "lIwUdYyCY8j4dE1KzijNnIP2llF2wcXNnsoapw9XxsgYAl6k+KzUXbi2yP3KR2ecf6z3BFsBICdW\n",
+       "nvnIaG3eHybqX7vbpEqUMT+9OL4Qpe8VON7dXuFd39v19FoAABRVePbGGuXTszO0P7tu6lghUonE\n",
+       "llRdrhArLvmKdh9u29jcFiRRkfLUxBiFNiqSU9icoZQHo5mYBI1MBgBH6wMNb+U7Pnw337H4gi1Y\n",
+       "ciWs+uks3Z9fztUvfzxTm9Ne8XXkvQLHNytOOZeiD4e0PgkAIAYCYknKUNUDSXEKzdWNpnil7r4p\n",
+       "xqkjTarZMtk/K8TQ6Qve78qqvXurGwIJqcOUKfUWHsm8KGvxSP68YudXq4pcj39X49uOK2X142O0\n",
+       "Tz5/u/7TVybqH0rSya6ZBwD21/gubbrgWdDgEOx9WUhfBaC2ibcEBYm7a7x+ukrBMNcEZggyR0TE\n",
+       "T8zUPjikQ4VosQZbTpS4vqizBKvqmvjsqnpfzaZyx9JPiz1/bfGKdgD45XB1zoIMzYbfTdS/NClB\n",
+       "Gct0USiY3YL/g0LHy/uq/Ef6uo5+n0R/vyhp17Klpge763f8rMu6YU/zrn2nml+2WtH+Z+5IAAFc\n",
+       "2bUTdTDOSNa9+cQY7YLsOIXhevEkCvzph7a8laecz/Un/z4/Ae04XeL3UQb57IwU9ZDr9UuKVajv\n",
+       "nxp1+1UVIo/LjztZkKH59fO3G/JemqCfmaCRqbqbd90ZZ8FfjtkfAyD0J/9+C2h1hDwsSxvGjNDc\n",
+       "b4zk5NfrSwiQblLHzZhg+Jf4aPlUwpDqkQqa9nimbt1/TDH8OitGMaQnj+RJS6B1fbF7SY1TqO5v\n",
+       "/v0WAADl1f7zokgS7s7VT2DZ7pegUjBM7mjtiDZbcN4j0YrHH0rXpCtY0qPX0cVL0rv5jv/ZXend\n",
+       "0u/EESYBAFBU4T4Qa5TflZOhTe7pmKpaP8kCVUVw1+yhXfJWvn1P3hnXi33JsTN6PnP3hHZ8Z3/h\n",
+       "aLHzmkNPuPj7Bc/F/Q38CwjTpSwQXgE4Vmwry9tpfq/ZFgqFMy4AVDtCvi8rvMvOmv0N4YwbVgEA\n",
+       "sPM72/KVnzfspmH7HQGCRLG2yL1+z8XwvPcdCbsAANh+xPzstgMtxeGKt+6MK3/tacfvwhWvIwMi\n",
+       "oKEBtm0H7W+UVfkc/Y1V0BhoPlDr/w1w/eu1vjIgAgDg22OtX6/eYfnEz/focrZTHAFR+PSs56/7\n",
+       "q32nwpjazxgwAQCwcU/T62t3WL7r6/jVRa6/byp1rei+Z98ZUAEAhEPHPc8fKnTU9nbgtnOe8h0l\n",
+       "9hcGIqmODLQAHCy2Xti6v/XNRivf43f4fFvIteu854+VHnR7q9tfBlwAAGz+pnndB9vM26UebAe8\n",
+       "SLHujPOTPVW+rwY+sxskAAC2HrA8t2Vvc7ffP1r9o+vwR2dcr92InIAbKKC1FZ5tB1tf+/G8p8sv\n",
+       "N/9Q5zd/XR34LYCwV5JdccMEAMDBk45DH243r/X4xGvqxFa/GNpS7n6rwOwNWwHVE26oAADYurf1\n",
+       "zx/utOzt+DMKYM0p17YtZZ5VNzqfsB2HewG1WXE8PoZ7gOclbTIvynZf9JV+fqZtfgs/8F/Nu5rB\n",
+       "EIBmJ+8QRMmpU7EzGRsf2FzuePqYRbzh/zE26EwdrT10f6r6o8HOYzCJB9Dpff8tbnGLG8L/A/WE\n",
+       "roTBs2RqAAAAAElFTkSuQmCC'\n",
+       "     style='height:25px; border-radius:12px; display: inline-block; float: left; vertical-align: middle'></img>\n",
+       "\n",
+       "\n",
+       "  <img src='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACMAAAAjCAYAAAAe2bNZAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAAK6wAACusBgosNWgAAABx0RVh0U29mdHdhcmUAQWRvYmUgRmlyZXdvcmtzIENTNui8sowAAAf9SURBVFiFvZh7cFTVHcc/59y7793sJiFAwkvAYDRqFWwdraLVlj61diRYsDjqCFbFKrYo0CltlSq1tLaC2GprGIriGwqjFu10OlrGv8RiK/IICYECSWBDkt3s695zTv9IAtlHeOn0O7Mzu797z+/3Ob/z+p0VfBq9doNFljuABwAXw2PcvGHt6bgwxhz7Ls4YZNVXxxANLENwE2D1W9PAGmAhszZ0/X9gll5yCbHoOirLzmaQs0F6F8QMZq1v/8xgNm7DYwwjgXJLYL4witQ16+sv/U9HdDmV4WrKw6B06cZC/RMrM4MZ7xz61DAbtzEXmAvUAX4pMOVecg9/MFFu3j3Gz7gQBLygS2RGumBkL0cubiFRsR3LzVBV1UMk3IrW73PT9C2lYOwhQB4ClhX1AuKpjLcV27oEjyUpNUJCg1CvcejykWTCXyQgzic2HIIBjg3pS6+uRLKAhumZvD4U+tq0jTrgkVKQQtLekfTtxIPAkhTNF6G7kZm7aPp6M9myKVQEoaYaIhEQYvD781DML/RfBGNZXAl4irJiwBa07e/y7cQnBaJghIX6ENl2GR/fGCBoz6cm5qeyEqQA5ZYA5x5eeiV0Qph4gjFAUSwAr6QllQgcxS/Jm25Cr2Tmpsk03XI9NfI31FTZBEOgVOk51adqDBNPCNPSRlkiDXbBEwOU2WxH+I7itQZ62g56OjM33suq1YsZHVtGZSUI2QdyYgkgOthQNIF7BIGDnRAJgJSgj69cUx1gB8PkOGwL4E1gPrM27gIg7NlGKLQApc7BmEnAxP5g/rw4YqBrCDB5xHkw5rdR/1qTrN/hKNo6YUwVDNpFsnjYS8RbidBPcPXFP6R6yfExuOXmN4A3jv1+8ZUwgY9D2OWjUZE6lO88jDwHI8ZixGiMKSeYTBamCoDk6kDAb6y1OcH1a6KpD/fZesoFw5FlIXAVCIiH4PxrV+p2npVDToTBmtjY8t1swh2V61E9KqWiyuPEjM8dbfxuvfa49Zayf9R136Wr8mBSf/T7bNteA8zwaGEUbFpckWwq95n59dUIywKl2fbOIS5e8bWSu0tJ1a5redAYfqkdjesodFajcgaVNWhXo1C9SrkN3Usmv3UMJrc6/DDwkwEntkEJLe67tSLhvyzK8rHDQWleve5CGk4VZEB1r+5bg2E2si+Y0QatDK6jUVkX5eg2YYlp++ZM+rfMNYamAj8Y7MAVWFqaR1f/t2xzU4IHjybBtthzuiAASqv7jTF7jOqDMAakFHgDNsFyP+FhwZHBmH9F7cutIYkQCylYYv1AZSqsn1/+bX51OMMjPSl2nAnM7hnjOx2v53YgNWAzHM9Q/9l0lQWPSCBSyokAtOBC1Rj+w/1Xs+STDp4/E5g7Rs2zm2+oeVd7PUuHKDf6A4r5EsPT5K3gfCnBXNUYnvGzb+KcCczYYWOnLpy4eOXuG2oec0PBN8XQQAnpvS35AvAykr56rWhPBiV4MvtceGLxk5Mr6A1O8IfK7rl7xJ0r9kyumuP4fa0lMqTBLJIAJqEf1J3qE92lMBndlyfRD2YBghHC4hlny7ASqCeWo5zaoDdIWfnIefNGTb9fC73QDfhyBUCNOxrGPSUBfPem9us253YTV+3mcBbdkUYfzmHiLqZbYdIGHHON2ZlemXouaJUOO6TqtdHEQuXYY8Yt+EbDgmlS6RdzkaDTv2P9A3gICiq93sWhb5mc5wVhuU3Y7m5hOc3So7qFT3SLgOXHb/cyOfMn7xROegoC/PTcn3v8gbKPgDopJFk3R/uBPWQiwQ+2/GJevRMObLUzqe/saJjQUQTTftEVMW9tWxPgAocwcj9abNcZe7s+6t2R2xXZG7zyYLp8Q1PiRBBHym5bYuXi8Qt+/LvGu9f/5YDAxABsaRNPH6Xr4D4Sk87a897SOy9v/fKwjoF2eQel95yDESGEF6gEMwKhLwKus3wOVjTtes7qzgLdXTMnNCNoEpbcrtNuq6N7Xh/+eqcbj94xQkp7mdKpW5XbtbR8Z26kgMCAf2UU5YEovRUVRHbu2b3vK1UdDFkDCyMRQxbpdv8nhKAGIa7QaQedzT07fFPny53R738JoVYBdVrnsNx9XZ9v33UeGO+AA2MMUkgqQ5UcdDLZSFeVgONnXeHqSAC5Ew1BXwko0D1Zct3dT1duOjS3MzZnEUJtBuoQAq3SGOLR4ekjn9NC5nVOaYXf9lETrUkmOJy3pOz8OKIb2A1cWhJCCEzOxU2mUPror+2/L3yyM3pkM7jTjr1nBOgkGeyQ7erxpdJsMAS9wb2F9rzMxNY1K2PMU0WtZV82VU8Wp6vbKJVo9Lx/+4cydORdxCCQ/kDGTZCWsRpLu7VD7bfKqL8V2orKTp/PtzaXy42jr6TwAuisi+7JolUG4wY+8vyrISCMtRrLKWpvjAOqx/QGhp0rjRo5xD3x98CWQuOQN8qumRMmI7jKZPUEpzNVZsj4Zbaq1to5tZZsKIydLWojhIXrJnES79EaOzv3du2NytKuxzJKAA6wF8xqEE8s2jo/1wd/khslQGxd81Zg62Bbp31XBH+iETt7Y3ELA0iU6iGDlQ5mexe0VEx4a3x8V1AaYwFJgTiwaOsDmeK2J8nMUOqsnB1A+dcA04ucCYt0urkjmflk9iT2v30q/gZn5rQPvor4n9Ou634PeBzoznes/iot/7WnClKoM/+zCIjH5kwT8ChQjTHPIPTjFV3PpU/Hx+DM/A9U3IXI4SPCYAAAAABJRU5ErkJggg=='\n",
+       "       style='height:15px; border-radius:12px; display: inline-block; float: left'></img>\n",
+       "  \n",
+       "\n",
+       "\n",
+       "\n",
+       "\n",
+       "</div>\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "1997ff4a8e9b47baa6ed84f66c0176c1",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "BokehModel(combine_events=True, render_bundle={'docs_json': {'bf8e0dd0-efc2-4b9c-8a6f-890020accf02': {'version…"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[2025-03-28 16:07:44,434 hyrax.data_sets.hsc_data_set:INFO] Processed 992 objects\n"
      ]
     }
    ],
    "source": [
-    "h.visualize(width=400, height=400)"
+    "h.visualize(width=800, height=800)"
    ]
   },
   {
@@ -587,7 +607,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.8"
+   "version": "3.10.14"
   }
  },
  "nbformat": 4,

--- a/src/hyrax/data_sets/data_set_registry.py
+++ b/src/hyrax/data_sets/data_set_registry.py
@@ -140,7 +140,8 @@ class HyraxDataset:
 
         """
         if hasattr(self, "__len__"):
-            return (str(x) for x in range(len(self)))
+            for x in range(len(self)):
+                yield str(x)
         elif hasattr(self, "__iter__"):
             for index, _ in enumerate(iter(self)):
                 yield (str(index))

--- a/src/hyrax/data_sets/hyrax_cifar_data_set.py
+++ b/src/hyrax/data_sets/hyrax_cifar_data_set.py
@@ -1,11 +1,9 @@
 # ruff: noqa: D101, D102
 import logging
-from collections.abc import Generator
-from typing import Optional
 
 import numpy as np
-import numpy.typing as npt
 import torchvision.transforms as transforms
+from astropy.table import Table
 from torchvision.datasets import CIFAR10
 
 from hyrax.config_utils import ConfigDict
@@ -24,35 +22,11 @@ class HyraxCifarDataSet(HyraxDataset, CIFAR10):
     """
 
     def __init__(self, config: ConfigDict):
-        super().__init__(config)
         transform = transforms.Compose(
             [transforms.ToTensor(), transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5))]
         )
         CIFAR10.__init__(
             self, root=config["general"]["data_dir"], train=True, download=True, transform=transform
         )
-
-    def ids(self) -> Generator[str]:
-        return (str(x) for x in range(len(self)))
-
-    def shape(self):
-        return (3, 32, 32)
-
-    def original_config(self) -> ConfigDict:
-        return self.config
-
-    def metadata_fields(self) -> list[str]:
-        return ["label"]
-
-    def metadata(self, idxs: npt.ArrayLike, fields: Optional[list[str]] = None) -> npt.ArrayLike:
-        if np.isscalar(idxs):
-            idxs = np.array([idxs])
-
-        if fields is None:
-            fields = self.metadata_fields()
-
-        if len(fields) == 0 or fields != ["label"]:
-            msg = "For CifarDataSet 'label' is the only supported field."
-            raise RuntimeError(msg)
-
-        return np.array([self[index][1] for index in np.array(idxs)])
+        metadata_table = Table({"label": np.array([self[index][1] for index in range(len(self))])})
+        super().__init__(config, metadata_table)

--- a/src/hyrax/data_sets/inference_dataset.py
+++ b/src/hyrax/data_sets/inference_dataset.py
@@ -75,7 +75,7 @@ class InferenceDataSet(HyraxDataset, Dataset):
     def ids(self) -> Generator[str]:
         """IDs of this dataset
 
-        Note: Not using HyraxDataset.ids() here because we need to be return the ids of whatever
+        Note: Not using HyraxDataset.ids() here because we need to return the ids of whatever
         dataset was used for inference, not the sequential index HyraxDataset.ids() gives.
 
         Returns

--- a/src/hyrax/data_sets/inference_dataset.py
+++ b/src/hyrax/data_sets/inference_dataset.py
@@ -47,6 +47,7 @@ class InferenceDataSet(HyraxDataset, Dataset):
         # Initializes our first element. This primes the cache for sequential access
         # as well as giving us a sample element for shape()
         self.cached_batch_num: Optional[int] = None
+
         self.shape_element = self._load_from_batch_file(
             self.batch_index["batch_num"][0], self.batch_index["id"][0]
         )[0]
@@ -61,6 +62,9 @@ class InferenceDataSet(HyraxDataset, Dataset):
     def shape(self):
         """The shape of the dataset (Discovered from files)
 
+        Note: our __getitem__() needs self.shape() to work. We cannot use HraxDataset.shape()
+        because that shape uses __getitem__(), so we must define this for ourselves
+
         Returns
         -------
         Tuple
@@ -70,6 +74,9 @@ class InferenceDataSet(HyraxDataset, Dataset):
 
     def ids(self) -> Generator[str]:
         """IDs of this dataset
+
+        Note: Not using HyraxDataset.ids() here because we need to be return the ids of whatever
+        dataset was used for inference, not the sequential index HyraxDataset.ids() gives.
 
         Returns
         -------
@@ -140,6 +147,8 @@ class InferenceDataSet(HyraxDataset, Dataset):
 
     def metadata_fields(self) -> list[str]:
         """Get the metadata fields associted with the original dataset used to generate this one
+
+        We must override this and pass to the original dataset.
 
         Returns
         -------

--- a/src/hyrax/models/hyrax_autoencoder.py
+++ b/src/hyrax/models/hyrax_autoencoder.py
@@ -20,7 +20,7 @@ class HyraxAutoencoder(nn.Module):
         super().__init__()
         self.config = config
 
-        # TODO xcxc config-ize or get from data loader somehow
+        # TODO config-ize or get from data loader somehow
         self.num_input_channels, self.image_width, self.image_height = shape
 
         self.c_hid = self.config["model"]["base_channel_size"]


### PR DESCRIPTION
- Metadata accessors `metadata()` and `metadata_fields()` moved to HyraxDataset base class
- HSCDataset and HyraxCifarDataset modified to use the new interface
- HyraxDataset constructor optionally takes a metadata_table for subclasses that want to opt in to metadata

Sidebar:
- Added a precommit hook which looks for 'xcxc'/'XCXC' across all source files. This is a string you can use in a note-to-self or work-in-progress comment which will flag to you so you don't forget to handle it before checking in.
