### PR TITLE
Remove dependency on GPUtil

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,10 +24,6 @@ dependencies = [
     "torchvision", # Used in hsc data loader, example autoencoder, and CNN model data set
     "tensorboardX", # Used to log training metrics
     "tensorboard", # Used to log training metrics
-    # GPUtil is on a branch because it does not install. 
-    # fixed by https://github.com/anderskm/gputil/pull/60
-    # 1.4.0 and earlier are affected.
-    "GPUtil @ git+https://github.com/Samoed/gputil.git@patch-1", # Used to gather GPU usage information
     "schwimmbad", # Used to speedup hsc data loader file scans
     "chromadb", # Used for similarity search
     "holoviews", # Used in Holoviews visualization prototype

--- a/src/hyrax/gpu_monitor.py
+++ b/src/hyrax/gpu_monitor.py
@@ -1,7 +1,8 @@
+import os
 import time
+from dataclasses import dataclass
+from subprocess import Popen, PIPE
 from threading import Thread
-
-import GPUtil
 
 
 class GpuMonitor(Thread):
@@ -20,7 +21,7 @@ class GpuMonitor(Thread):
     def run(self):
         """Run loop that logs GPU metrics every `self.delay` seconds."""
         while not self.stopped:
-            gpus = GPUtil.getGPUs()
+            gpus = getGPUs()
             step = time.time() - self.start_time
             for gpu in gpus:
                 gpu_name = f"GPU_{gpu.id}"
@@ -33,3 +34,62 @@ class GpuMonitor(Thread):
     def stop(self):
         """Stop the monitoring thread."""
         self.stopped = True
+
+
+"""The following is based on GPUtil. It has been striped down to only the
+functionality needed for Hyrax. The original code can be found here:
+https://github.com/anderskm/gputil
+"""
+@dataclass
+class GPU:
+    """Holds the GPU metrics retrieved from nvidia-smi."""
+    id: int
+    load: float
+    memoryTotal: float
+    memoryUsed: float
+
+    @property
+    def memoryUtil(self):
+        """Return the memory utilization of the GPU."""
+        return self.memoryUsed / self.memoryTotal
+
+
+def safeFloatCast(strNumber):
+    try:
+        number = float(strNumber)
+    except ValueError:
+        number = float('nan')
+    return number
+
+
+def getGPUs():
+    """Get the GPU utilization and memory usage for all GPUs on the system using
+    nvidia-smi. Returns a list of GPU objects."""
+
+    try:
+        p = Popen(["nvidia-smi","--query-gpu=index,utilization.gpu,memory.total,memory.used", "--format=csv,noheader,nounits"], stdout=PIPE)
+        stdout, stderror = p.communicate()
+    except:
+        return []
+    output = stdout.decode('UTF-8')
+
+    # Parse output
+    lines = output.split(os.linesep)
+
+    numDevices = len(lines)-1
+    GPUs = []
+    for g in range(numDevices):
+        line = lines[g]
+        vals = line.split(', ')
+        for i in range(4):
+            if (i == 0):
+                deviceIds = int(vals[i])
+            elif (i == 1):
+                gpuUtil = safeFloatCast(vals[i])/100
+            elif (i == 2):
+                memTotal = safeFloatCast(vals[i])
+            elif (i == 3):
+                memUsed = safeFloatCast(vals[i])
+
+        GPUs.append(GPU(deviceIds, gpuUtil, memTotal, memUsed))
+    return GPUs

--- a/src/hyrax/gpu_monitor.py
+++ b/src/hyrax/gpu_monitor.py
@@ -1,7 +1,7 @@
 import os
 import time
 from dataclasses import dataclass
-from subprocess import Popen, PIPE
+from subprocess import PIPE, Popen
 from threading import Thread
 
 
@@ -21,13 +21,13 @@ class GpuMonitor(Thread):
     def run(self):
         """Run loop that logs GPU metrics every `self.delay` seconds."""
         while not self.stopped:
-            gpus = getGPUs()
+            gpus = get_gpu_info()
             step = time.time() - self.start_time
             for gpu in gpus:
                 gpu_name = f"GPU_{gpu.id}"
                 self.tensorboard_logger.add_scalar(f"{gpu_name}/load", gpu.load * 100, step)
                 self.tensorboard_logger.add_scalar(
-                    f"{gpu_name}/memory_utilization", gpu.memoryUtil * 100, step
+                    f"{gpu_name}/memory_utilization", gpu.memory_util * 100, step
                 )
             time.sleep(self.delay)
 
@@ -40,56 +40,78 @@ class GpuMonitor(Thread):
 functionality needed for Hyrax. The original code can be found here:
 https://github.com/anderskm/gputil
 """
+
+
 @dataclass
 class GPU:
     """Holds the GPU metrics retrieved from nvidia-smi."""
+
     id: int
     load: float
-    memoryTotal: float
-    memoryUsed: float
+    memory_total: float
+    memory_used: float
 
     @property
-    def memoryUtil(self):
+    def memory_util(self):
         """Return the memory utilization of the GPU."""
-        return self.memoryUsed / self.memoryTotal
+        return self.memory_used / self.memory_total
 
 
-def safeFloatCast(strNumber):
+def safe_float_cast(str_number):
+    """Convert a string into a float handling the case of `nan`.
+
+    Parameters
+    ----------
+    str_number : str
+        The string to convert to a float.
+
+    Returns
+    -------
+    float
+        The converted float.
+    """
     try:
-        number = float(strNumber)
+        number = float(str_number)
     except ValueError:
-        number = float('nan')
+        number = float("nan")
     return number
 
 
-def getGPUs():
+def get_gpu_info():
     """Get the GPU utilization and memory usage for all GPUs on the system using
     nvidia-smi. Returns a list of GPU objects."""
 
     try:
-        p = Popen(["nvidia-smi","--query-gpu=index,utilization.gpu,memory.total,memory.used", "--format=csv,noheader,nounits"], stdout=PIPE)
+        p = Popen(
+            [
+                "nvidia-smi",
+                "--query-gpu=index,utilization.gpu,memory.total,memory.used",
+                "--format=csv,noheader,nounits",
+            ],
+            stdout=PIPE,
+        )
         stdout, stderror = p.communicate()
-    except:
+    except:  # noqa: E722
         return []
-    output = stdout.decode('UTF-8')
+    output = stdout.decode("UTF-8")
 
     # Parse output
     lines = output.split(os.linesep)
 
-    numDevices = len(lines)-1
-    GPUs = []
-    for g in range(numDevices):
+    num_devices = len(lines) - 1
+    gpus = []
+    for g in range(num_devices):
         line = lines[g]
-        vals = line.split(', ')
+        vals = line.split(", ")
         for i in range(4):
-            if (i == 0):
-                deviceIds = int(vals[i])
-            elif (i == 1):
-                gpuUtil = safeFloatCast(vals[i])/100
-            elif (i == 2):
-                memTotal = safeFloatCast(vals[i])
-            elif (i == 3):
-                memUsed = safeFloatCast(vals[i])
+            if i == 0:
+                device_ids = int(vals[i])
+            elif i == 1:
+                gpu_util = safe_float_cast(vals[i]) / 100
+            elif i == 2:
+                mem_total = safe_float_cast(vals[i])
+            elif i == 3:
+                mem_used = safe_float_cast(vals[i])
 
-        GPUs.append(GPU(deviceIds, gpuUtil, memTotal, memUsed))
-    return GPUs
+        gpus.append(GPU(device_ids, gpu_util, mem_total, mem_used))
+    return gpus


### PR DESCRIPTION
GPUtil has been stagnant for several years now, and recently broke. The metrics that it provides are useful, but not so useful that we should incur the penalty of not being able to deploy to pypi by taking a dependency on a github branch. 

In this PR I have:
- Removed the dependency on GPUtil.
- Copied over the relevant code from GPUtil
- Trimmed down the call to nvidia-smi to be only what is needed by Hyrax
- Converted the `GPU` class into a dataclass.

