### PR TITLE
Fix incorrect usage of `shape` in HyraxDataSet

### DIFF
--- a/src/hyrax/data_sets/data_set_registry.py
+++ b/src/hyrax/data_sets/data_set_registry.py
@@ -147,10 +147,10 @@ class HyraxDataset:
         """
         if hasattr(self, "__getitem__"):
             data_sample = self[0]
-            return data_sample[0].shape if isinstance(data_sample, tuple) else data_sample.shape()
+            return data_sample[0].shape if isinstance(data_sample, tuple) else data_sample.shape
         elif hasattr(self, "__iter__"):
             data_sample = next(iter(self))
-            return data_sample[0].shape if isinstance(data_sample, tuple) else data_sample.shape()
+            return data_sample[0].shape if isinstance(data_sample, tuple) else data_sample.shape
         else:
             return NotImplementedError("You must define __getitem__ or __iter__ to use automatic shape()")
 


### PR DESCRIPTION
It should have been `...shape` not `...shape()`.