### PR TITLE
Iterable dataset support

### DIFF
--- a/docs/external_libraries.rst
+++ b/docs/external_libraries.rst
@@ -75,12 +75,18 @@ items in the batch. This loss is logged to MLflow and tensorboard.
 Defining a dataset class
 ------------------------
 
-Dataset classes are written as subclasses of both ``hyrax.data_sets.HyraxDataset`` and 
-``torch.utils.data.Dataset``. Datasets must minimally define the methods below. These are similar in form to 
-Torch's `Map-style datasets <https://pytorch.org/docs/stable/data.html#map-style-datasets>`_
+Dataset classes are written as subclasses of ``hyrax.data_sets.HyraxDataset``. Datasets must choose to be 
+either "map style", and also inherit from ``torch.utils.data.Dataset`` or "iterable" and inherit from 
+``torch.utils.data.IterableDataset``. `Look here <https://pytorch.org/docs/stable/data.html#dataset-types>`_ 
+for an overview of the difference between map style and iterable datasets.
 
-A fully worked example of creating a custom dataset class is in the example notebook 
+A fully worked example of creating a custom map-style dataset class is in the example notebook 
 :doc:`/pre_executed/custom_dataset`
+
+The methods required are detailed by category below.
+
+All datasets
+............
 
 ``__init__(self, config)``
 .................................
@@ -92,6 +98,9 @@ dataset will be done by Hyrax, when running the relevant verb. Further detail on
 You must call ``super().__init__(config)`` or ``super().__init__(config, metadata_table)`` in your 
 ``__init__`` function
 
+Map style datasets
+..................
+
 ``__getitem(self, idx:int)``
 ............................
 Return a single item in your dataset given a zero-based index.
@@ -99,6 +108,16 @@ Return a single item in your dataset given a zero-based index.
 ``__len__(self)``
 .................
 Return the length of your dataset.
+
+Iterable datasets
+.................
+
+``__iter__(self)``
+.................
+Yield a single item in your dataset, or supply a generator function which does the same.
+If your dataset has an end, yield StopIteration at the end.
+
+Warning: Iterable datasets which do not yield StopIteration are not currently supported in hyrax.
 
 Optional Overrides
 ..................

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,12 @@ dynamic = ["version"]
 requires-python = ">=3.9"
 dependencies = [
     "astropy", # Used to load fits files of sources to query HSC cutout server
-    "pytorch-ignite", # Used for distributed training, logging, etc.
+    # Pin to the current version of pytorch ignite so workarounds to 
+    # https://github.com/pytorch/ignite/issues/3372 function correctly
+    # while allowing us to release packages that don't depend on dev versions
+    # of pytorch-ignite.
+    "pytorch-ignite <= 0.5.2", # Used for distributed training, logging, etc.
+    "more-itertools", # Used to work around the issue in pytorch-ignite above
     "toml", # Used to load configuration files as dictionaries
     "tomlkit", # Used to load configuration files as dictionaries and retain comments
     "torch", # Used for CNN model and in train.py

--- a/src/hyrax/data_sets/__init__.py
+++ b/src/hyrax/data_sets/__init__.py
@@ -8,6 +8,7 @@ __all__ = [
     "DATA_SET_REGISTRY",
     "HyraxCifarDataSet",
     "FitsImageDataSet",
+    "HyraxCifarIterableDataSet",
     "HSCDataSet",
     "InferenceDataSet",
     "Dataset",

--- a/src/hyrax/data_sets/hsc_data_set.py
+++ b/src/hyrax/data_sets/hsc_data_set.py
@@ -321,7 +321,7 @@ class HSCDataSet(FitsImageDataSet):
                 # Drop objects that can't meet the cutout size provided
                 for shape in self.dims[object_id]:
                     if shape[0] < cutout_shape[0] or shape[1] < cutout_shape[1]:
-                        msg = f"A file for object {object_id} has shape ({shape[1]}px, {shape[1]}px)"
+                        msg = f"A file for object {object_id} has shape ({shape[0]}px, {shape[1]}px)"
                         msg += " this is too small for the given cutout size of "
                         msg += f"({cutout_shape[0]}px, {cutout_shape[1]}px)"
                         self._mark_for_prune(object_id, msg)

--- a/src/hyrax/data_sets/hyrax_cifar_data_set.py
+++ b/src/hyrax/data_sets/hyrax_cifar_data_set.py
@@ -4,6 +4,7 @@ import logging
 import numpy as np
 import torchvision.transforms as transforms
 from astropy.table import Table
+from torch.utils.data import IterableDataset
 from torchvision.datasets import CIFAR10
 
 from hyrax.config_utils import ConfigDict
@@ -14,8 +15,8 @@ logger = logging.getLogger(__name__)
 
 
 class HyraxCifarDataSet(HyraxDataset, CIFAR10):
-    """This is simply a version of CIFAR10 that has our needed shape method, and is initialized using
-    Hyrax config with a transformation that works well for example code.
+    """This is simply a version of CIFAR10 that is initialized using Hyrax config with a transformation
+    that works well for example code.
 
     We only use the training split in the data, because it is larger (50k images). Hyrax will then divide that
     into Train/test/Validate according to configuration.
@@ -30,3 +31,28 @@ class HyraxCifarDataSet(HyraxDataset, CIFAR10):
         )
         metadata_table = Table({"label": np.array([self[index][1] for index in range(len(self))])})
         super().__init__(config, metadata_table)
+
+
+class HyraxCifarIterableDataSet(HyraxDataset, IterableDataset):
+    """This is simply a version of CIFAR10 that is initialized using Hyrax config with a transformation
+    that works well for example code. This version only supports iteration, and not map-style access
+
+    We only use the training split in the data, because it is larger (50k images). Hyrax will then divide that
+    into Train/test/Validate according to configuration.
+    """
+
+    def __init__(self, config: ConfigDict):
+        transform = transforms.Compose(
+            [transforms.ToTensor(), transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5))]
+        )
+        self.cifar = CIFAR10(
+            root=config["general"]["data_dir"], train=True, download=True, transform=transform
+        )
+        metadata_table = Table(
+            {"label": np.array([self.cifar[index][1] for index in range(len(self.cifar))])}
+        )
+        super().__init__(config, metadata_table)
+
+    def __iter__(self):
+        for item in self.cifar:
+            yield item

--- a/src/hyrax/infer.py
+++ b/src/hyrax/infer.py
@@ -43,7 +43,8 @@ def run(config: ConfigDict):
     data_set = setup_dataset(config, tensorboardx_logger)
 
     model = setup_model(config, data_set)
-    logger.info(f"data set has length {len(data_set)}")  # type: ignore[arg-type]
+    if data_set.is_map():
+        logger.info(f"data set has length {len(data_set)}")  # type: ignore[arg-type]
     data_loader = dist_data_loader(data_set, config, split=config["infer"]["split"])
 
     log_runtime_config(config, results_dir)

--- a/tests/hyrax/test_e2e.py
+++ b/tests/hyrax/test_e2e.py
@@ -15,7 +15,12 @@ def model_class_name(request):
 # Fixture to give us every dataset which will be used for testing
 @pytest.fixture(
     scope="module",
-    params=[("HSCDataSet", "hsc1k"), ("HyraxCifarDataSet", None), ("FitsImageDataSet", "hsc1k")],
+    params=[
+        ("HSCDataSet", "hsc1k"),
+        ("HyraxCifarDataSet", None),
+        ("HyraxCifarIterableDataSet", None),
+        ("FitsImageDataSet", "hsc1k"),
+    ],
 )
 def dataset_spec(request):
     """Fixture to generate all the Dataset class, sample data pairs


### PR DESCRIPTION
- Adds an example CIFAR iterable dataset
- Changes to pytorch_ignite.py to work around an ignite bug in iterable datasets https://github.com/pytorch/ignite/issues/3372
- New is_iterable() and is_map() interface on dataset base class to unify discernment logic
- Support for abstract base classes that derive from HyraxDataset not being themselves checked for required methods.