### PR TITLE
Huggingface Multimodal Universe dataset

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,12 @@ dynamic = ["version"]
 requires-python = ">=3.9"
 dependencies = [
     "astropy", # Used to load fits files of sources to query HSC cutout server
-    "pytorch-ignite", # Used for distributed training, logging, etc.
+    # Pin to the current version of pytorch ignite so workarounds to 
+    # https://github.com/pytorch/ignite/issues/3372 function correctly
+    # while allowing us to release packages that don't depend on dev versions
+    # of pytorch-ignite.
+    "pytorch-ignite <= 0.5.2", # Used for distributed training, logging, etc.
+    "more-itertools", # Used to work around the issue in pytorch-ignite above
     "toml", # Used to load configuration files as dictionaries
     "tomlkit", # Used to load configuration files as dictionaries and retain comments
     "torch", # Used for CNN model and in train.py

--- a/src/hyrax/data_sets/__init__.py
+++ b/src/hyrax/data_sets/__init__.py
@@ -1,5 +1,6 @@
 from .data_set_registry import DATA_SET_REGISTRY, HyraxDataset
 from .hsc_data_set import HSCDataSet
+from .huggingface_dataset import HyraxHFIterableDataSet, HyraxHFMapDataSet
 from .hyrax_cifar_data_set import HyraxCifarDataSet
 from .inference_dataset import InferenceDataSet
 
@@ -11,4 +12,6 @@ __all__ = [
     "InferenceDataSet",
     "Dataset",
     "HyraxDataset",
+    "HyraxHFMapDataSet",
+    "HyraxHFIterableDataSet",
 ]

--- a/src/hyrax/data_sets/__init__.py
+++ b/src/hyrax/data_sets/__init__.py
@@ -6,6 +6,7 @@ from .inference_dataset import InferenceDataSet
 __all__ = [
     "DATA_SET_REGISTRY",
     "HyraxCifarDataSet",
+    "HyraxCifarIterableDataSet",
     "HSCDataSet",
     "InferenceDataSet",
     "Dataset",

--- a/src/hyrax/data_sets/data_set_registry.py
+++ b/src/hyrax/data_sets/data_set_registry.py
@@ -5,6 +5,7 @@ from typing import Optional
 
 import numpy.typing as npt
 from astropy.table import Table
+from torch.utils.data import Dataset, IterableDataset
 
 from hyrax.config_utils import ConfigDict
 from hyrax.plugin_utils import get_or_load_class, update_registry
@@ -86,15 +87,46 @@ class HyraxDataset:
         self._metadata_table = metadata_table
         self.tensorboardx_logger = None
 
+    def is_iterable(self):
+        """
+        Returns true if underlying dataset is iterable style, supporting __iter__ vs map style
+        where  __getitem__/__len__ are the preferred access methods.
+
+        Returns
+        -------
+        bool
+            True if underlying dataset is iterable
+        """
+        if isinstance(self, (Dataset, IterableDataset)):
+            return isinstance(self, IterableDataset)
+        else:
+            return hasattr(self, "__iter__")
+
+    def is_map(self):
+        """
+        Returns true if underlying dataset is map style, supporting __getitem__/__len__ vs iterable
+        where __iter__ is the preferred access method.
+
+        Returns
+        -------
+        bool
+            True if underlying dataset is map-style
+        """
+        if isinstance(self, (Dataset, IterableDataset)):
+            # All torch IterableDatasets are also Datasets
+            return not isinstance(self, IterableDataset)
+        else:
+            return hasattr(self, "__getitem__")
+
     @property
     def config(self):
         return self._config
 
     def __init_subclass__(cls):
-        from torch.utils.data import IterableDataset
+        from abc import ABC
 
-        if IterableDataset in cls.__bases__ or hasattr(cls, "__iter__"):
-            logger.error("Hyrax does not fully support iterable data sets yet. Proceed at your own risk.")
+        if ABC in cls.__bases__:
+            return
 
         # Paranoia. Deriving from a torch dataset class should ensure this, but if an external dataset author
         # Forgets to to do that, we tell them.
@@ -126,10 +158,10 @@ class HyraxDataset:
             A generator yielding all the string IDs of the dataset.
 
         """
-        if hasattr(self, "__len__"):
+        if self.is_map():
             for x in range(len(self)):
                 yield str(x)
-        elif hasattr(self, "__iter__"):
+        elif self.is_iterable():
             for index, _ in enumerate(iter(self)):
                 yield (str(index))
         else:
@@ -145,12 +177,12 @@ class HyraxDataset:
         tuple
             Shape tuple of the tensor that will be returned from the dataset.
         """
-        if hasattr(self, "__getitem__"):
+        if self.is_map():
             data_sample = self[0]
-            return data_sample[0].shape if isinstance(data_sample, tuple) else data_sample.shape()
-        elif hasattr(self, "__iter__"):
+            return data_sample[0].shape if isinstance(data_sample, tuple) else data_sample.shape
+        elif self.is_iterable():
             data_sample = next(iter(self))
-            return data_sample[0].shape if isinstance(data_sample, tuple) else data_sample.shape()
+            return data_sample[0].shape if isinstance(data_sample, tuple) else data_sample.shape
         else:
             return NotImplementedError("You must define __getitem__ or __iter__ to use automatic shape()")
 

--- a/src/hyrax/data_sets/data_set_registry.py
+++ b/src/hyrax/data_sets/data_set_registry.py
@@ -5,6 +5,8 @@ from typing import Optional
 
 import numpy.typing as npt
 from astropy.table import Table
+from datasets import Dataset as hfDataset
+from datasets import IterableDataset as hfIterableDataset
 from torch.utils.data import Dataset, IterableDataset
 
 from hyrax.config_utils import ConfigDict
@@ -97,7 +99,9 @@ class HyraxDataset:
         bool
             True if underlying dataset is iterable
         """
-        if isinstance(self, (Dataset, IterableDataset)):
+        if isinstance(self, (hfIterableDataset, hfDataset)):
+            return isinstance(self, hfIterableDataset)
+        elif isinstance(self, (Dataset, IterableDataset)):
             return isinstance(self, IterableDataset)
         else:
             return hasattr(self, "__iter__")
@@ -112,7 +116,9 @@ class HyraxDataset:
         bool
             True if underlying dataset is map-style
         """
-        if isinstance(self, (Dataset, IterableDataset)):
+        if isinstance(self, (hfIterableDataset, hfDataset)):
+            return isinstance(self, hfDataset)
+        elif isinstance(self, (Dataset, IterableDataset)):
             # All torch IterableDatasets are also Datasets
             return not isinstance(self, IterableDataset)
         else:

--- a/src/hyrax/data_sets/hsc_data_set.py
+++ b/src/hyrax/data_sets/hsc_data_set.py
@@ -433,7 +433,7 @@ class HSCDataSet(HyraxDataset, Dataset):
                 # Drop objects that can't meet the cutout size provided
                 for shape in self.dims[object_id]:
                     if shape[0] < cutout_shape[0] or shape[1] < cutout_shape[1]:
-                        msg = f"A file for object {object_id} has shape ({shape[1]}px, {shape[1]}px)"
+                        msg = f"A file for object {object_id} has shape ({shape[0]}px, {shape[1]}px)"
                         msg += " this is too small for the given cutout size of "
                         msg += f"({cutout_shape[0]}px, {cutout_shape[1]}px)"
                         self._mark_for_prune(object_id, msg)

--- a/src/hyrax/data_sets/huggingface_dataset.py
+++ b/src/hyrax/data_sets/huggingface_dataset.py
@@ -1,0 +1,207 @@
+import abc
+from collections.abc import Generator
+from typing import Optional
+
+from datasets import Dataset as HFDataset
+from datasets import IterableDataset as HFIterableDataset
+from torch import Tensor
+
+from .data_set_registry import HyraxDataset
+
+
+class HyraxHFDatasetBase(HyraxDataset, abc.ABC):
+    """
+    Base class for multimodal universe datasets.
+
+    Unifies common config, tensor lookup, and id generation functionality. These are essentially the user
+    facing pieces of the iterable, map, and streaming versions of these classes.
+    """
+
+    def __init__(self, config: dict):
+        super().__init__(self, config)
+        print("HyraxHFDatasetBase __init__")
+
+        # Parse config: All of these are required
+        # TODO: error checking here
+        self.hf_config = config["data_set.HuggingFace"]
+        dataset_name = self.hf_config["dataset"]
+        max_size = self.hf_config["max_size"]
+        self.dataset_dict_keys = list(self.hf_config["dict_keys"])
+
+        # Set up the dataset, calling subclass if necessary
+        hf_dataset = self._create_dataset(dataset_name, split="train")
+        hf_dataset = hf_dataset.with_format("torch")
+        if max_size:
+            hf_dataset = hf_dataset.take(max_size)
+
+        # Allow the subclass to do whatever initialization is necessary
+        # depending on what HF class it is inherited from
+        self._become_hf(hf_dataset.select_columns(self.dataset_dict_keys[0]))
+
+        # Create our IDs
+        self.id_dataset = hf_dataset.select_columns("object_id")
+
+    def _create_dataset(self, dataset_name, **kwargs):
+        from datasets import load_dataset
+
+        return load_dataset(dataset_name, **kwargs)
+
+    @abc.abstractmethod
+    def _become_hf(self):
+        raise NotImplementedError(
+            "Subclasses of MMUDatasetBase must call __init__ of the appropriate HF class themselves"
+        )
+
+    def ids(self) -> Generator[str]:
+        """
+        Generator of ids for all HyraxHFDataSets
+
+        Yields
+        ------
+        Generator[str]
+            Yields object ID strings
+        """
+        iterator = iter(self.id_dataset)
+        return (item["object_id"] for item in iterator)
+
+    def _lookup_tensor(self, dset_object: dict, dict_keys: Optional[list[str]] = None) -> Tensor:
+        # TODO: This method of lookup is not very flexible.
+        #
+        # multimodal dataset HSC cutouts have a dict structure that looks like:
+        # {
+        #  image: {
+        #     band: <list of HSC filters>
+        #     flux: <tensor>
+        #     ivar:
+        #     psf_fwhm:
+        #     mask:
+        #     scale:
+        #  }
+        #  object_id:
+        #  ...
+        # }
+        #
+        # In general HuggingFace prefers this structure, at least enforcing it at the top
+        # level of the dict.
+        #
+        # One could imagine:
+        # 1) wanting all of this metadata as input which would require some overhaul
+        # of our contract between models and the rest of fibad. e.g. the invariant of
+        # "model inputs are always a tensor with a given shape" would no longer be true.
+        #
+        # 2) wanting more than one of the tensors packed a particular way. This would
+        # break the configuration I've set in this version of the code
+        #
+        # 3) wanting only a single layer of the tensor. This is currently
+        # disallowed, because dataset_dict_keys is a list of strings, but could be enabled
+        # with some clever stuffing of integer indexes into strings at the config level
+        #
+        dict_keys = self.dataset_dict_keys if dict_keys is None else dict_keys
+
+        current = dset_object
+        for key in dict_keys:
+            current = current[key]
+        return current
+
+
+class HyraxHFMapDataSet(HyraxHFDatasetBase, HFDataset):
+    """
+    Map style HuggingFace Dataset
+    """
+
+    def _become_hf(self, hf_dataset):
+        HFDataset.__init__(
+            self,
+            arrow_table=hf_dataset._data,
+            info=hf_dataset.info,
+            split=hf_dataset.split,
+            indices_table=hf_dataset._indices,
+        )
+        self.set_format("torch")
+
+    def __getitem__(self, idxs):
+        """
+        Get an item from the dataset, can handle a list of indexes
+
+        Parameters
+        ----------
+        idxs : Union[int, list[int]]
+            index or list of indexes
+
+        Returns
+        -------
+        torch.Tensor
+            The data itself
+        """
+        # First lookup required by HF
+        item = super().__getitem__(idxs)[self.dataset_dict_keys[0]]
+        items = [item] if not isinstance(item, list) else item
+        tensors = [self._lookup_tensor(item, self.dataset_dict_keys[1:]) for item in items]
+        retval = tensors if len(tensors) > 1 else tensors[0]
+        return retval
+
+    def __getitems__(self, idxs):
+        # HF (and pytorch) use the not-python-standard
+        # __getitems__ as an interface to get batches.
+        return self.__getitem__(idxs)
+
+
+class HyraxHFIterableDataSet(HyraxHFDatasetBase, HFIterableDataset):
+    """
+    Iterable style HuggingFace Dataset
+    """
+
+    def __init__(self, config: dict):
+        super().__init__(config)
+        self.batch_size = config["data_loader"]["batch_size"]
+
+    def _become_hf(self, hf_dataset):
+        HFIterableDataset.__init__(
+            self,
+            ex_iterable=hf_dataset._ex_iterable,
+            info=hf_dataset.info,
+            split=hf_dataset.split,
+            formatting=hf_dataset._formatting,
+            shuffling=hf_dataset._shuffling,
+            distributed=hf_dataset._distributed,
+            token_per_repo_id=hf_dataset._token_per_repo_id,
+        )
+
+    def _create_dataset(self, dataset_name, **kwargs):
+        from datasets import load_dataset
+
+        hf_dataset = load_dataset(dataset_name, split="train")
+        return hf_dataset.to_iterable_dataset()
+
+    # TODO: the major issue with this code is that iterating is non-performant
+    # Below are two implementations of __iter__(), Each of them take about a second
+    # to evaluate the superclass iterator we depend on for data
+    #
+    #  The performance in a notebook is ~5ms for the same iterator, and
+    #  I suspect something about the interaction between this code and the torch
+    #  dataloader may be to blame; however, there is no root cause at time of writing.
+
+    # non-batch implementation
+    # def __iter__(self) -> Generator[Tensor]:
+    #     import time
+    #     iterator = super().__iter__()
+    #     start_time_ns = time.monotonic_ns()
+    #     for item in iterator:
+    #         time_ms = (time.monotonic_ns() - start_time_ns)/1_000_000
+    #         print(f"Iterator took {time_ms} ms")
+    #         tensor = self._lookup_tensor(item)
+    #         time_ms = (time.monotonic_ns() - start_time_ns)/1_000_000
+    #         print(f"Lookup took {time_ms} ms")
+    #         yield tensor
+    #         print("Begin clock")
+    #         start_time_ns = time.monotonic_ns()
+
+    # batch implementation
+    def __iter__(self):
+        for batch in super().iter(batch_size=self.batch_size):
+            batch = batch[self.dataset_dict_keys[0]]
+            tensor_batch = [self._lookup_tensor(item, self.dataset_dict_keys[1:]) for item in batch]
+            print(type(tensor_batch[0]))
+            print(tensor_batch[0].shape)
+            for tensor in tensor_batch:
+                yield tensor

--- a/src/hyrax/data_sets/hyrax_cifar_data_set.py
+++ b/src/hyrax/data_sets/hyrax_cifar_data_set.py
@@ -4,6 +4,7 @@ import logging
 import numpy as np
 import torchvision.transforms as transforms
 from astropy.table import Table
+from torch.utils.data import IterableDataset
 from torchvision.datasets import CIFAR10
 
 from hyrax.config_utils import ConfigDict
@@ -14,8 +15,8 @@ logger = logging.getLogger(__name__)
 
 
 class HyraxCifarDataSet(HyraxDataset, CIFAR10):
-    """This is simply a version of CIFAR10 that has our needed shape method, and is initialized using
-    Hyrax config with a transformation that works well for example code.
+    """This is simply a version of CIFAR10 that is initialized using Hyrax config with a transformation
+    that works well for example code.
 
     We only use the training split in the data, because it is larger (50k images). Hyrax will then divide that
     into Train/test/Validate according to configuration.
@@ -30,3 +31,28 @@ class HyraxCifarDataSet(HyraxDataset, CIFAR10):
         )
         metadata_table = Table({"label": np.array([self[index][1] for index in range(len(self))])})
         super().__init__(config, metadata_table)
+
+
+class HyraxCifarIterableDataSet(HyraxDataset, IterableDataset):
+    """This is simply a version of CIFAR10 that is initialized using Hyrax config with a transformation
+    that works well for example code. This version only supports iteration, and not map-style access
+
+    We only use the training split in the data, because it is larger (50k images). Hyrax will then divide that
+    into Train/test/Validate according to configuration.
+    """
+
+    def __init__(self, config: ConfigDict):
+        transform = transforms.Compose(
+            [transforms.ToTensor(), transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5))]
+        )
+        self.cifar = CIFAR10(
+            root=config["general"]["data_dir"], train=True, download=True, transform=transform
+        )
+        metadata_table = Table(
+            {"label": np.array([self.cifar[index][1] for index in range(len(self.cifar))])}
+        )
+        super().__init__(config, metadata_table)
+
+    def __iter__(self):
+        for item in self.cifar:
+            yield item

--- a/src/hyrax/hyrax_default_config.toml
+++ b/src/hyrax/hyrax_default_config.toml
@@ -195,6 +195,17 @@ use_cache = true
 # Warning: Only suitable for situations where the entire dataset fits in system memory
 preload_cache = true
 
+["data_set.HuggingFace"]
+# Which dataset to use
+dataset = false
+
+# Sequence of keys in nested dict to use as tensor model input
+dict_keys = false
+
+# Limit on size of data used
+max_size = false
+
+
 [data_loader]
 # The number of data points to load at once.
 batch_size = 512


### PR DESCRIPTION
This is a prototype that allows the use of Huggingface data sets including multimodal universe within hyrax.

Essentially you just have to config it like
```
[data_set]
name=HyraxHFMapDataset # or HyraxHFIterableDataset

["data_set.HuggingFace"]
# Which dataset to use
dataset = "MultiModalUniverse/hsc"

# Sequence of keys in nested dict to use as tensor model input
dict_keys = ["image","flux"] # this will get item["image"]["flux"] as the output tensor

# Limit on size of data used
max_size = 100               # A good idea if you like your runs to finish
```

The iterative implementation is very slow and heavily instrumented, and may need to be removed. See comments in the code for the state of the perf investigation. Streaming is not supported, but could be added easily

I'm not sure if we should merge this, but putting it out for consideration.

I think there's a case for creating this sort of support *after* we set up dataset <-> model communication to be more flexible than just a tensor.