### PR TITLE
Allow user paths (unix ~) in config values

### DIFF
--- a/docs/pre_executed/mpr_demo.ipynb
+++ b/docs/pre_executed/mpr_demo.ipynb
@@ -1016,7 +1016,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {

--- a/docs/pre_executed/mpr_demo_plotting.py
+++ b/docs/pre_executed/mpr_demo_plotting.py
@@ -71,7 +71,7 @@ def sort_objects_by_median_distance(all_embeddings, median_dist_all_nn, data_dir
     Return a tuple for easy plotting: (object id, rounded median distance, file name)."""
 
     # Use the indexes to gather metadata: object ID, rounded median distance, and file name
-    data_directory = Path(data_directory).resolve()
+    data_directory = Path(data_directory).expanduser().resolve()
     objects = []
     for indx in np.argsort(median_dist_all_nn):
         object_id = all_embeddings["ids"][indx]

--- a/src/hyrax/config_utils.py
+++ b/src/hyrax/config_utils.py
@@ -398,7 +398,7 @@ class ConfigManager:
             # On the non-break end of the loop we do path resolution, preserving falsy values
             # as false.
             else:
-                new_val = str(Path(current_val).resolve()) if current_val else False
+                new_val = str(Path(current_val).expanduser().resolve()) if current_val else False
                 current_dict[current_key] = new_val
 
     @staticmethod
@@ -456,7 +456,7 @@ def create_results_dir(config: ConfigDict, postfix: str) -> Path:
     Path
         The path created by this function
     """
-    results_root = Path(config["general"]["results_dir"]).resolve()
+    results_root = Path(config["general"]["results_dir"]).expanduser().resolve()
     # This date format is chosen specifically to create a lexical search order
     # which matches the date order.
     timestamp = datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
@@ -478,7 +478,7 @@ def find_most_recent_results_dir(config: ConfigDict, verb: str) -> Optional[Path
     This function may return None indicating it could not find a directory matching
     the query verb
     """
-    results_root = Path(config["general"]["results_dir"]).resolve()
+    results_root = Path(config["general"]["results_dir"]).expanduser().resolve()
 
     max_timestamp = 0
     best_path = None

--- a/src/hyrax/data_sets/hsc_data_set.py
+++ b/src/hyrax/data_sets/hsc_data_set.py
@@ -550,7 +550,7 @@ class HSCDataSet(HyraxDataset, Dataset):
 
         logger.info("Reading in catalog file... ")
         location_table = Downloader.filterfits(
-            Path(config["download"]["fits_file"]).resolve(), ["object_id", "ra", "dec"]
+            Path(config["download"]["fits_file"]).expanduser().resolve(), ["object_id", "ra", "dec"]
         )
 
         obj_to_ra = {

--- a/src/hyrax/download.py
+++ b/src/hyrax/download.py
@@ -35,7 +35,7 @@ class Downloader:
 
     def __init__(self, config):
         self.config = config
-        self.cutout_path = Path(config["general"]["data_dir"]).resolve()
+        self.cutout_path = Path(config["general"]["data_dir"]).expanduser().resolve()
         self.manifest_file = self.cutout_path / Downloader.MANIFEST_FILE_NAME
 
     def run(self):
@@ -80,7 +80,7 @@ class Downloader:
             msg += " https://hsc-release.mtk.nao.ac.jp/datasearch/new_user/new "
             raise RuntimeError(msg)
 
-        fits_file = Path(self.config["download"]["fits_file"]).resolve()
+        fits_file = Path(self.config["download"]["fits_file"]).expanduser().resolve()
         logger.info(f"Reading in fits catalog: {fits_file}")
         # Filter the fits file for the fields we want
         column_names = ["object_id"] + Downloader.VARIABLE_FIELDS

--- a/src/hyrax/pytorch_ignite.py
+++ b/src/hyrax/pytorch_ignite.py
@@ -456,7 +456,7 @@ def create_trainer(
         prev_checkpoint = torch.load(config["train"]["resume"], map_location=device)
         Checkpoint.load_objects(to_load=to_save, checkpoint=prev_checkpoint)
 
-    # results_root_dir = Path(config["general"]["results_dir"]).resolve()
+    # results_root_dir = Path(config["general"]["results_dir"]).expanduser().resolve()
     # mlflow_logger = MLflowLogger("file://" + str(results_root_dir / "mlflow"))
 
     @trainer.on(Events.STARTED)

--- a/src/hyrax/train.py
+++ b/src/hyrax/train.py
@@ -52,7 +52,7 @@ def run(config):
 
     monitor = GpuMonitor(tensorboard_logger=tensorboardx_logger)
 
-    results_root_dir = Path(config["general"]["results_dir"]).resolve()
+    results_root_dir = Path(config["general"]["results_dir"]).expanduser().resolve()
     mlflow.set_tracking_uri("file://" + str(results_root_dir / "mlflow"))
 
     # Get experiment_name and cast to string (it's a tomlkit.string by default)


### PR DESCRIPTION
Fixes #271 

Basic issue is that in pathlib `.resolve()` and `.absolute()` don't expand `~` but `.expanduser()` does without doing any additional path changes. 

Everywhere where we have written `.resolve()` in library code has been changed to `.expanduser().resolve()` which produces correct behavior on valid user paths.
