### PR TITLE
Fix for upstream API change to chromadb

### DIFF
--- a/src/hyrax/vector_dbs/chromadb_impl.py
+++ b/src/hyrax/vector_dbs/chromadb_impl.py
@@ -3,7 +3,6 @@ from typing import Union
 
 import chromadb
 import numpy as np
-from chromadb.api.types import IncludeEnum
 
 from hyrax.vector_dbs.vector_db_interface import VectorDB
 
@@ -56,7 +55,7 @@ def _query_for_id(results_dir: str, shard_name: str, id: str):
     """
     chromadb_client = chromadb.PersistentClient(path=str(results_dir))
     collection = chromadb_client.get_collection(name=shard_name)
-    return collection.get(id, include=[IncludeEnum.embeddings])
+    return collection.get(id, include=["embeddings"])
 
 
 class ChromaDB(VectorDB):


### PR DESCRIPTION
Fixes #272 which was introduced by an [upstream API change in chromadb](https://github.com/chroma-core/chroma/commit/e36511bc8c8d4802ed1679b890dd19e613da9524#diff-0dabdf3b1a34381fc025f4a2a8b8225d84188dfbf8f102f4e7c3f1c08b5c9af3L315-R328) which removed `IncludeEnum.embeddings` in favor of `Literal['embeddings']` in their type definitions.