### PR TITLE
Adding column config to visualizer

### DIFF
--- a/docs/pre_executed/mpr_demo.ipynb
+++ b/docs/pre_executed/mpr_demo.ipynb
@@ -13,7 +13,16 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/mtauraso/miniforge3/envs/hyrax/lib/python3.10/site-packages/ignite/handlers/checkpoint.py:16: DeprecationWarning: `TorchScript` support for functional optimizers is deprecated and will be removed in a future PyTorch release. Consider using the `torch.compile` optimizer instead.\n",
+      "  from torch.distributed.optim import ZeroRedundancyOptimizer\n"
+     ]
+    }
+   ],
    "source": [
     "import hyrax\n",
     "import pooch\n",
@@ -77,7 +86,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[2025-03-26 13:52:04,828 hyrax:INFO] Runtime Config read from: /home/drew/code/fibad/src/hyrax/hyrax_default_config.toml\n"
+      "[2025-04-18 16:37:13,094 hyrax:INFO] Runtime Config read from: /Users/mtauraso/src/fibad/src/hyrax/hyrax_default_config.toml\n"
      ]
     }
    ],
@@ -145,27 +154,648 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/home/drew/miniconda3/envs/fibad/lib/python3.12/site-packages/ignite/handlers/checkpoint.py:16: DeprecationWarning: `TorchScript` support for functional optimizers is deprecated and will be removed in a future PyTorch release. Consider using the `torch.compile` optimizer instead.\n",
-      "  from torch.distributed.optim import ZeroRedundancyOptimizer\n",
-      "[2025-03-26 13:52:08,690 hyrax.data_sets.hsc_data_set:INFO] Processed 993 objects for pruning\n",
-      "[2025-03-26 13:52:08,691 hyrax.data_sets.hsc_data_set:INFO] Checking file dimensions to determine standard cutout size...\n",
-      "[2025-03-26 13:52:08,694 hyrax.data_sets.hsc_data_set:INFO] HSC Data set loader has 993 objects\n",
-      "[2025-03-26 13:52:08,696 hyrax.data_sets.hsc_data_set:INFO] Preloading HSCDataSet cache...\n",
-      "[2025-03-26 13:52:08,770 hyrax.models.model_registry:INFO] Using criterion: torch.nn.CrossEntropyLoss with default arguments.\n",
-      "2025-03-26 13:52:08,840 ignite.distributed.auto.auto_dataloader INFO: Use data loader kwargs for dataset '<hyrax.data_sets.hsc': \n",
-      "\t{'sampler': <torch.utils.data.sampler.SubsetRandomSampler object at 0x7fa2a012b8f0>, 'batch_size': 32, 'pin_memory': True}\n",
-      "2025-03-26 13:52:08,851 ignite.distributed.auto.auto_dataloader INFO: Use data loader kwargs for dataset '<hyrax.data_sets.hsc': \n",
-      "\t{'sampler': <torch.utils.data.sampler.SubsetRandomSampler object at 0x7fa2a012b950>, 'batch_size': 32, 'pin_memory': True}\n",
-      "/home/drew/miniconda3/envs/fibad/lib/python3.12/site-packages/ignite/handlers/tqdm_logger.py:127: TqdmExperimentalWarning: Using `tqdm.autonotebook.tqdm` in notebook mode. Use `tqdm.tqdm` instead to force console mode (e.g. in jupyter console)\n",
-      "  from tqdm.autonotebook import tqdm\n",
-      "2025/03/26 13:52:10 INFO mlflow.system_metrics.system_metrics_monitor: Started monitoring system metrics.\n",
-      "[2025-03-26 13:52:11,093 hyrax.pytorch_ignite:INFO] Training model on device: cuda\n"
+      "[2025-04-18 16:37:18,063 hyrax.data_sets.hsc_data_set:INFO] Checking file dimensions to determine standard cutout size...\n",
+      "[2025-04-18 16:37:18,066 hyrax.data_sets.fits_image_dataset:INFO] FitsImageDataSet has 993 objects\n",
+      "[2025-04-18 16:37:18,075 hyrax.data_sets.hsc_data_set:INFO] Processed 993 objects for pruning\n",
+      "[2025-04-18 16:37:18,076 hyrax.data_sets.fits_image_dataset:INFO] Preloading FitsImageDataSet cache...\n",
+      "[2025-04-18 16:37:18,097 hyrax.models.model_registry:INFO] Using criterion: torch.nn.CrossEntropyLoss with default arguments.\n",
+      "2025-04-18 16:37:18,115 ignite.distributed.auto.auto_dataloader INFO: Use data loader kwargs for dataset '<hyrax.data_sets.hsc': \n",
+      "\t{'sampler': <hyrax.pytorch_ignite.SubsetSequentialSampler object at 0x1666aee00>, 'batch_size': 32, 'shuffle': False, 'pin_memory': False}\n",
+      "2025-04-18 16:37:18,118 ignite.distributed.auto.auto_dataloader INFO: Use data loader kwargs for dataset '<hyrax.data_sets.hsc': \n",
+      "\t{'sampler': <hyrax.pytorch_ignite.SubsetSequentialSampler object at 0x1666afb80>, 'batch_size': 32, 'shuffle': False, 'pin_memory': False}\n",
+      "/Users/mtauraso/miniforge3/envs/hyrax/lib/python3.10/site-packages/ignite/handlers/tqdm_logger.py:127: TqdmExperimentalWarning: Using `tqdm.autonotebook.tqdm` in notebook mode. Use `tqdm.tqdm` instead to force console mode (e.g. in jupyter console)\n",
+      "  from tqdm.autonotebook import tqdm\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'train': (<torch.utils.data.dataloader.DataLoader object at 0x16666e020>, [131, 613, 731, 646, 4, 920, 347, 616, 359, 49, 18, 937, 510, 539, 139, 24, 851, 382, 324, 963, 899, 293, 778, 417, 924, 650, 619, 866, 446, 505, 541, 747, 958, 575, 902, 547, 898, 370, 519, 310, 471, 789, 197, 115, 732, 507, 55, 183, 258, 90, 956, 172, 430, 166, 401, 860, 658, 728, 448, 840, 729, 768, 982, 917, 330, 890, 779, 396, 476, 153, 488, 588, 167, 843, 486, 798, 916, 208, 579, 882, 631, 376, 171, 93, 644, 465, 640, 105, 199, 499, 643, 551, 515, 305, 657, 754, 745, 369, 933, 634, 562, 668, 782, 825, 590, 853, 805, 481, 674, 531, 762, 299, 148, 7, 688, 398, 38, 452, 314, 381, 497, 427, 113, 912, 679, 70, 485, 328, 973, 689, 609, 671, 797, 741, 221, 767, 276, 533, 457, 864, 637, 500, 555, 715, 431, 295, 473, 64, 513, 981, 662, 969, 984, 584, 243, 460, 255, 520, 641, 378, 683, 765, 390, 820, 372, 989, 716, 811, 743, 245, 753, 89, 114, 695, 812, 914, 603, 425, 257, 455, 591, 196, 835, 615, 918, 677, 22, 706, 786, 92, 810, 307, 412, 288, 99, 218, 934, 10, 304, 0, 358, 136, 104, 149, 182, 605, 439, 854, 157, 213, 355, 77, 249, 983, 190, 296, 3, 726, 459, 626, 976, 826, 300, 274, 472, 150, 669, 23, 402, 879, 846, 656, 365, 834, 98, 144, 227, 107, 407, 684, 67, 327, 137, 72, 909, 385, 29, 202, 857, 341, 164, 518, 35, 286, 428, 36, 17, 558, 896, 755, 53, 730, 462, 599, 742, 872, 819, 749, 230, 960, 867, 16, 97, 814, 126, 194, 311, 804, 335, 850, 816, 298, 343, 703, 60, 292, 203, 537, 483, 594, 580, 878, 192, 760, 318, 532, 554, 395, 932, 406, 714, 241, 974, 253, 5, 287, 573, 709, 290, 795, 52, 121, 908, 818, 926, 885, 238, 400, 821, 240, 802, 266, 681, 102, 186, 39, 399, 884, 133, 736, 498, 456, 151, 334, 458, 895, 392, 845, 85, 169, 769, 530, 941, 187, 803, 582, 572, 59, 758, 967, 188, 88, 246, 475, 101, 722, 265, 635, 278, 433, 645, 583, 667, 985, 901, 309, 655, 163, 970, 461, 317, 526, 875, 712, 801, 223, 824, 602, 841, 28, 326, 180, 342, 574, 117, 58, 642, 435, 110, 859, 815, 316, 178, 19, 639, 761, 490, 50, 491, 319, 8, 527, 509, 678, 205, 833, 12, 138, 721, 734, 852, 877, 432, 454, 373, 281, 991, 262, 776, 832, 589, 959, 665, 746, 638, 65, 248, 349, 553, 128, 529, 966, 629, 200, 71, 447, 947, 118, 849, 611, 892, 817, 346, 225, 873, 284, 283, 73, 362, 512, 31, 780, 502, 717, 675, 659, 336, 790, 988, 54, 146, 474, 315, 87, 664, 793, 231, 944, 979, 450, 320, 576, 492, 598, 693, 968, 122, 724, 750, 388, 251, 708, 608, 348, 627, 557, 925, 308, 185, 277, 306, 103, 883, 686, 680, 175, 224, 597, 40, 285, 938, 333, 270, 842, 130, 546, 766, 303, 504, 910, 607, 79, 62, 751, 331, 43, 606, 380, 69, 542, 48, 713, 569, 207, 379, 254, 61, 612, 226, 942, 236, 161, 886, 467, 651, 501, 263, 337, 434, 75, 235, 108, 141, 76, 787, 229, 697, 661, 568, 503, 891, 239, 112, 222, 975, 514, 748, 889, 132, 201, 20, 242, 210, 622, 921, 289, 453, 377, 544, 344, 744, 904, 350, 618, 928, 397, 949, 540, 905, 727, 799, 496, 663, 487, 596, 560, 83, 470, 950, 352, 135, 922, 81, 426, 957, 649, 647, 414, 410, 911, 493, 32, 585, 366, 561, 707, 96, 962, 856, 556, 443, 691, 345, 604, 863, 628, 870, 508, 267, 156, 887, 586, 391, 666, 489, 545, 360, 291, 21, 940, 595, 781, 986, 420, 191, 806, 363, 415, 592, 429, 549, 422, 214, 567, 837, 943, 528, 600, 468, 100, 624, 109, 735, 621, 955, 858, 733, 237, 571, 129, 409, 536, 676, 690, 830, 176, 419, 394, 927, 862, 915, 275, 581, 654, 987, 313, 405, 868, 913, 636, 479, 322, 41, 548, 80, 393, 566, 56, 961, 124, 757, 247, 897, 523, 250, 174, 173, 159, 198, 978, 698, 623, 340, 259, 418, 535, 752, 339, 294, 906, 441, 2, 440, 127, 368, 383, 445, 763, 935, 791, 375, 329, 367, 84, 91, 145, 482, 948, 907, 219, 653, 244, 301, 181, 66, 601, 437, 931, 361, 152, 711, 389, 794, 964, 865, 785, 51, 323, 808, 670, 232, 34, 756, 170, 829, 617, 796, 652, 692, 438, 177, 900, 228, 861, 936, 564, 351, 261, 280, 952, 552, 234, 570, 919, 506, 704, 836, 534, 699, 86, 687, 923, 827, 423, 233, 685, 694, 332, 386, 813, 673, 577, 155, 633]), 'validate': (<torch.utils.data.dataloader.DataLoader object at 0x1666af8b0>, [630, 593, 116, 364, 807, 847, 45, 876, 992, 209, 74, 972, 463, 893, 625, 63, 416, 720, 216, 282, 47, 710, 831, 464, 256, 939, 484, 449, 929, 881, 9, 951, 954, 771, 371, 495, 696, 632, 620, 68, 855, 106, 408, 823, 119, 357, 160, 738, 525, 930, 770, 784, 700, 723, 777, 701, 424, 162, 442, 404, 945, 268, 26, 838, 42, 521, 788, 614, 82, 44, 828, 774, 977, 6, 844, 140, 773, 903, 587, 740, 702, 953, 15, 563, 271, 125, 273, 264, 120, 648, 772, 354, 980, 511, 211, 610, 444, 217, 466, 33, 143, 11, 387, 134, 325, 154, 725, 871, 739, 272, 550, 158, 25, 792, 94, 413, 880, 252, 193, 338, 946, 195, 37, 179, 165, 451, 220, 524, 478, 469, 297, 874, 30, 269, 204, 312, 142, 279, 206, 839, 718, 990, 759, 147, 783, 800, 971, 212, 123, 737, 168, 477, 672, 559, 302, 95, 822, 14, 321, 682, 13, 517, 764, 353, 215, 578, 480, 1, 869, 775, 809, 894, 189, 705, 516, 719, 27, 565, 384, 660, 421, 848, 494, 78, 260, 374, 965, 543, 522, 57, 356, 411, 403, 888, 538, 111, 46, 436, 184])}\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025/04/18 16:37:18 WARNING mlflow.system_metrics.system_metrics_monitor: Skip logging GPU metrics because creating `GPUMonitor` failed with error: Failed to initialize NVML, skip logging GPU metrics: NVML Shared Library Not Found.\n",
+      "2025/04/18 16:37:18 INFO mlflow.system_metrics.system_metrics_monitor: Started monitoring system metrics.\n",
+      "[2025-04-18 16:37:18,776 hyrax.pytorch_ignite:INFO] Training model on device: mps\n",
+      "[2025-04-18 16:37:21,703 hyrax.data_sets.fits_image_dataset:INFO] Processed 992 objects\n"
      ]
     },
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "435847d040c74130b1723bcca4761058",
+       "model_id": "f4f30a72a1864c9d915b058b20dd341f",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  4%|4         | 1/25 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "State:\n",
+      "\titeration: 25\n",
+      "\tepoch: 1\n",
+      "\tepoch_length: 25\n",
+      "\tmax_epochs: 20\n",
+      "\toutput: <class 'dict'>\n",
+      "\tbatch: <class 'torch.Tensor'>\n",
+      "\tmetrics: <class 'dict'>\n",
+      "\tdataloader: <class 'torch.utils.data.dataloader.DataLoader'>\n",
+      "\tseed: <class 'NoneType'>\n",
+      "\ttimes: <class 'dict'>\n",
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "4ab77e29b8324cfcb35f7233d05300bf",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  4%|4         | 1/25 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "State:\n",
+      "\titeration: 50\n",
+      "\tepoch: 2\n",
+      "\tepoch_length: 25\n",
+      "\tmax_epochs: 20\n",
+      "\toutput: <class 'dict'>\n",
+      "\tbatch: <class 'torch.Tensor'>\n",
+      "\tmetrics: <class 'dict'>\n",
+      "\tdataloader: <class 'torch.utils.data.dataloader.DataLoader'>\n",
+      "\tseed: <class 'NoneType'>\n",
+      "\ttimes: <class 'dict'>\n",
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "f4701f00c3c84cc4b8590ff68aad2e9a",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  4%|4         | 1/25 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "State:\n",
+      "\titeration: 75\n",
+      "\tepoch: 3\n",
+      "\tepoch_length: 25\n",
+      "\tmax_epochs: 20\n",
+      "\toutput: <class 'dict'>\n",
+      "\tbatch: <class 'torch.Tensor'>\n",
+      "\tmetrics: <class 'dict'>\n",
+      "\tdataloader: <class 'torch.utils.data.dataloader.DataLoader'>\n",
+      "\tseed: <class 'NoneType'>\n",
+      "\ttimes: <class 'dict'>\n",
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "b4ee91e8b4ce4dc182cf963459632473",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  4%|4         | 1/25 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "State:\n",
+      "\titeration: 100\n",
+      "\tepoch: 4\n",
+      "\tepoch_length: 25\n",
+      "\tmax_epochs: 20\n",
+      "\toutput: <class 'dict'>\n",
+      "\tbatch: <class 'torch.Tensor'>\n",
+      "\tmetrics: <class 'dict'>\n",
+      "\tdataloader: <class 'torch.utils.data.dataloader.DataLoader'>\n",
+      "\tseed: <class 'NoneType'>\n",
+      "\ttimes: <class 'dict'>\n",
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "ea1ae5ac911d46c59ea840d60a7568b2",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  4%|4         | 1/25 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "State:\n",
+      "\titeration: 125\n",
+      "\tepoch: 5\n",
+      "\tepoch_length: 25\n",
+      "\tmax_epochs: 20\n",
+      "\toutput: <class 'dict'>\n",
+      "\tbatch: <class 'torch.Tensor'>\n",
+      "\tmetrics: <class 'dict'>\n",
+      "\tdataloader: <class 'torch.utils.data.dataloader.DataLoader'>\n",
+      "\tseed: <class 'NoneType'>\n",
+      "\ttimes: <class 'dict'>\n",
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "2500c3ba8640485b81959e5b6d21006a",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  4%|4         | 1/25 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "State:\n",
+      "\titeration: 150\n",
+      "\tepoch: 6\n",
+      "\tepoch_length: 25\n",
+      "\tmax_epochs: 20\n",
+      "\toutput: <class 'dict'>\n",
+      "\tbatch: <class 'torch.Tensor'>\n",
+      "\tmetrics: <class 'dict'>\n",
+      "\tdataloader: <class 'torch.utils.data.dataloader.DataLoader'>\n",
+      "\tseed: <class 'NoneType'>\n",
+      "\ttimes: <class 'dict'>\n",
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "b0d00fa3d56043ec8d3b9b8100fd225b",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  4%|4         | 1/25 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "State:\n",
+      "\titeration: 175\n",
+      "\tepoch: 7\n",
+      "\tepoch_length: 25\n",
+      "\tmax_epochs: 20\n",
+      "\toutput: <class 'dict'>\n",
+      "\tbatch: <class 'torch.Tensor'>\n",
+      "\tmetrics: <class 'dict'>\n",
+      "\tdataloader: <class 'torch.utils.data.dataloader.DataLoader'>\n",
+      "\tseed: <class 'NoneType'>\n",
+      "\ttimes: <class 'dict'>\n",
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "d9060d1dcc13401e9fb8e91a4782cda7",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  4%|4         | 1/25 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "State:\n",
+      "\titeration: 200\n",
+      "\tepoch: 8\n",
+      "\tepoch_length: 25\n",
+      "\tmax_epochs: 20\n",
+      "\toutput: <class 'dict'>\n",
+      "\tbatch: <class 'torch.Tensor'>\n",
+      "\tmetrics: <class 'dict'>\n",
+      "\tdataloader: <class 'torch.utils.data.dataloader.DataLoader'>\n",
+      "\tseed: <class 'NoneType'>\n",
+      "\ttimes: <class 'dict'>\n",
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "3044fc853a7e49559891faf3046359ca",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  4%|4         | 1/25 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "State:\n",
+      "\titeration: 225\n",
+      "\tepoch: 9\n",
+      "\tepoch_length: 25\n",
+      "\tmax_epochs: 20\n",
+      "\toutput: <class 'dict'>\n",
+      "\tbatch: <class 'torch.Tensor'>\n",
+      "\tmetrics: <class 'dict'>\n",
+      "\tdataloader: <class 'torch.utils.data.dataloader.DataLoader'>\n",
+      "\tseed: <class 'NoneType'>\n",
+      "\ttimes: <class 'dict'>\n",
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "8ed96dd2f3e545c2a2973a69bb8bc72f",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  4%|4         | 1/25 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "State:\n",
+      "\titeration: 250\n",
+      "\tepoch: 10\n",
+      "\tepoch_length: 25\n",
+      "\tmax_epochs: 20\n",
+      "\toutput: <class 'dict'>\n",
+      "\tbatch: <class 'torch.Tensor'>\n",
+      "\tmetrics: <class 'dict'>\n",
+      "\tdataloader: <class 'torch.utils.data.dataloader.DataLoader'>\n",
+      "\tseed: <class 'NoneType'>\n",
+      "\ttimes: <class 'dict'>\n",
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "7695a7bac3aa45159c2b556fc6550d16",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  4%|4         | 1/25 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "State:\n",
+      "\titeration: 275\n",
+      "\tepoch: 11\n",
+      "\tepoch_length: 25\n",
+      "\tmax_epochs: 20\n",
+      "\toutput: <class 'dict'>\n",
+      "\tbatch: <class 'torch.Tensor'>\n",
+      "\tmetrics: <class 'dict'>\n",
+      "\tdataloader: <class 'torch.utils.data.dataloader.DataLoader'>\n",
+      "\tseed: <class 'NoneType'>\n",
+      "\ttimes: <class 'dict'>\n",
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "a0b8a6c7665446a4abbfdb57ecfcf9c8",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  4%|4         | 1/25 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "State:\n",
+      "\titeration: 300\n",
+      "\tepoch: 12\n",
+      "\tepoch_length: 25\n",
+      "\tmax_epochs: 20\n",
+      "\toutput: <class 'dict'>\n",
+      "\tbatch: <class 'torch.Tensor'>\n",
+      "\tmetrics: <class 'dict'>\n",
+      "\tdataloader: <class 'torch.utils.data.dataloader.DataLoader'>\n",
+      "\tseed: <class 'NoneType'>\n",
+      "\ttimes: <class 'dict'>\n",
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "5ed168525c0c45fcaf1a230d86877b20",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  4%|4         | 1/25 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "State:\n",
+      "\titeration: 325\n",
+      "\tepoch: 13\n",
+      "\tepoch_length: 25\n",
+      "\tmax_epochs: 20\n",
+      "\toutput: <class 'dict'>\n",
+      "\tbatch: <class 'torch.Tensor'>\n",
+      "\tmetrics: <class 'dict'>\n",
+      "\tdataloader: <class 'torch.utils.data.dataloader.DataLoader'>\n",
+      "\tseed: <class 'NoneType'>\n",
+      "\ttimes: <class 'dict'>\n",
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "516446a8f6ae46d4950c9997e713ce24",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  4%|4         | 1/25 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "State:\n",
+      "\titeration: 350\n",
+      "\tepoch: 14\n",
+      "\tepoch_length: 25\n",
+      "\tmax_epochs: 20\n",
+      "\toutput: <class 'dict'>\n",
+      "\tbatch: <class 'torch.Tensor'>\n",
+      "\tmetrics: <class 'dict'>\n",
+      "\tdataloader: <class 'torch.utils.data.dataloader.DataLoader'>\n",
+      "\tseed: <class 'NoneType'>\n",
+      "\ttimes: <class 'dict'>\n",
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "eafe48a10f7f4613b57851e5cf6e4040",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  4%|4         | 1/25 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "State:\n",
+      "\titeration: 375\n",
+      "\tepoch: 15\n",
+      "\tepoch_length: 25\n",
+      "\tmax_epochs: 20\n",
+      "\toutput: <class 'dict'>\n",
+      "\tbatch: <class 'torch.Tensor'>\n",
+      "\tmetrics: <class 'dict'>\n",
+      "\tdataloader: <class 'torch.utils.data.dataloader.DataLoader'>\n",
+      "\tseed: <class 'NoneType'>\n",
+      "\ttimes: <class 'dict'>\n",
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "4ef974363f634d03bfb65b10ce402788",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  4%|4         | 1/25 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "State:\n",
+      "\titeration: 400\n",
+      "\tepoch: 16\n",
+      "\tepoch_length: 25\n",
+      "\tmax_epochs: 20\n",
+      "\toutput: <class 'dict'>\n",
+      "\tbatch: <class 'torch.Tensor'>\n",
+      "\tmetrics: <class 'dict'>\n",
+      "\tdataloader: <class 'torch.utils.data.dataloader.DataLoader'>\n",
+      "\tseed: <class 'NoneType'>\n",
+      "\ttimes: <class 'dict'>\n",
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "64cc55226f094b3e8628edec34d37a6c",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  4%|4         | 1/25 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "State:\n",
+      "\titeration: 425\n",
+      "\tepoch: 17\n",
+      "\tepoch_length: 25\n",
+      "\tmax_epochs: 20\n",
+      "\toutput: <class 'dict'>\n",
+      "\tbatch: <class 'torch.Tensor'>\n",
+      "\tmetrics: <class 'dict'>\n",
+      "\tdataloader: <class 'torch.utils.data.dataloader.DataLoader'>\n",
+      "\tseed: <class 'NoneType'>\n",
+      "\ttimes: <class 'dict'>\n",
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "8e9a974624b64a9daa277fcfc40d01b8",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  4%|4         | 1/25 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "State:\n",
+      "\titeration: 450\n",
+      "\tepoch: 18\n",
+      "\tepoch_length: 25\n",
+      "\tmax_epochs: 20\n",
+      "\toutput: <class 'dict'>\n",
+      "\tbatch: <class 'torch.Tensor'>\n",
+      "\tmetrics: <class 'dict'>\n",
+      "\tdataloader: <class 'torch.utils.data.dataloader.DataLoader'>\n",
+      "\tseed: <class 'NoneType'>\n",
+      "\ttimes: <class 'dict'>\n",
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "3d4d506fd83c442094efbbe0cde4d06f",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  4%|4         | 1/25 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "State:\n",
+      "\titeration: 475\n",
+      "\tepoch: 19\n",
+      "\tepoch_length: 25\n",
+      "\tmax_epochs: 20\n",
+      "\toutput: <class 'dict'>\n",
+      "\tbatch: <class 'torch.Tensor'>\n",
+      "\tmetrics: <class 'dict'>\n",
+      "\tdataloader: <class 'torch.utils.data.dataloader.DataLoader'>\n",
+      "\tseed: <class 'NoneType'>\n",
+      "\ttimes: <class 'dict'>\n",
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "af1fabf05e8845829bfa1c4a99b084bf",
        "version_major": 2,
        "version_minor": 0
       },
@@ -180,286 +810,37 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[2025-03-26 13:52:22,474 hyrax.data_sets.hsc_data_set:INFO] Processed 992 objects\n"
+      "[2025-04-18 16:37:35,531 hyrax.pytorch_ignite:INFO] Total training time: 16.75[s]\n",
+      "[2025-04-18 16:37:35,531 hyrax.pytorch_ignite:INFO] Latest checkpoint saved as: /Users/mtauraso/src/fibad/docs/pre_executed/results/20250418-163718-train-_hkr/checkpoint_epoch_20.pt\n",
+      "[2025-04-18 16:37:35,531 hyrax.pytorch_ignite:INFO] Best metric checkpoint saved as: /Users/mtauraso/src/fibad/docs/pre_executed/results/20250418-163718-train-_hkr/checkpoint_20_loss=-174.2037.pt\n",
+      "2025/04/18 16:37:35 INFO mlflow.system_metrics.system_metrics_monitor: Stopping system metrics monitoring...\n",
+      "2025/04/18 16:37:35 INFO mlflow.system_metrics.system_metrics_monitor: Successfully terminated system metrics monitoring!\n"
      ]
     },
     {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "4db55cf01f9f4bf2b6aebd057372562f",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "  4%|4         | 1/25 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "5f7fd52ad4154d70860ae95204bc77e2",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "  4%|4         | 1/25 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "78693f67311b4bc1924f53f63227c677",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "  4%|4         | 1/25 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "832a8cf9a7904a3884e267b11afb5fc0",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "  4%|4         | 1/25 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f0e8162d76d943829999eb866904cf55",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "  4%|4         | 1/25 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "bd37f2989a0d4697a0f441af4d01763e",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "  4%|4         | 1/25 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "880a5bb45432485f8cc224a9e7ba3ccb",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "  4%|4         | 1/25 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "720fb0c09a8c45edbfa1b49cb88501aa",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "  4%|4         | 1/25 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c074888fc4c14e2da317c78edb7db010",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "  4%|4         | 1/25 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "62807ca147c047839903dde6e86a5078",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "  4%|4         | 1/25 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "04bac7b0eba048dba66b55f7524dca3b",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "  4%|4         | 1/25 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "6a3274a0c54043b09882abc93d511456",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "  4%|4         | 1/25 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "ca277e028bee4a23a478867d4694e632",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "  4%|4         | 1/25 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "49775b3580664998b23114183aa3b087",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "  4%|4         | 1/25 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "04d108e853a2476da2fd7722d2f4c948",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "  4%|4         | 1/25 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "6d70c111a7e0457094031b7896437273",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "  4%|4         | 1/25 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "04c35fb2286b47f6b1713237539dd5f7",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "  4%|4         | 1/25 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "96857bde669a4c839cb8d31a10b4db4d",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "  4%|4         | 1/25 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "b61c06d5082d435c822fa8491e33fcef",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "  4%|4         | 1/25 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "State:\n",
+      "\titeration: 500\n",
+      "\tepoch: 20\n",
+      "\tepoch_length: 25\n",
+      "\tmax_epochs: 20\n",
+      "\toutput: <class 'dict'>\n",
+      "\tbatch: <class 'torch.Tensor'>\n",
+      "\tmetrics: <class 'dict'>\n",
+      "\tdataloader: <class 'torch.utils.data.dataloader.DataLoader'>\n",
+      "\tseed: <class 'NoneType'>\n",
+      "\ttimes: <class 'dict'>\n",
+      "\n"
+     ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[2025-03-26 13:52:39,386 hyrax.pytorch_ignite:INFO] Total training time: 28.29[s]\n",
-      "[2025-03-26 13:52:39,387 hyrax.pytorch_ignite:INFO] Latest checkpoint saved as: /home/drew/code/fibad/docs/pre_executed/results/20250326-135208-train-WDiF/checkpoint_epoch_20.pt\n",
-      "[2025-03-26 13:52:39,388 hyrax.pytorch_ignite:INFO] Best metric checkpoint saved as: /home/drew/code/fibad/docs/pre_executed/results/20250326-135208-train-WDiF/checkpoint_17_loss=-155.8799.pt\n",
-      "2025/03/26 13:52:39 INFO mlflow.system_metrics.system_metrics_monitor: Stopping system metrics monitoring...\n",
-      "2025/03/26 13:52:39 INFO mlflow.system_metrics.system_metrics_monitor: Successfully terminated system metrics monitoring!\n",
-      "[2025-03-26 13:52:39,407 hyrax.train:INFO] Finished Training\n",
-      "[2025-03-26 13:52:39,581 hyrax.model_exporters:INFO] Exported model to ONNX format: /home/drew/code/fibad/docs/pre_executed/results/20250326-135208-train-WDiF/example_model_opset_20.onnx\n"
+      "[2025-04-18 16:37:35,575 hyrax.train:INFO] Finished Training\n",
+      "[2025-04-18 16:37:35,762 hyrax.model_exporters:INFO] Exported model to ONNX format: /Users/mtauraso/src/fibad/docs/pre_executed/results/20250418-163718-train-_hkr/example_model_opset_20.onnx\n"
      ]
     }
    ],
@@ -1083,28 +1464,64 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[2025-03-26 13:53:07,443 hyrax.data_sets.hsc_data_set:INFO] Processed 993 objects for pruning\n",
-      "[2025-03-26 13:53:07,444 hyrax.data_sets.hsc_data_set:INFO] Checking file dimensions to determine standard cutout size...\n",
-      "[2025-03-26 13:53:07,448 hyrax.data_sets.hsc_data_set:INFO] HSC Data set loader has 993 objects\n",
-      "[2025-03-26 13:53:07,450 hyrax.data_sets.hsc_data_set:INFO] Preloading HSCDataSet cache...\n",
-      "[2025-03-26 13:53:07,483 hyrax.models.model_registry:INFO] Using criterion: torch.nn.MSELoss with arguments: {'reduction': 'none'}.\n",
-      "[2025-03-26 13:53:07,505 hyrax.models.model_registry:INFO] Using optimizer: torch.optim.Adam with arguments: {'lr': 0.001}.\n",
-      "[2025-03-26 13:53:07,519 hyrax.infer:INFO] data set has length 993\n",
-      "2025-03-26 13:53:07,539 ignite.distributed.auto.auto_dataloader INFO: Use data loader kwargs for dataset '<hyrax.data_sets.hsc': \n",
-      "\t{'sampler': None, 'batch_size': 512, 'pin_memory': True}\n",
-      "[2025-03-26 13:53:10,346 hyrax.pytorch_ignite:INFO] Evaluating model on device: cuda\n",
-      "[2025-03-26 13:53:10,350 hyrax.pytorch_ignite:INFO] Total epochs: 1\n",
-      "[2025-03-26 13:53:22,777 hyrax.data_sets.hsc_data_set:INFO] Processed 992 objects\n",
-      "[2025-03-26 13:53:24,475 hyrax.pytorch_ignite:INFO] Total evaluation time: 14.13[s]\n",
-      "[2025-03-26 13:53:24,579 hyrax.infer:INFO] Inference results saved in: /home/drew/code/fibad/docs/pre_executed/results/20250326-135307-infer-IUup\n"
+      "[2025-04-18 16:37:46,721 hyrax.data_sets.hsc_data_set:INFO] Checking file dimensions to determine standard cutout size...\n",
+      "[2025-04-18 16:37:46,723 hyrax.data_sets.fits_image_dataset:INFO] FitsImageDataSet has 993 objects\n",
+      "[2025-04-18 16:37:46,734 hyrax.data_sets.hsc_data_set:INFO] Processed 993 objects for pruning\n",
+      "[2025-04-18 16:37:46,734 hyrax.data_sets.fits_image_dataset:INFO] Preloading FitsImageDataSet cache...\n",
+      "[2025-04-18 16:37:46,743 hyrax.models.model_registry:INFO] Using criterion: torch.nn.CrossEntropyLoss with default arguments.\n",
+      "[2025-04-18 16:37:46,746 hyrax.verbs.infer:INFO] data set has length 993\n",
+      "2025-04-18 16:37:46,753 ignite.distributed.auto.auto_dataloader INFO: Use data loader kwargs for dataset '<hyrax.data_sets.hsc': \n",
+      "\t{'sampler': None, 'batch_size': 512, 'shuffle': False, 'pin_memory': False}\n",
+      "[2025-04-18 16:37:46,832 hyrax.verbs.infer:INFO] Saving inference results at: /Users/mtauraso/src/fibad/docs/pre_executed/results/20250418-163746-infer-ynj3\n",
+      "[2025-04-18 16:37:47,160 hyrax.pytorch_ignite:INFO] Evaluating model on device: mps\n",
+      "[2025-04-18 16:37:47,165 hyrax.pytorch_ignite:INFO] Total epochs: 1\n"
      ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "ddf1aeadfbdb48eaa2667e87a3c6f59f",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       " 50%|#####     | 1/2 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[2025-04-18 16:37:50,578 hyrax.data_sets.fits_image_dataset:INFO] Processed 992 objects\n",
+      "[2025-04-18 16:37:50,777 hyrax.pytorch_ignite:INFO] Total evaluation time: 3.62[s]\n",
+      "[2025-04-18 16:37:50,818 hyrax.verbs.infer:INFO] Inference Complete.\n",
+      "[2025-04-18 16:37:50,952 hyrax.config_utils:WARNING] Cannot find default_config.toml for torch.\n",
+      "[2025-04-18 16:37:50,952 hyrax.config_utils:WARNING] Cannot find default_config.toml for torch.\n",
+      "[2025-04-18 16:37:52,955 hyrax.config_utils:WARNING] Cannot find default_config.toml for umap.\n",
+      "[2025-04-18 16:37:52,974 hyrax.data_sets.hsc_data_set:INFO] Checking file dimensions to determine standard cutout size...\n",
+      "[2025-04-18 16:37:52,976 hyrax.data_sets.fits_image_dataset:INFO] FitsImageDataSet has 993 objects\n",
+      "[2025-04-18 16:37:52,985 hyrax.data_sets.hsc_data_set:INFO] Processed 993 objects for pruning\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<hyrax.data_sets.inference_dataset.InferenceDataSet at 0x169c15660>"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -1286,55 +1703,59 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[2025-03-26 14:02:16,411 hyrax.data_sets.inference_dataset:INFO] Using most recent results dir /home/drew/code/fibad/docs/pre_executed/results/20250326-135307-infer-IUup for lookup. Use the [results] inference_dir config to set a directory or pass it to this verb.\n",
-      "[2025-03-26 14:02:16,457 hyrax.config_utils:WARNING] Cannot find default_config.toml for torch.\n",
-      "[2025-03-26 14:02:16,458 hyrax.config_utils:WARNING] Cannot find default_config.toml for torch.\n",
-      "[2025-03-26 14:02:16,459 hyrax.config_utils:WARNING] Cannot find default_config.toml for umap.\n",
-      "[2025-03-26 14:04:02,804 hyrax.data_sets.hsc_data_set:INFO] Processed 993 objects for pruning\n",
-      "[2025-03-26 14:04:02,806 hyrax.data_sets.hsc_data_set:INFO] Checking file dimensions to determine standard cutout size...\n",
-      "[2025-03-26 14:04:02,810 hyrax.data_sets.hsc_data_set:INFO] HSC Data set loader has 993 objects\n",
-      "[2025-03-26 14:04:02,812 hyrax.data_sets.hsc_data_set:INFO] Preloading HSCDataSet cache...\n",
-      "[2025-03-26 14:04:02,815 hyrax.verbs.umap:INFO] Saving UMAP results to /home/drew/code/fibad/docs/pre_executed/results/20250326-140402-umap-02yK\n"
+      "[2025-04-18 16:38:02,075 hyrax.data_sets.inference_dataset:INFO] Using most recent results dir /Users/mtauraso/src/fibad/docs/pre_executed/results/20250418-163746-infer-ynj3 for lookup. Use the [results] inference_dir config to set a directory or pass it to this verb.\n",
+      "[2025-04-18 16:38:02,107 hyrax.config_utils:WARNING] Cannot find default_config.toml for torch.\n",
+      "[2025-04-18 16:38:02,108 hyrax.config_utils:WARNING] Cannot find default_config.toml for torch.\n",
+      "[2025-04-18 16:38:02,108 hyrax.config_utils:WARNING] Cannot find default_config.toml for umap.\n",
+      "[2025-04-18 16:38:02,130 hyrax.data_sets.hsc_data_set:INFO] Checking file dimensions to determine standard cutout size...\n",
+      "[2025-04-18 16:38:02,132 hyrax.data_sets.fits_image_dataset:INFO] FitsImageDataSet has 993 objects\n",
+      "[2025-04-18 16:38:02,141 hyrax.data_sets.hsc_data_set:INFO] Processed 993 objects for pruning\n",
+      "[2025-04-18 16:38:02,142 hyrax.verbs.umap:INFO] Saving UMAP results to /Users/mtauraso/src/fibad/docs/pre_executed/results/20250418-163802-umap-BMkM\n",
+      "OMP: Info #276: omp_set_nested routine deprecated, please use omp_set_max_active_levels instead.\n"
      ]
     },
     {
-     "ename": "AssertionError",
-     "evalue": "<code object _pairwise_callable at 0x558731dd8150, file \"/home/drew/miniconda3/envs/fibad/lib/python3.12/site-packages/sklearn/metrics/pairwise.py\", line 1991> != <code object euclidean at 0x7fa3a7131290, file \"/home/drew/miniconda3/envs/fibad/lib/python3.12/site-packages/umap/distances.py\", line 22>",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mKeyError\u001b[0m                                  Traceback (most recent call last)",
-      "File \u001b[0;32m_pydevd_sys_monitoring\\\\_pydevd_sys_monitoring_cython.pyx:592\u001b[0m, in \u001b[0;36m_pydevd_sys_monitoring_cython._get_func_code_info\u001b[0;34m()\u001b[0m\n",
-      "\u001b[0;31mKeyError\u001b[0m: (22, '/home/drew/miniconda3/envs/fibad/lib/python3.12/site-packages/umap/distances.py', <code object euclidean at 0x7fa3a7131290, file \"/home/drew/miniconda3/envs/fibad/lib/python3.12/site-packages/umap/distances.py\", line 22>)",
-      "\nDuring handling of the above exception, another exception occurred:\n",
-      "\u001b[0;31mAssertionError\u001b[0m                            Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[23], line 2\u001b[0m\n\u001b[1;32m      1\u001b[0m h\u001b[38;5;241m.\u001b[39mconfig[\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mgeneral\u001b[39m\u001b[38;5;124m'\u001b[39m][\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mdev_mode\u001b[39m\u001b[38;5;124m'\u001b[39m] \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;01mTrue\u001b[39;00m\n\u001b[0;32m----> 2\u001b[0m \u001b[43mh\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mumap\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m      3\u001b[0m plot_umap(find_most_recent_results_dir(h\u001b[38;5;241m.\u001b[39mconfig, \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mumap\u001b[39m\u001b[38;5;124m\"\u001b[39m))\n",
-      "File \u001b[0;32m~/code/fibad/src/hyrax/verbs/umap.py:67\u001b[0m, in \u001b[0;36mUmap.run\u001b[0;34m(self, input_dir)\u001b[0m\n\u001b[1;32m     65\u001b[0m \u001b[38;5;28;01mwith\u001b[39;00m warnings\u001b[38;5;241m.\u001b[39mcatch_warnings():\n\u001b[1;32m     66\u001b[0m     warnings\u001b[38;5;241m.\u001b[39msimplefilter(action\u001b[38;5;241m=\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mignore\u001b[39m\u001b[38;5;124m\"\u001b[39m, category\u001b[38;5;241m=\u001b[39m\u001b[38;5;167;01mFutureWarning\u001b[39;00m)\n\u001b[0;32m---> 67\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_run\u001b[49m\u001b[43m(\u001b[49m\u001b[43minput_dir\u001b[49m\u001b[43m)\u001b[49m\n",
-      "File \u001b[0;32m~/code/fibad/src/hyrax/verbs/umap.py:100\u001b[0m, in \u001b[0;36mUmap._run\u001b[0;34m(self, input_dir)\u001b[0m\n\u001b[1;32m     97\u001b[0m data_sample \u001b[38;5;241m=\u001b[39m inference_results[index_choices]\u001b[38;5;241m.\u001b[39mnumpy()\u001b[38;5;241m.\u001b[39mreshape((sample_size, \u001b[38;5;241m-\u001b[39m\u001b[38;5;241m1\u001b[39m))\n\u001b[1;32m     99\u001b[0m \u001b[38;5;66;03m# Fit a single reducer on the sampled data\u001b[39;00m\n\u001b[0;32m--> 100\u001b[0m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mreducer\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mfit\u001b[49m\u001b[43m(\u001b[49m\u001b[43mdata_sample\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    102\u001b[0m \u001b[38;5;66;03m# Save the reducer to our results directory\u001b[39;00m\n\u001b[1;32m    103\u001b[0m \u001b[38;5;28;01mwith\u001b[39;00m \u001b[38;5;28mopen\u001b[39m(results_dir \u001b[38;5;241m/\u001b[39m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mumap.pickle\u001b[39m\u001b[38;5;124m\"\u001b[39m, \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mwb\u001b[39m\u001b[38;5;124m\"\u001b[39m) \u001b[38;5;28;01mas\u001b[39;00m f:\n",
-      "File \u001b[0;32m~/miniconda3/envs/fibad/lib/python3.12/site-packages/umap/umap_.py:2555\u001b[0m, in \u001b[0;36mUMAP.fit\u001b[0;34m(self, X, y, force_all_finite, **kwargs)\u001b[0m\n\u001b[1;32m   2552\u001b[0m \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[1;32m   2553\u001b[0m     \u001b[38;5;66;03m# sklearn pairwise_distances fails for callable metric on sparse data\u001b[39;00m\n\u001b[1;32m   2554\u001b[0m     _m \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mmetric \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_sparse_data \u001b[38;5;28;01melse\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_input_distance_func\n\u001b[0;32m-> 2555\u001b[0m     dmat \u001b[38;5;241m=\u001b[39m \u001b[43mpairwise_distances\u001b[49m\u001b[43m(\u001b[49m\u001b[43mX\u001b[49m\u001b[43m[\u001b[49m\u001b[43mindex\u001b[49m\u001b[43m]\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mmetric\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43m_m\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_metric_kwds\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m   2556\u001b[0m \u001b[38;5;28;01mexcept\u001b[39;00m (\u001b[38;5;167;01mValueError\u001b[39;00m, \u001b[38;5;167;01mTypeError\u001b[39;00m) \u001b[38;5;28;01mas\u001b[39;00m e:\n\u001b[1;32m   2557\u001b[0m     \u001b[38;5;66;03m# metric is numba.jit'd or not supported by sklearn,\u001b[39;00m\n\u001b[1;32m   2558\u001b[0m     \u001b[38;5;66;03m# fallback to pairwise special\u001b[39;00m\n\u001b[1;32m   2560\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_sparse_data:\n\u001b[1;32m   2561\u001b[0m         \u001b[38;5;66;03m# Get a fresh metric since we are casting to dense\u001b[39;00m\n",
-      "File \u001b[0;32m~/miniconda3/envs/fibad/lib/python3.12/site-packages/sklearn/utils/_param_validation.py:216\u001b[0m, in \u001b[0;36mvalidate_params.<locals>.decorator.<locals>.wrapper\u001b[0;34m(*args, **kwargs)\u001b[0m\n\u001b[1;32m    210\u001b[0m \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[1;32m    211\u001b[0m     \u001b[38;5;28;01mwith\u001b[39;00m config_context(\n\u001b[1;32m    212\u001b[0m         skip_parameter_validation\u001b[38;5;241m=\u001b[39m(\n\u001b[1;32m    213\u001b[0m             prefer_skip_nested_validation \u001b[38;5;129;01mor\u001b[39;00m global_skip_validation\n\u001b[1;32m    214\u001b[0m         )\n\u001b[1;32m    215\u001b[0m     ):\n\u001b[0;32m--> 216\u001b[0m         \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mfunc\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43margs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    217\u001b[0m \u001b[38;5;28;01mexcept\u001b[39;00m InvalidParameterError \u001b[38;5;28;01mas\u001b[39;00m e:\n\u001b[1;32m    218\u001b[0m     \u001b[38;5;66;03m# When the function is just a wrapper around an estimator, we allow\u001b[39;00m\n\u001b[1;32m    219\u001b[0m     \u001b[38;5;66;03m# the function to delegate validation to the estimator, but we replace\u001b[39;00m\n\u001b[1;32m    220\u001b[0m     \u001b[38;5;66;03m# the name of the estimator by the name of the function in the error\u001b[39;00m\n\u001b[1;32m    221\u001b[0m     \u001b[38;5;66;03m# message to avoid confusion.\u001b[39;00m\n\u001b[1;32m    222\u001b[0m     msg \u001b[38;5;241m=\u001b[39m re\u001b[38;5;241m.\u001b[39msub(\n\u001b[1;32m    223\u001b[0m         \u001b[38;5;124mr\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mparameter of \u001b[39m\u001b[38;5;124m\\\u001b[39m\u001b[38;5;124mw+ must be\u001b[39m\u001b[38;5;124m\"\u001b[39m,\n\u001b[1;32m    224\u001b[0m         \u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mparameter of \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mfunc\u001b[38;5;241m.\u001b[39m\u001b[38;5;18m__qualname__\u001b[39m\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m must be\u001b[39m\u001b[38;5;124m\"\u001b[39m,\n\u001b[1;32m    225\u001b[0m         \u001b[38;5;28mstr\u001b[39m(e),\n\u001b[1;32m    226\u001b[0m     )\n",
-      "File \u001b[0;32m~/miniconda3/envs/fibad/lib/python3.12/site-packages/sklearn/metrics/pairwise.py:2480\u001b[0m, in \u001b[0;36mpairwise_distances\u001b[0;34m(X, Y, metric, n_jobs, force_all_finite, ensure_all_finite, **kwds)\u001b[0m\n\u001b[1;32m   2477\u001b[0m         \u001b[38;5;28;01mreturn\u001b[39;00m distance\u001b[38;5;241m.\u001b[39msquareform(distance\u001b[38;5;241m.\u001b[39mpdist(X, metric\u001b[38;5;241m=\u001b[39mmetric, \u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mkwds))\n\u001b[1;32m   2478\u001b[0m     func \u001b[38;5;241m=\u001b[39m partial(distance\u001b[38;5;241m.\u001b[39mcdist, metric\u001b[38;5;241m=\u001b[39mmetric, \u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mkwds)\n\u001b[0;32m-> 2480\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43m_parallel_pairwise\u001b[49m\u001b[43m(\u001b[49m\u001b[43mX\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mY\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mfunc\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mn_jobs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mkwds\u001b[49m\u001b[43m)\u001b[49m\n",
-      "File \u001b[0;32m~/miniconda3/envs/fibad/lib/python3.12/site-packages/sklearn/metrics/pairwise.py:1973\u001b[0m, in \u001b[0;36m_parallel_pairwise\u001b[0;34m(X, Y, func, n_jobs, **kwds)\u001b[0m\n\u001b[1;32m   1970\u001b[0m X, Y, dtype \u001b[38;5;241m=\u001b[39m _return_float_dtype(X, Y)\n\u001b[1;32m   1972\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m effective_n_jobs(n_jobs) \u001b[38;5;241m==\u001b[39m \u001b[38;5;241m1\u001b[39m:\n\u001b[0;32m-> 1973\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mfunc\u001b[49m\u001b[43m(\u001b[49m\u001b[43mX\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mY\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mkwds\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m   1975\u001b[0m \u001b[38;5;66;03m# enforce a threading backend to prevent data communication overhead\u001b[39;00m\n\u001b[1;32m   1976\u001b[0m fd \u001b[38;5;241m=\u001b[39m delayed(_dist_wrapper)\n",
-      "File \u001b[0;32m~/miniconda3/envs/fibad/lib/python3.12/site-packages/sklearn/metrics/pairwise.py:2010\u001b[0m, in \u001b[0;36m_pairwise_callable\u001b[0;34m(X, Y, metric, ensure_all_finite, **kwds)\u001b[0m\n\u001b[1;32m   2008\u001b[0m     x \u001b[38;5;241m=\u001b[39m X[[i], :] \u001b[38;5;28;01mif\u001b[39;00m issparse(X) \u001b[38;5;28;01melse\u001b[39;00m X[i]\n\u001b[1;32m   2009\u001b[0m     y \u001b[38;5;241m=\u001b[39m Y[[j], :] \u001b[38;5;28;01mif\u001b[39;00m issparse(Y) \u001b[38;5;28;01melse\u001b[39;00m Y[j]\n\u001b[0;32m-> 2010\u001b[0m     out[i, j] \u001b[38;5;241m=\u001b[39m \u001b[43mmetric\u001b[49m\u001b[43m(\u001b[49m\u001b[43mx\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43my\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mkwds\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m   2012\u001b[0m \u001b[38;5;66;03m# Make symmetric\u001b[39;00m\n\u001b[1;32m   2013\u001b[0m \u001b[38;5;66;03m# NB: out += out.T will produce incorrect results\u001b[39;00m\n\u001b[1;32m   2014\u001b[0m out \u001b[38;5;241m=\u001b[39m out \u001b[38;5;241m+\u001b[39m out\u001b[38;5;241m.\u001b[39mT\n",
-      "File \u001b[0;32m<stringsource>:69\u001b[0m, in \u001b[0;36mcfunc.to_py.__Pyx_CFunc_893235__29_pydevd_sys_monitoring_cython_object__lParen__etc_to_py_4code_18instruction_offset.wrap\u001b[0;34m()\u001b[0m\n",
-      "File \u001b[0;32m_pydevd_sys_monitoring\\\\_pydevd_sys_monitoring_cython.pyx:1697\u001b[0m, in \u001b[0;36m_pydevd_sys_monitoring_cython._start_method_event\u001b[0;34m()\u001b[0m\n",
-      "File \u001b[0;32m_pydevd_sys_monitoring\\\\_pydevd_sys_monitoring_cython.pyx:599\u001b[0m, in \u001b[0;36m_pydevd_sys_monitoring_cython._get_func_code_info\u001b[0;34m()\u001b[0m\n",
-      "\u001b[0;31mAssertionError\u001b[0m: <code object _pairwise_callable at 0x558731dd8150, file \"/home/drew/miniconda3/envs/fibad/lib/python3.12/site-packages/sklearn/metrics/pairwise.py\", line 1991> != <code object euclidean at 0x7fa3a7131290, file \"/home/drew/miniconda3/envs/fibad/lib/python3.12/site-packages/umap/distances.py\", line 22>"
-     ]
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "16ac76427b794f2fbc7585bd043319fb",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Creating lower dimensional representation using UMAP::   0%|          | 0/2 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[2025-03-26 14:04:18,259 hyrax.data_sets.hsc_data_set:INFO] Processed 992 objects\n"
+      "/Users/mtauraso/miniforge3/envs/hyrax/lib/python3.10/site-packages/ignite/handlers/checkpoint.py:16: DeprecationWarning: `TorchScript` support for functional optimizers is deprecated and will be removed in a future PyTorch release. Consider using the `torch.compile` optimizer instead.\n",
+      "  from torch.distributed.optim import ZeroRedundancyOptimizer\n",
+      "/Users/mtauraso/miniforge3/envs/hyrax/lib/python3.10/site-packages/ignite/handlers/checkpoint.py:16: DeprecationWarning: `TorchScript` support for functional optimizers is deprecated and will be removed in a future PyTorch release. Consider using the `torch.compile` optimizer instead.\n",
+      "  from torch.distributed.optim import ZeroRedundancyOptimizer\n",
+      "OMP: Info #276: omp_set_nested routine deprecated, please use omp_set_max_active_levels instead.\n",
+      "OMP: Info #276: omp_set_nested routine deprecated, please use omp_set_max_active_levels instead.\n"
      ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA8oAAAPHCAYAAADw8bDqAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjkuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8hTgPZAAAACXBIWXMAAA9hAAAPYQGoP6dpAAB8aUlEQVR4nO39W4yd53knej5VPFRRtGlLtlgyS2Y7liXbchzB9oxFJ2m7aY6zNwRojI76Rt77JkFuZDhuIHMbIxloX8xVA8kYyc2eNBAMcjPti0CAEURbEbwb3ZaRyNnbjmQdYkdiRMqkLImSXSKLJVbNBV3UYnGd13d4D78fECCUyapvre/0/p/n+dZauufLX94JAAAAICIilvveAAAAAEiJoAwAAAADBGUAAAAYICgDAADAAEEZAAAABgjKAAAAMEBQBgAAgAH7u/6F29vb8falS7G8f38sLS11/esBAACozM7OTmy//XbsX12N5eXJ/eLOg/Lbly7Fjx59tOtfCwAAQOU+/qUvxcGbbpr49zoPysv7r/7Kj3/pS7HvwIGufz0AAACVubK1FT969NFreXSSzoPy7rj1vgMHBGUAAAA6M+3jvz7MCwAAAAYIygAAADBAUAYAAIABgjIAAAAMEJQBAABggKAMAAAAAwRlAAAAGCAoAwAAwABBGQAAAAYIygAAADBAUAYAAIABgjIAAAAMEJQBAABggKAMAAAAAwRlAAAAGCAoAwAAwABBGQAAAAYIygAAADBAUAYAAIABgjIAAAAMEJQBAABggKAMAAAAAwRlAAAAGCAoAwAAwABBGQAAAAYIygAAADBAUAYAAIABgjIAAAAMEJQBAABggKAMAAAAAwRlAAAAGCAoAwAAwABBGQAAAAYIygAAADBg/yx/eWdnJ376zDNx4aWXYuvSpTiwuhq3HD8eR++6K5aWltraRgAAAOjMTEH5/PPPx6svvBDHP/WpWD1yJN66cCH+9fvfj+X9++PWO+5oaxsBAACgMzMF5Y3XXov33HZbHLnttoiIOHjTTXHhpZfirQsX2tg2AAAA6NxMzygfvuWW+Pkrr8TmL34REREX33gjNl57LY4cPTry32xfuRJXtrau+z8AANKwvrYR9588HetrG31vCkAyZuooH73zzriytRXPPPZYxNJSxM5O3Pbxj8fNH/zgyH9z/vnn49yzzy68oQAANGt9bSP+y588HodWr8TFS/viP/zHk3Hm3OG+NwugdzMF5QtnzsSFl16K45/5TKweORIX33gjzv7wh9c+1GuYo3feed3zy1e2tuJHjz662FYDANlbX9uIT9/9anz/6fcJZz359N2vxqHVKxERcWj1Snz67lftC4CYMSi//NRTcfTOO+Pm22+PiIhDR47E1ltvxfnnnx8ZlJf37YvYt2/xLQUAFpJSMNXJTMP3n35fXLy079p++P7T7+t7kwCSMFNQ3r5y5erI9aClpdjZ2WlymwCAhqUWTHUy03Dm3OH4D//xZDIFFIBUzBSUj9x2W5x/7rk4eOjQ1dHrCxfilR//eGQ3GQBIQ2rBVCczHWfOHRaQAfaYKSivf/KT8dNnnomXfvCDeHtzMw6srsb7PvShWPvoR9vaPgCgAYPB9PLlpTh7/lCv26OTCUDKZgrK+w4ciPVPfjLWP/nJtrYHAGjBmXOH42sP3xt//sdPxMGD2/HNb3yv9/FrnUwAUjXT9ygDAPk6dvRiHDywHRHvjF8zH989DFC2mTrKAEC+PBfcjNQ+GA2A5gnKANCwlL6GaZDngpuR2gejAdA8QRkAGpR6t9FzwYvTmQcon6AMAA3SbSyfzjxA+QRlAGiQbmMddOYByiYoA0CDUu02pvrcNACkSFAGoEh9BsPUuo2pPzcNAKkRlAEojmB4Pc9NA8BslvveAABo2rBgWLPd56YjIi5e2hdnzx+K+0+ejvW1jZ63bH7raxvZvwYA0qWjDJAQz5E2wwdqXW/wuemz5w/FN7/xvay77SYGAGiboAwULafgafHfnFQ/UKtPu89N33/ydPZj2KNGyXM63wFIm6AMFCu34Ok50mal9oFaqSih2z7sNeR2vs9CAQCge4IyUKzcgmcJAaZrAsTsSui2D3sNJXTKhym5AACQMkEZKFZuwbOEANMlAWJ+KXTbFy1y7H0NuZ3v08qt4AdQCkEZKFaOwTOFAJMLASJfbRQ5cjzfp1FqAQAgdYIyUDTBs1wCRL7aKnKUeL6XWgAASJ2gDECWBIh8KXLMpsQCAEDqBGWgGj74qTwCRJ4UOQBInaAMVMEHP0Fa+ipy9F0w6/v3AzAdQRmogg9+AvoumPX9+wGY3nLfGwDQhd1nIiPCM5FQqWEFs5p+PwDT01EGsjPP6KJnIoG+P0Ss798PwPQEZSAri4wu+uAnqFvfBbO+fz8A0xOUgax41hhYRN8Fs75/PwDT8YwykBXPGgOLWl/biPtPno71tY2+NwWAROkoA1kxuji7cc90+6oaauOTpwGYhqAMZMfo4vTGhQKBgRp5fAOAaQjKQK9K7mim8NpGfR3Np+9+NW4+sikwUB2fPA3ANARloDe5dTRnCb6pvLa9oeDs+UPXtuvS5nJc2lyO1ZVtgYFqeHyDpqVQFAWaJyhD4VK+gec0Ajlr8E3lte0NBYPbtbqyHf/pP98dr7+5kuTxAW3x+AZNSaUoCjRPUIaCpX4Dz2kEctbgm9Jr2xsKBrfrsSeOJXVMAOQklaIo0DxBGQqW+g180RHILrvlswbfVMc7U90u0pDyBAp5Kv2YSqkoCjRLUIaC5XADn3cEsutu+TwBM9XxzlS3K2WpL/ab2L7UJ1DIT5fHVF/n6O694dSJs539TqAbgjIUrOTuYR/dcgGzTtMs9vsM0k2FkdQnULqQekEkN10dUykUeR568Nk4tHolHnrwWUUmKISgDIUrNdzl0C2nDJMW+30v0psKI7WfU33vxxJ1dUz1XeSZ5vcrwkB+BGXgmpxu5CV3y0nLpMV+34v0psJI7edU3/uxRF0dU30XeSb9/lmKMDndh6F0gjIQEXl2U0rtlpOWSYv9vhfpTYaRms+pvvdjqbo4pvou8kz6/dMWYXK8D0PJBGUgIprppqiE07Y+P7Bn1O/re5G+uw3OucWksB+ZX9/nwLjfP20RxlQDpEVQhpblEh4X7aaohNO2lI+xvhfpNMN+pA3TFmFMNUBaBGVoUcoL+70W7aaohNM2xxiQo2kL5qYaIC2CMrQot4X9It0UlXDa5hgjF7vB6Oz5Q3Hs6EWhZ065TGSNs7dg/rWH7x17TJhqgHQIytCimhb2KuG0ratjrITFOf0ZDEY7OxFLS5H8RFGfRp1vOU1kjbO3YP7nf/xEHDywnfVrgloIytCiWsLj4ELnkceP9705FKztbkspi3P6MxiMlpau/rccJor6MO58y20ia5TBgvnly0tx8OB2ROT9mqAWgjIsaFL3qfQxKsGCkuS2ONf9Ts9gMBrsKJc8UTSvcedbKRNZgwXzs+cPxTe/8b3sXxPUQlCGBeQcEqdZYI/7O7v/281HNrMKFjDM4DOluSzOc77+lGxvMPKM8mjjwvCsE1kpF40GC+Y1TJlBKQRlWEBu3add0yywx/2dwf/t0uZyXNpcjtWV7eSDBQwz64ftpCLX608NBoPRk0/1vDEJmxSGp53IyqloVPqUGZREUIYF5DoaNs0Ce9zfGfzfVle24//z//tIvPc9l+Pb37ndAoDs7D3Wjx29mMWz9rlef7heyp3Qpg17rU0ER0UjoA2CMiwg1w/rmmaBPe7vDP5vlzaX43/6v/8kVle2477Pn7mhkl/TIpA85Ro4c73+8I6cOqGLavO1LnoOu08BwwjKsKAcx6imWWCfOXc4/vib98R/+B9fiP/yNx+67u8M/vubj2zGH/zO0xFxYyW/pkUg+co5cOZ4/eEdNXVC23yti5zD7lPAKIIyVGrSAvszn3gl/l//j+/H0lLE/+UTr8XPXl+NJ5+69YZ/v762EQ89+OzQSn5Ni0Dy1lXg1LliUK7TDPNo+7XOew67T93IdQquEpSBoe77wkvXvgN0aenqnweD8q5xlfyaFoEwic4Ve+U8zTCrVF+r+9T1XKfgHYIyMNS3v3N7/PaXTsfSUsTOztU/jzKqkp/qwgj6oHPFMDWNz6f4WnO/TzXd/XWdgncIysBQTz51a/zeH/563PeFl+Lb37l9aDd5GikujEhPDaN+fXSuanhfYVG53qfa6P7qsMM7BGVgpCefunXugAzTqmXUr+vOVS3vK9Sqje5v7h12aJKgDEykK0Wbahr167JzVdP7CjVqq/uba4cdmiYoUwVBb366UrTNqF87vK9QNt1faJegTPEEvcXoStE2i712eF+vUiilZLq/0B5BmeIJeovRlaILFnvvaDLY1f6+KpSWSfED6IKgTPEEvcX02ZWyGKI2gl2zFErL4xwBuiIoUzzjh4vroyu1yGJIwCZXgl2zFErL4xwBuiIoU4Xaxw9zNO9iSLeBnAl2zVIoLY9zBOiKoAwkad7FkG4DORPsmqdQWhbnCNAVQRlI0ryLId0GcifYwXjOEaALgjKQrHkWQ7oN0DzP/UMenKvQHEEZKM6sAdvCAkYb99y/cwfHQDp8Rgc0S1AGqmZhAeONeu7fuYNjIC0+owOatdz3BgDTWV/biPtPno71tY2+N6UowxYWwDt2n/uPiOue+y/l3HFtnV8px0Bq5j0mR52rwHx0lCEDqvbt8eFfMN6o5/5LOHdSvrbmMNJcwjGQmkWOSZ/RAc0SlGFGfSxejFO1Z3dhcerE2b43BZI17Ln/EhblqV5bUw7wg0o4BlKz6DHpE8GhOYIyzKCvxYuqffseevDZOLR6JR568NlkF6WQmtwX5aleW1MN8MOkfAzk0JXfK9VjEmokKMMM+lq8qNq3K6dFKdCcVK+twtLicunK75XqMQk1EpRhBn0uXlKu2ufOorROOXabaF6K11ZhaXE5F0BTPCahRoIyzMDipUz2a31y7TZRD2FpMX0UQBXfoCyCMszI4qVM9mtdRn2tjUWuxT5l6LoAqvgG5RGUAehc32Fsb7fp7PlD2S5ym3wvLfYpSZcF0JxHvQf1fW2GlAjKAHQqhTC2t9uU6yK36fcy1/cB+lbCZ12kcG2GlAjKkCAVXUqWShjb220atcht63xs4uc2/V6mvth3bSRVJXzWRSrXZkiFoAyJUdGlT10EkRTD2KhFblvnY1M/t+n3MuXFvmsjqcv9sy5SvDZDnwRlklRz16Cvim7N7zlXdRVEdsPYqRNnG//Zixi2yG3rfGzq57YRbFNd7Ot2QbtSLpRBHwRlklN716Cvr7So+T3nqq6DyEMPPhuHVq/EQw8+2/oxN28hqK3zcZqfO+02pxpsm6bblR8F2PzUcj2BaQjKJGfWxXppN+I+Kro6NUR0G0S6POYWKQS1dT5O+rltFq9yvWbqduUlpQJsrsc80C9BmeTMslhv40acwg2164quTg0R3QaRnEJ5W+fjuJ/bViEhpfAyj5y6XSncS/qUSgE292Me6I+gTHJmWaw3fSOu9YbaRUCqfdGYi66CSKmhvCltbXMq4aV0td5LBqVy3jnmb+R+DNMRlEnStIv1UTfieW8CNd9Q2wxIFo0Mk3oo73Mx2VYhIZXwUrqa7yW7UhmVd8xfz/0Ypicok7VhN+JFbgJuqO2waKRvs4byFBaTbRQSUgkvpdt7Lzl7/lDcf/J0de95CqPyfR3zqXZt3Y9heoIy2dt7I17kJjDPDTXVm2FKFCDITcmLyRTCyzglXFMH7yVnzx+Kb37jezp4Per6mE+h0DaK+zFMT1CmOIveBGa5oaZ8M0yJLha5sZjsR0nX1N17yf0nTxdbdGG4lAtt7scwPUGZ4nR5E0j5Zpia1LtYMMhish8lXlMVXcozaeoh9X3ufgzTEZQpUlc3gVm/ysqiG5rT9jnVx7hm7Y99pB4w5rF3DPvTd7967b+Tn2mmHhTaoAyCMixg2pthSeOEkILSzqlZX09pr39XqQFj93WUuM+GKbGIs2vaqQddW8ifoAwLmuZmWOI4IfSptHNq1tdT2usfVGrAKHmfDSq1iLOrxKkHYDhBGTrgxgrNKu2cmvX1lPb6a1DLPiu9IFDq1ANwo6V7vvzlnS5/4ZWtrfinb387fvW++2LfgQNd/mroVcmjaNCH0s4pzyiXr4Z9trej/LWH741jRy8W/ZqBPMyaQ3WUoSOljhNCX0o7p2Z9PaW9/hp0sc/6DuO+QxoohaAMANF/wIBFpfJ8sO+QBkogKANQvVQCBvnqstAy6nel9nxwLc9lA2USlAGoXmoBo2Qldu67LLSM+12pBVMffAXkTFAGoHqpBYxSldq5b6PQMk/XOMVg6ll6IFeCMtUosYsBNCPFgFGiUjv3TRdaFukaC6bNyGXNkMt2Qo4EZaqQQxfDzQ761WXAqPV8L7Vz33ShJbeucUnW1zbi1Imz8dWvPBOrK9vJrhki8ljbQM4EZaqQehfDzQ7qUfP5XnLIG1domaYwMvh3dI37MXhu7kpxzbAr9bUN5E5QpgqpdzHc7KAei57vuXejawt50xRGhv2dUgsKKRs8N3eluGbYlfraBnInKFOF1LsYbnZQj0XO95q70bmapjAy7O888vhx+7Zjg+fmpc3l+LO/+lg89sSxZPdD6msbyJ2gTDVS7mKkfLNLvXuV+vbBXouc77lPn9R4vk5TGFEsTUPK9+JRUl7bQO4EZUhEije71LtXqW8fjDLv+Z5zoKr1fJ0mfOUY0EpUYyEHGE1QBkZKvXuV+vZB03IOVLmdr02GpmkKIykWS2tSayEHGE1QBkZKvXuV+vZBG3INVDmdr0JTfVIr5OhuQ/8EZbLghtGP1LtXTWyfY6s53kvGSf16Mii10LQI5+V0UirkpFqocSxRG0E5M6VepMa9rlRvGLXosns1z/G9yPY5tprjvWQauXTDUwpNi3BeTq/LQs6ke12KhRrHEjUSlDOwe0E9e/5QfPMb3yvuIjXp4pviDYPm9XETdmw1x3tJSXLqfo/jvJxNF4Wcae51fRZqRoV4xxI1EpQTN3hBvby1HAcPbEdEWRepSRffUir7bSllyqCPm7Bjqzney3KUck1ZVC7d73Gcl+mZ5l7XV6FmXIh3LFEjQTlxgxfUgwe24/LlpTh4cKeoi9Ski28plf02lDQK1cdN2LHVHO9lGUq6psyqxAKB8zI9097r+ijUjAvxjiVqJCgnbu8F9WsP3xvHjl4s6iI17XdMlvJ6m1TSKFRfN2HHVnO8l/kr6Zoyi5ILBH2flyUWIBaRcuCcpnGR0vZC2wTlxA27oD75VN9b1TwX3/mUNgrlOIB+lXZNmVatBYK2lVyAWESq97qUQzz0QVDOQB8XVBXgPLip5c15xrS6OlZqvabUWiBomwJEflIN8dAHQZkbqADnxU0tT84zpjXPsbJIsK7xmlJrgaBtChBAzgRlblBbBVhXjy7tHm83H9ms6jxjfpOuyXuvYYow86mxQNA2BQggZ4IyN6ipAmxBSZcGj7dLm8txaXM5Vle2iz/PWMy4a/Kwa1htxU7SpgAB5EpQ5gY1VYAtKOnS4PG2urId/+k/3x2vv7lS/HnGYsZdk4ddw2oqdgJAWwRlhqqlAmxBSZf2Hm+PPXGsivOMxY26Jg+7huVa7PQYDKlybEKdBGWqluuCkjztPd4iIu4/edqxx9xGXcNyK3Z6DIZUOTahXoIy1cttQUnedo83iy+aUsI1zGMwpCqlY1NnG7olKAP0IKXFF/TNYzCkKpVjU3EVuicoA9dRse5GKosvSIHHYEhVKsem4ip0T1AGrlGx7k4qiy9IRQkj5HSvi+JuCsem4ip0T1AGrlGx7lYKiy+AXNVU3FVche4JysA1KtYA5KKP4m6fjycprkK3BGXgmhwq1p6hBiCi++JuTR1sQFAG9ki5Ym2RAs1TfCJXXRd3PZ4EdRGUgWxYpECzFJ/IXZfFXY8n5U1RkFkJykA2LFKgWYpPML0mOtjCWj8UBZmHoAxkI4dnqCEnik8wm0U62MJafxQFmYegDGSlyTE7lX1qp/j0jnmvB64jTEtY64+iIPMQlIEqqezDVal9gF8fwXPe64HrCLMQ1vqjKMg8BGWYgo5BeVT2IT19Bc95rweuI+Vp834vrPUrtaIg6ROUYQIdgzJ1VdlXZIHp9RU8570e6BCWpYv7vbAG+RCUyVZXAUTHoExdVPYVWWA2fQXPea8HbV5HFNm6534PDBKUe+ZGOJ8uA4iOQXqaOm/aruxbdMFs+hxNnfd60MZ1RJGtH6Xc760toRmCco/cCOfXZQDxTFFacjpvSll0QZeMpiqy9aWE+31O90hInaDcIzfC+XUdQCzc0pHTeVPCogvoniJbf3K/3+d0j4TUCcodGTYG40Y4PwGkXrmdN7kvuqAUOY2jusexa9bjNrd7JKRMUO7AqDEYN8LFCCB1ct4As8pxHNU9jvW1jfjWn/5drK5sx6XN5Xjg61+ceEy4R94opyIZaRGUOzBuDMaNEGbnvAFmYRyVHJ06cTZWV7YjImJ1ZTtOnTgbf/nXd078d+6R78ixSEY6lvvegBrsjsFEhDEYgIqsr23E/SdPx/raRt+bMrOct30v92Go07AiGUxLR7kDxmDIgdEkaFbOnYyct30Y92Fy9NgTx+KrX3nm2uj1Y08c63uTsuOZbRYhKHfEGAzT6CuslrYohhTkPO6b87aP4j5Mbs6cOxwPfP2LCjwLUCRjEYIyJKLPsFriohj6lnMnI+dth5Io8CzOe8i8BGVIRJ9h1aIYmpdzJyPnbQe65/EtSiQowxhdXvj7DKsWxdCOnDsZOW870B2Pb1EqQRlG6PrC33dYtSgGAGbl8S1K5euhZlDSV2UwWR9fKXDm3OF45PHjbjAAQOPaWMv6+rWr5ITy6ChPyVhJfTy3S9M8wwVAX+Zdy066d/U9EZcCOaFMgvKUjJXUx4WfJrmJQnkUv8jJPGvZae9dtT++JSeUSVCeku5inWq/8NMcN1FoXp9BVfGrWZP2paLE4uZZy456DG2afVHTPpMTyiQoT0l3EViEmyg0q++gqvjVnEn7su99XYp51rJ7711nzx+aal9Mu89KCdNyQpkE5RnoLgLzchOFZvUdVEspfqUQVCbty773dUkG17LT7Pu9965p98U0f6+0AoicUB5BGaAjbqLQnL6DagnFr1SCyqR92fe+LtEs+37vvWuafTHNPlMAIXWCMgAwt746kikE1dyLX6kElUn7MoV9XZp59/20+2Kav6cAQuoEZQBgLn13JHMPqn1LKahM2pf2dbMW2ffT7otp9qkCCCkTlAGAuaTSkWQ+gsqNUnhmuwup7HsFEFImKAMAc0mpI8l8BJV39D0h0TX7HsYTlCeopbIIALPa7UqdOnG2702BhZmQeIf1LwjKY01TWXQhAaB2Dz34bBxavRIPPfhs8V04ypXbhERba9DaOuswiqA8xqTKogsJALXThaMUqTy3O40216CpntOaU3RNUB5jUmUx1QsJAHQlty4cdfjMJ16J+77wUnz7O7fHk0/dOvW/y+W53TbXoCme05pT9EFQHmNvZTEi4v6Tp69VslK8kACkQOW/Hjl14ajDZz7xSvyv/8t/j6WliN/+0un4vT/89ZnCcg6+//T74tLmcqyubMelzeVG16ApntOaU/RBUJ5gt7I4qpKV2oUEoG8q/+UaVQDJpQtHHe77wkuxtHT1/19auvrn0oJy21I7pzWn6IOgPKVRlazULiQAfVP5L5MCCLn49nduj9/+0ulYWorY2bn659J8+u5XY3VlOyIiVle2i7/Oak7RB0F5SipZANNxvSyTAgi5ePKpW+P3/vDX53pGORc1Xmc1p+iaoDwllSyA6bhelqnGhTn5evKpW4sMyLtcZ8vlMz7SISjPQCULYDqul+WxME+DRTS7hl1nHR9584hLWgRlAGAqCiD9sohmHMdH/jzikpaZg/LWxYtx9umn4+fnzsX2lSuxcvhwfPBTn4qbbr65je0DACDKXkTrhC6u5OOjFh5xSctMQfnty5fj+f/6X+Nd739/fPhzn4t9Bw/G5Y2N2HfwYFvbR0LauolN83PdQAGoXamLaJ3QZpR6fNTEIy5pmSkon3/++Th46FAc//Snr/23lcN2YA3auolN83PdQAGg3EW0TmgzSj0+auMRl3TMFJTf/OlP491Hj8YLf//3sfGzn8X+Q4fi/R/6ULzvQx8a+W+2r1yJne3ta3++srU198bSn7ZuYtP8XDdQALiqxEW0TmhzSjw+oC8zBeXLb70Vr77wQtx6xx1x9M474+KFC3Hmhz+MpeXluOX48aH/5vzzz8e5Z59tZGPpT1s3sWl+rhsofTP6D9AenVBS4p7Prtk+zGtnJw69973xgbvvjoiIm9773rj05pvx6gsvjAzKR++8M269445rf76ytRU/evTR+beYXrR1E5vm57qB0iej/wDt0wklBe75DJopKO9fXY3Vd7/7uv+28u53x4WXXx75b5b37YvYt2++rSMpbd3Epvm5bqD0xeg/UCNdNWrkns+gmYLy4Vtuic1f/OK6/7b5i1/EwUOHGt0ocIMmFUb/gdroqlGrRe751q7lmSko33rHHfH8f/2vce655+K9x47FWxcuxGsvvhi333NPW9tHhdygSYnRf6A2umrUat57vrVrmWYKyjfdfHP8ymc/Gy8//XSce/bZOHjTTXHsV381bv7gB9vaPirkBk1qjP7DVTomdTBJQ83muedbu5Zptg/ziogjt90WR267rY1tgYhwgwZIkY5JPUzSwGxSXbvuFjfPnj8Ux45edD7PaOagDG1zgwZIj45JXUzS1MOkyOJSXLsOFjd3diKWlmKmIqfjQlAmUW7QAGlJtWMCzK+pSRGhKr2162Bxc2np6n+btshpgugqQRkAmCjFjgmwmCYmRYSqNA0WNwc7ytMUOU0QXSUoA0BPcuvCpNYxqVVuxw3pamJSRKhK02Bxc9ZnlE0QXSUoA0APdGHK0lV4ddzQpCYmRYSqdA0WN598arZ/Z4JIUAZone4Pw+jClKPL8Oq4KVsf94tFJ0WEqjKZIBKUGcHCnnk5dq6n+8MoujDl6DK8Om7KlfP9QqiiRIIyN8j5Qk2/HDs30v1hFF2YcnQZXnePm1Mnzrb2O+iH+wWkRVDmBi7UzMuxcyPdH8bRhSlDH0WPhx58Ng6tXomHHnxWUbIQ7heQFkF5BrWMlLpQM68ajp1ZrwO6hlCHLoseipJlcr9gr1qyR6oE5SnVNFLqQs28Sj925r0O6BoCTaqhKFmrmu8XQuH1Usoete4bQXlKtVVva75Qs5iSj53argNAmvYWJSMi7j95urpFLOVIKRSmoos1xzQBuOZ9IyhPSfUWcB2AMpTQHdktSta8iKVfTZ5HCtE3anvNMe21o+Z9IyhPqfSRUmAy1wHIX2nBsuZFLP1p+jxSiL5R22uOaa8dNe8bQXkGbYyUllDVhpqO45JHy6EGpQXLmhex9Kep82hw/aAQfaM21xzTXjtqbhIIyg2YNySUVtWmTo5jYBqpFNRKC5Y1L2JzkMpx37QmzqNh64dHHj/ewtYyzCzXjlqbBILyghYJCaVVtamT4xiYJKWCWonBstZFbOpSOu6b1sR5ZP3QP9eO8QTlBS1ykpdW1aZOJR/HpXYCoGupLYgtDulCasd90xY9j0peP1AGQXmEaRfIi5zkJVa1+yTUTK/J96rU47jkTgB0zYKYGjnux8tt/WCdWR9BeYhZFsiLnuSq2s0Qaqa/gLfxXpV4HJfeCYAu5bYghiY47ifLZf0w7dqpyzAtuLdPUB5i1gVyLid5yWoONetrG3HqxNn46leeidWV7Ynht+b3ahY6AdAs90pq5LgvwzRrpy6bNhpE3RCUh1hkgay6049aQ83ghXLXpPBb63s1K50A6If7KJCaadZOXTYiND26ISgPMe8CWXWnP7WGmsEL5a5J4bfW92oeOgHQLfdRaqVAlI5h+2KatVOXjYhFf5fjbTqC8gjzLJBVd/pVY6gZvFBe2lyOP/urj8VjTxyb+D7U+F4B6XMfpUYKROkYty8mrZ26bEQs8rscb9MTlBtkpJWu6Q4DJXEfpUZtFIh0DOez6L7oshEx7+9SkJyeoNwgoYU+6A4DpXAfpUZNF4h0DOdXQ7GuhtfYFEG5YUJL/1RRAfLlPpo/9+HZNF0g0jGcXw3FuhpeY1MEZYqiigoA/XEfns9ggWjRQoOO4WJqKNbV8BqbIChTFFVUAPqik+o+vKgmCg06htAMQZmiqKIC0Aed1KvchxfTVKGhtI6hIlR/an7vBWWKoooKQB90Uq9yH16MQsONFKH6U/t7LyhTnNKqqACkT8B5x6j7cM2dqWkpNNxIEepGXZ1Ltb/3gjJJc1MFIAcCzni1d6ZmoeB/PUWo63V5LtX+3gvKJGuRC4GADUDXBJzRau9MMT9FqOtNOpeaXAPX/t4LyiRr3puqqjUApKX2zhSLUYR6JwCfPX9o5LnUxhq45vdeUCZZ895UVa0BIC21d6ZyZ1KvX3sD8NcevjeOHb14w/6wBm6WoEyy5r2pqloDQHpq7kzlzKRe//YG4GNHL8Yjjx+/4e9ZAzdLUCZp89xUVa3roLoN6XFeQvfaPu90Kfs3bQC2Bm6WoEyRVK3L1ld1WwiA0XSdmMQ1tHldnHe6lP2bJQBbAzdHUIY93MjT10d1WwiA8XSdGMc1tB1dnHe6lGkQgLsnKMMAN/I89FHdFgJgvNS7Toqg/XINbUdX552QRo0E5Y64QefBjTwPbVS3J52jqYcA6FvKXSdF0P65hrYj5fMOcicod8ANOh9u5Plosro9zTlqMQKTpdp1UgTtX8rX0NybGamed5A7QbkDbtDT6/tmlfKNfJS+37O+NfH6pz1HLUYgT4qgaUjxGqqZAYwiKHdg1A26yYBTQlhK5WaV4o18lFTes7409fotoqFsORZB6YZmBjCKoNyBM+cOx9cevjfu+8JL8e3v3B5nzh1uNOCUEpbcrGZX+3vW1Ou3iIby5VQEpTs1F0pnabKk0pBJZTuog6DcgfW1jfjmN74Xh1avxH2fP3NtQd5UwCklLNV8s5pX7e9Zk6/fIhqgPrUWSmdpsqTSkEllO6iHoNyBYUG2yQV+KWGp1pvVImp/z2p//QAsrsZC6SxNllQaMqlsRy107wXlTgwLsk0u8EsKCzXerBZV+3tW++sHgFnN0mRJpSGTynbUQPf+KkG5A6OCbJMLfGHhKtUvAIDxZmmypNKQSWU7aqB7f5Wg3BFBtn1Nf0CaCzFAmYZd4133qc0sa9NU1rGpbEfpdO+vEpQpRlPVL+MmAOUado2PCNd9gF/Svb9KUKYYTVW/jJsATJZrB3bYNX73/x/8bzm9JqA8fV9jde8F5WL0fTKloKnql3ETgPFynrwZdY133QdSkfM1tiSCcgGcTO9oovpl3ARgvJwnb0Zd4133yYXmSPlyvsaWRFCeU0oXKSdT84ybAIyW++TNsGu86z450BxpR0rr+oj8r7GlEJTnkNpFyskEQJdM3kA/NEeal9q6PsI1NhWC8hxSu0g5mQDomg4sdE9zpHmpret35XKNTa0b3yRBeQ4pXqRyOZkAAJje3iCiOdKsFNf1uUixG98kQXkOLlIAALRtVBCx9myOdf1V83SGU+3GN0VQnpOLFAAAbSo9iKSi9nX9vJ3h0rvxgjIAACSo9CAyi5Kfhe3bvAWZ0rvxgjIAACSo9CAyrdKfhe3bIgWZkrvxgjIAACSqrSCSU4fWCHq7FGSGE5QBIFE5LWSBfOTWoTWC3r6SO8PzEpQBIEG5LWRhVgpB/cmtQ6vjSR8EZQBIUG4LWZhF04UgoXs2OXZodTzpmqAMAAnKcSFLntoKmeN+bpOFINMX09m7P3RoYTxBGQASZCFLF9oKmZN+bpOFINMXk43aH94nGE1QBoBEWcjStrZC5qSf22QhyPTFZIoJMDtBGaBhnpUDIvK4FrQVMqf5uU0VgkxfTKaYUJ8crj+pE5QBGuRZOSAin2tBWyGz6/Bq+mI8xYS65HL9SZ2gDNAg421ARF7XgrZCpvDar70dRfujHjldf1ImKAM0yHgbEDH6WmAcki7oKF6vtvPOWqQZgjJAg4y3ARHDrwXCC00bFQB1FN9R43lnLdIMQRkKVlsFNRXG24CIG68FwgtNGhcAdRTfUet5Zy2yOEEZClVjBRUgFcMKlcILTRoXAHUU3+G8Y16CMhSq1goqQN9GFSqFF5o0KQDqKF7lvGNegjIUSgUVoB+TOn0W6jRBAJye8455CMpQKDdQgH4oVNIVARDaIyhDwdxAAbqnUAmQP0EZAKBhCpVMyzdUQJoEZQAA6IFvqIB0Lfe9AQAAUKNhH/wGpEFQBgAgS+trG3H/ydOxvrbR96bMZfeD3yLCB79lJvdjj8mMXgMAkJ1Ux5ZneebYB7/lKdVjj2YJygAAZGfc91V3YVggnidA+eC3/PR97NENQZmRfAojDOfcAOhfn99XPSoQ7w1Qp06cjdffXHG/KIzvSq+DoMxQRkpgOOcGQBr6HFse1VEcDFCXNpfjq195JlZXtt0vCmNkvg6CMkMZKYHhpjk3dJwButHX2PKojuJggLr5yGb8we88HRHWUiUyMl8+QZmhjJTAcJPODR1ngPKN6yjuBqj1tY146MFnh94vFFQhfYIyQxkpgeEmnRumMaBsAg67JnUUR90vFFTb09T56TwnQlBmDCMlMNy4c8M0BpRLwBlNsBhu2P1CQbUdTZ2fznN2CcoADTKNAeUScIYTLGaTSkG1tOLGIufn4HvhPGeXoAzQMNMYUKZUAk5qBIvZpFBQLbG4Me/5ufe9+NrD9zrPiQhBGQBgKikEnBQpIMyu74JqicWNec/Pve/FsaMXnedEhKAM1Slt1AqgS30HnBQpIOSn1OLGPOfnsPfCeU6EoAxVKXHUCoD+CRZ5Udx4h/eCUQRlqEiJo1YAwOwUN97hvWCY5b43AOjO7nhRRBQ1agUAAE3SUYaKGC8CAIDJBGWojPEiAAAYz+g1AECG1tc24v6Tp2N9baPvTYFiNHVe5Xx+5rztTdJRBgDITBvfYuDrA9NnH7WrqfMq528ZyXnbmyYoV84FF4CUpXafSmV7mv4WA4vj9NlH7WvqvMr5W0Zy3vamCcoVc8EFIGWp3adS2p7dbzHY3ZZFv8XA4jh99lH7mjqvmj4/u5TztjdNUK6YCy4AKUvtPpXS9jT9LQYWx+mzj8ZrYtqjqfNq1M9JZSJlHN+Q8g5BuWIuuFCfHG7SsCu1+1Rq29PktxhYHKevr32Uw32jyWmPps6rvT8npYmUSXxDylWCcsXcFKEuOd2kISK9+1Rq29M0i+P0db2PcrlvpDTtMUob25hDESNngnLl3BShHjksJGCv1O5TqW1PUyy4GSaX+0ZT0x5tngdNT6TkUsTImaAMUInUxkaBNFhwM0ou940mpj3aPg+ankjJpYiRM0EZoBKlj40C87HgZpSc7huLTnt0cR40OZGSSxEjZ4IyQEVKHRsF5mfBzTi13DdyOw9yKmLkSlAGAKiYBTc4D7iRoAwAULlauoaUqakP4crpPPDZAu0TlAEAEuCTp2F2tQZGny3QPkEZAKBntS72a6IQ0o5aA2Nuz1TnSFAGAOhZrYv9nM0SfNfXNuJbf/p3sbqyHZc2l+OBr3+xtf1bWyCvNTB6prp9gjIAQM9qXeznatYJgFMnzsbqynZERKyubMepE2fjL//6zt63a9afnWIoqzkw5vRMdY4EZQB6keqiC/pQ82I/R6lOALS1Xak/GtBlYHTvqoegDEDnUl90QR90h/Ix6wTAY08ci69+5Zlro9ePPXEsie2aVqqFgSZNE4Ddu+oiKJME1TmoSw2LLqBcs04AnDl3OB74+hdbX+u0NZlQ+qMB0wZg9666CMr0TnUO6lP6ogso36wTAF1NDLTxe0p/NGDaAOzeVRdBmd6pzkF9Sl90AZSm5EcDpg3A7l11EZTpneoc1KnkRRcA+ZglALt31UNQplPDnkVWnQMAyFvqnzczafsEYPYSlOnMuGeRXZwAAPKU+ufNpL59pGm57w2gHsOeRSYf62sbcf/J07G+ttH3pgAACUl9jZf69pEmHWU641nkfKnEApCK1Ed8a5T6Gi/17SNNgjKd8SxyvnwyOQApULhNU+prvNS3jzQJynTKs8h5UokFIAUKt+lKfY2X+vaRHkEZmEglFiBNtY0hK9wCXRGUgamoxAI1ySGA1jiGrHCbnhzOFZiHoAwAMCCXAFrrGLLCbTpyOVdgHr4eCgBgQC5fJbM7hhwRRY8h+3rCdOVyrvTJ8ZsvHWUAgAG5PAdbwxiyjmXacjlX+uL4zZugDJAQz3pB/3IKoMPGkEu6jtQ6Xp6LnM6VPjh+8yYoAyRiUuW5pMUvpC7X52BL62DpWKYv13OlC00cv+79/RGUARIxrvJc2uIXaEdfHay2FvM6luRs0ePXvb9fgjJAIsZVno1vAdPoowPb5GJ+WOBuomOpK0dfFjl+3fv7JSgDJGJc5dn4ITCNPjqwTS3m2+qe6cqRK/f+fgnKAAkZ98E8X3v43jh29KKOCDBW18+MNrWYb6t7VnJXTqe8bE2Mbjs+5icoAyRMJwRIXVNd7La6Z6V25dwf6jBv4cvxsThBGSBhJXdCgMly6Qg10cVua2y81A8Ec39gHMfH4gRlgISV2gkBJquxI9TW2HhpX2G0vrYRNx/ZjEuby7G6su3+kJkuCmDWD4sTlAESVmonBJhMR6he44LUYAHl0uZy/Kf/fHc89sQxx0YmhhXAIsIkRYIEZYDEldYJAaajI1SnSZMEgwWU1ZXteP3NFfeIjOwtgJ06cTYeevDZViZHrB8WIygDACRIR6gffT8XPmmSQAElb3v3X0SYHEmUoAwAkCgdoW6l8Fz4pCCsgJK3vfsvIq7rKCt8pENQBgCASOO58GmCsAJK3vbuv3kKH31PPtRAUAYAgFh8rLmp8CIItyu1kDnr/k5h8qEGgjIAAMRiY83CSx663E9tBfIUJh9qICgDAMAvzdvNFV7y0NV+ajOQ+0C3bgjKZCO1MRkAgF2phxfrqKu62k9tBnIf6NYNQZksGGeajZshAHQr5fBiHfWOrvZT24Hcc+ztE5TJgnGm6bkZAn3oskCnGEiqUg0v1lHX62I/pVw4YTqCMllIfZwpJW6GQNe6/nAcxUCYjXVUP1ItnDAdQZksqMpNz80Q6FqXBTrFQJiddVT7TLqUR1AmG6py03EzBLrWZYFOMRDmYx3VHpMuZRKUoUBuhkCXuizQKQZCumrtqpp0KZOgDAAsrMsCnWIgpKfmrqpJlzIJygAAwEJq7qqadCmToAwAACyk9q6qSZfyCMoAADCFWp/BnYauKqURlAEqY6EHMLuan8Gdlq4qJRGUASpioQcwn5qfwYUaLfe9AQB0Z9hCD4DJdp/BjYi4fHkpzp4/1PMWAW0SlAEqMrjQG/VhK+trG3H/ydOxvrbR9eYBJOvMucPxtYfvjctby3Hw4E588xvfy/Y66ToPkxm9BqjIpA9bMZoNMNqxoxfj4IHtiMh3/Np1vnuLfjaIzxbph6AMUJlxH7biGTxIg4Vxmkr4CiTX+fnNc14uWphQ2OiPoAzANXsXgWfPH4r7T562WIcOWRinK8WvQJo1vJUQ9vsw73m5aGFCYaM/gjIA1wwuAs+ePxTf/Mb3LNahY30sjHWwp5fSVyDNE95SDPs5mPe8XLQwobDRH0EZgOvsLgLvP3laFRt60PXCWAc7X3vD2+8+8Fz8xbfumiosD/uMCuF5tHnPy0ULEwob/VkoKJ977rn46Y9+FO//8Idj/ZOfbGqbAFhQEwseVWzoR9cL4xpGO0sNgYPX6Z2diAd+63Tc9/kz1T4H2+Z+XuS8XHQKIaUphprMHZTfev31eO3FF2P1yJEmtweABTW14FHFhv50uTAuvShWSggcZvc6/bsPPBcP/NbpiKj3Odgu9rPAWpe5vkf5yttvx4tPPhm333NP7DtwoOltAmABwxY88zpz7nA88vhxCwMo2G7Y+saffKqoELmryWtiis6cOxx/8a274uKlfRERCz0HO++/T0ET+9n3SzNoro7ymR/8II6srcW7jx6Nc889N/bvbl+5Ejvb29f+fGVra55fCcCUSu8OAc0ruVNWwzXRc7CL7+eSJw+Yz8xB+fWXXoqLFy7EnV/4wlR///zzz8e5Z5+decMAmE8JCx6AptRyTezyOdgUn/ledD+XMH5Os2YKypcvXoyz//RP8eHPfS6W9+2b6t8cvfPOuPWOO679+crWVvzo0Udn20oAZlJydwhgVq6JzUm587rIp3nXMHnAbGYKyhcvXIi3Nzfjue98553/uLMTG6++Gj/7l3+JX7v//lhaWrru3yzv2xcxZagGAADSlVPndZZQX8vkAdObKSi/6/3vj7tOnrzuv/3rP/5jrL7rXXHrnXfeEJIBAIBy5NR5nTXUmzxg0ExBed+BA3Foz6dcL+/bF/sOHoxDviYKAEhIis9RQu5y6rzmFOpJz9zfowwAkKqUn6OE3OXSec0p1JOehYPyR37zN5vYDgCAxuT0HCXQnlxCPelZ7nsDAACatjtyGRFGLsdYX9uI+0+ejvW1jb43hcw4dubjfcuH0WsAoDhGLiczns68HDvz8b7lRUcZACjSmXOH45HHj1uIjjBsPB2m4diZj/ctL4IyAECFjKczL8fOfLxveTF6DQBQIePpzKvLY6ekr3lzzuVFUAaoSEkLDmBxPhGYeXVx7JT4TK9zLh+CMkAlSlxwAFAuX/NGnzyjDFAJHyICwDz6+kojz/TSJx1lmMCoKqXYXXDsdpQtOACYpM9pJM/00idBGcYwqkpJLDhgPgqm1Kzv8WfP9NIXQRnG6PvmAE2z4IDZKJhSO9NI1EpQhjHcHIDU6G7OZtH3S8GU2s0yjVTj9anG11wLQRnGMKoK/bMIeYfu5myaeL8UTEldF9fIaaaRarw+1fiaayIowwRGVaE/FiHX092cTRPvl4IpKUvpGlnj9anG11wTXw8FQLJ8pdX1fFXKbJp6v86cOxyPPH7cArhCfX0t0rRSukbWeH2q8TXXREcZgGQZe72e7uZsvF8sIqVu7SgpXSNrPN9qfM01EZQBSJZFyI08DjIb7xfzymGsNrVrZI3nW42vuRaCMgBJswgB+pBSt3Yc10hoh6AMQGd8gjWQi9S6tUC3BGUAOpHD834Ag3RroV4+9RqATqT06axAuj7ziVfiG1/9x/jMJ17pdTtS/8RroF06ygB0Ipfn/YD+fOYTr8T/+r/891haivjtL52O3/vDX48nn7q18+0wAVMGj/uwCEEZgE543g+Y5L4vvBRLS1f//6Wlq3/uIyjn8InXjKfYwaKMXsMYxq6gWWfOHY5HHj8+82LFuQh1+PZ3bo+dnav//87O1T/3YXcCJiJMwGTK4z4sSkcZRlCJhDQ4F6EeTz51a/zeH/563PeFl+Lb37m9l25yhAmYEnjch0UJyjDCqErkp+9+Nc6ePxTHjl5084QOGIGEujz51K29BeRBPvE6b4odLEpQhhH2ViLPnj90rau1s3P12SndLWifrkD7fOANUCLFDhYhKMMIeyuRg12t3Q8a0d2C9ukKtMtoOwDcSFCGMfZWIne7WoMdZd0taJ+uQHuMtkP3THFA+gRlmNJgV8szypAeC8/5GG2HbpnigDwIyjCDwa7Wk0/1vDHANRae8zPaDt0yxQF5EJQByJ6F52KMtkN3THFAHgRlALJn4dk8o+zQjlKnOFwzKI2gDED2Sl149sUoe32EnG6VNsXhmkGJBGUAZpbiorq0hWefjLLXRchhUa4ZlEhQBmAmFtXlM8peFyGHRTV5zUixEEudBGUAZmJRXT6j7HWZJuQIL4zT1DVDIZaUCMoAzES3sQ5G2esxKeQIL0yjiWuGQiwpEZQBmIluI5RnXMgRXujK959+X1zaXI7Vle24tLlcVSHW1EZ6BGUAZqbbCPUwRULKSgiY005tlPBacyIoAwAwkimS8YSX5nz67ldjdWU7IiJWV7YnTi+U8ljANFMbpbzWnAjKAACMZYpkOOGlWbNOL5TyWMA0r7uU15oTQRkAAOYgvDRr1umFUh4LmOZ1l/JacyIoAwDAHISX5gyOsD/y+PGp/k1JjwVMmtoo6bXmQlAGAIA5CC/NWGSEvabHAmp6rSkQlAEA8KFUcxJeFmeEnRQJygAAlfOhVPTJCDspEpQBACqno0efjLCTIkEZAKByOnr0zQg7qRGUAeicZyEhLTp6ANcTlAHolGchIU06egDvWO57AwCoy7BnIQEAUiIoA9Cp3WchI8KzkABAkoxeA9Cp1J6F9Lz0jbwnANROUAagc6k8C+l56Rt5TwDA6DUAFfO89I28J2VYX9uI+0+ejvW1jb43BSBLOsoAVMt3x97Ie5I/UwEAixOUAahWas9Lp8B7kr9hUwFN70fPsY/mvaEJjqP+CcoAVC2V56VT4j3JW9tTATrWo3lvujFriMwtdDqO0iAoAwAUpO2pgC461m1rMjgN/qwS3pvUzRoicwydjqM0CMoAAIVpcyog9+fYmwxOe3/W1x6+N+v3JgezhsgcQ2fu51gpBGXITG7jQwCUJffn2JsMTnt/1rGjF7N+b3Iwa4jMMXSeOXc4vvbwvXHfF16Kb3/ndsdRTwRlyEiO40MAlCfn59ibDE7DflbO700OZi3U5FjYWV/biG9+43txaPVK3Pf5M9Z7PRGUISM5jg8B8zE9Au1oMjjlGMJKMGsxIrfihfVeGgRlyEiO40PA7EyPMIziSXOaDE65hTDSZ72XBkEZMqJyDXXQTWAvxROoh/VeGgRlyIzKNZRPN4G9FE+gLtZ7/ROUASAxugnspXhCzjw2QI4EZQBIkG7CdGpZgCueMK3UzgmPDZArQRkAyFJqC/C2A4riCZOkdk5EeGyAfAnKAECWUlqApxhQqE9K58Qujw2QK0EZAMhSSgvwFAMK9UnpnNjlsYHxUhuV5x2CMgCQpZQW4CkGFOqT0jkxyGMDw62vbcS3/vTvYnVlOy5tLscDX/+i9ykhgjIAkK1UFuCpBpSa1dqpS+WcYLJTJ87G6sp2RESsrmzH7//PT8f/+/979w37r9ZjuW+CMgBAAwSUdOT8zLhQVK//8d+ejS/8X89dd7zmfCznbrnvDQDatb62EfefPB3raxt9bwokw3kBZRv2zHgOdkPRw//xH+O//MnjrlGFe+yJY3Fp8/o4tvd4zfVYLoGOMhRMFRJu5LyA8rX9zHhbXd/SPxROt/x6Z84djge+/sU4deJsfPUrz8TqyvYNx+uoY9l72T5BGQpW+g0X5uG86J8FHm1r85nxNottJX8onCLlcGfOHY6//Os747Enjg09Xocdy97LbgjKULCSb7gwL+dFvyzw6Epbz4y3WWxL5UPh2ihm9VWkzKUwN+543fu/Kfh2Q1CGgqVyw4WUOC/6ZYFH7toutvX9oXBtFbP6KFKWWphT8O2GoAyF6/uGCylyXvTHAo/clV5sa6uY1cf7VmphrvRjMBWCMgDQGQs8SlBysa2tYlYfI9AlF+ZKPgZTISgDScvl2SJgehZ4kK42ill9jUArzLEIQRlIVqnPFgFAypouZvU5Aq0wx7yWJ/8VgH4Mu7ECQGnW1zbi/pOnY31tY67/PXW7I9ARUdwINOXSUQaSVfKzRQBMVsPjN5Omp0qYrjICTY4EZSBZbqwA9SohIE5j0lhyKZ/cbASa3Bi9BpJ25tzheOTx426uQBFyH6HtUi2P30waSza2vBjnHPPSUQYoQA3jiZC7LjukJVwTann8ZtL0lOmq+dUylRBRxjmfGkEZIHM1LQQgZ12N0DZ9TehrAV5TQJw0lmxseT6ljK1PYh3QDkEZIHO1LAQgd111SJu8JvS9ABcQ2WuWwk0tUwnWAe0QlAEyV8tCgPkYx0tHVx3SJq8JFuDjLXp+OT9nM2vhZpZzLud9Mcs5n/Pr7JqgDJC5msYTmU3f3UButLdD2saitclrgkLcaIueX87P2c1TuJlmKiH3fTHtOZ/76+yaoAxQAOOJDKMbmLY2F61NXRMU4kZb9Pxyfs6urcJNCftimnO+hNfZJUEZAAqlG5i2XBatCnHDLXp+OT9n11bhppZ9UcvrbIqgDACF0g1Mm0VrM3L9VG7n53zaKNzUsi9qeZ1NEZQBoGC6gemyaF3csPH1iOjsPV30/HJ+pqPvfdFVwafv15kTQRkAoCcWrYvZO75+6sTZeOjBZ31Y0ZR8AnIafMhWmgRlAACytHd8PSIaee67hgApnKUjl88rqI2gDABAlvaOr0fEdR3leZ77riVACmfp8HkFaRKUIWM1VLwBYJy94+uLPvddS4AUztLh8wrSJChDpmqpeAPALBZ97ruWACmcpcXnFaRHUIZM1VLxrokJAYD+1RQgpwln4+5N7luUTFCGTNVS8a6FCQGAdOjuXTXu3uS+RekEZchUTRXvGpgQACA14+5N7luUTlCGjKl4l8OEAACpGXdvct+idIIyQAJMCAA0w3OzzRl3b3LfonSCMkAiTAgALMZzs80bd2/K4b6lcMK8BGUAAIrQ1XOzwlceFE5YhKAM9M6CA4AmdPHcrPDVr1nWDD5wjEUIykCvLDgAaEoXz80KX/2Zdc3gA8dYhKAM9MqCA4Amtf3crPDVn1nXDH1/4JiJubwJykCvLDgAyEnf4atm86wZ+vrAMRNz+ROUgc7trbBacJAr3QKoUw6f9lyinNYMJubyJygDnRpVYXXzIDe6BQDdy2XN0MbEnOJstwRloFMqrJTCsdwvC0YgZU13vxVnuycoA53yTDKlcCz3x4IRyMGs3e9xBUDF2e4JykCncnq+qES6cM1xLPfHghEozaQCoOJs9wRloHO5PF9UGl245jmW+2HBCJRmUgFQcbZ7gjJAJXThKIUFY1pMqsDipikAKs52S1AGqIQuHCWxYEyDSRVohgJgegRlgEq4CUM9uurymlS5SledJigApkVQBqiImzCUr8sur0kVXXUolaAMAA3SWaJvXXZ5TaroqkOpBGUAaIjOEn3aLdKcPX+o0y5v7ZMquupQJkEZaIWuGjXSWaIve4s0X3v43jh29KJrcAd01aFMgjLQOF01aqWzRJNmKTjuLdIcO3oxHnn8eBebSeiq0wxNhrQIykDjdNWolc4STZm14KhIA3nTZEiPoAw0zoKNmuks0YRZC46KNJA3TYb0CMpA4yzYABYzS8FxcFzTuDXkSZMhPYIy0ApdNaApNT63N23B0bgmlEGTIT2CMgAkqsaAuFfNQXCagqNxTSiHJkNaBGUASFDNAXFQ30Ew9WKFcU2AdgjKAJCgvgNiKvoMgjkUK4xrArRDUAaABNXaKdzbwe0zCOZSrDCuSQ1GTXekPvVBvgRlAEhQjZ3CUR3cvoJgrcUKSM2oa0MOUx/kS1AGgETNGxBz7bCk1sHtq1iR6/5jtJz3aQrbPura0NQ1I4XXSHoEZQAoSM4dlhQ7uF13s3PefwyX8z5NZdtHXRuauGak8hpJj6AMAAVJrSs7ixrHzffKef8xXM77NJVtH3VtaOKakcprJD2CMgAUJMWu7Cxq/2Cq3Pdfqvocrc15n6a07aOuDYteM1J6jaMYDe/H0j1f/vJOl7/wytZW/NO3vx2/et99se/AgS5/NQBUwaIqb/Zfs1IYrc15n+a87dNK+TWmcPyWYtYcqqMMAIWpvSubq8HF+iOPH+97c4qRwmhtzudk6tveRMhN+TWmcPzWSlAGAOiZrlF7FhmtTbnTSB3nTQ6j4aUSlAEgU10s4gWFbugatWfeD3yqIYTlrobzZvD4PXv+UHz67lev/XfaJSgD0CpBqx1dLOIFhe7oGrVrntHaGkJY7mo5b3aPO9fjbgnKALRG0GpPF4t4QaE7vhorPbWEsJzVdN64HndPUAYgItrp/LqxT2ee976LRbyg0K2UP1CoRtOGMFMz/erivElhH7sed09QBoqUwk0tJ211ft3YJ5v3ve+ik1JTtwaGmRTCmr52unelJ5XJKNfj7gnKQHFSuanlpK3Orxv7ZIu89110UnQ5YbQmr53uXWlKaTLK9bhby31vAFCn9bWNuP/k6Vhf22j8Zw+7qTHebuc3Ihrv/J45dzgeefy4m/sI8773bZ5DwHSavHa6d6WpzfsjadNRBjrXdtXcuO/sdH77M897r/MEaWjy2unelSb3x3oJykDn2h5j6uqmVtqzZEa6+jPre5/SKGCNSjv3WUxT106BLF1N3h9dP/IhKAOd66Jq3nbo09GjTzpP/XHu06a27l3CWRomXT/sp7QIykDncqya77156ejRpxzPoVI498lNKcWdEkLkuOtHKfupJIIy0ItRVfMUb4TDbl46ejRhkePdqHw/nPvkpoTiTikhctz1o4T9VBpBGUhGqjfCYTevRx4/PrGjl2LoJx2pHu+MN6yb39a57hpCE0oo7pQSIsdNA5Wwn0ojKAPJSPVGOOrmNa6jJwQxSarHO5MNnvttneuuIdNRTJishEc1SgqRo9YOJeyn0gjKQDJSvRHOc/MSgpgk1eOd2bR1rruGTKaYML3cH9WoJUTmvp9KIygDyUj5RjjrzUsIYpKUj/ecdd1hbOtcdw2ZLIVigo52d4RIuiYoA0kp5UYoBDGNUo73VPTRYWzrXM/xGlJKkWJaOtpQNkEZoCVCEHSrrw5jW+d6TteQkooU00qhow20R1AGAIrQd4exZqUVKabheIOyCcoAQBH67jDWrMbQ6HiDsgnKAEAxchpXLkmtodHxBuUSlAEAWNg8oXHeDwDzadNA2wRlAAA6N+8HgPm0aaALy31vAAAA9Rn2AWBt/juAWQjKAAAtWF/biPtPno71tY1ef0aqdj8ALCJm+gCwef8dwCyMXgMANKyJ8eDSR4zn+QCw3WeTv/bwvXHs6EXPKAOtEZQBAOY06kOlmvhe4b6+m7hLs3wAWOmFAyAtgjIAzMkn79ZtXHBr4nuFa/xu4nFqKBwA6RCUAWAOuluMC25NfK9wrd9NPIrCATVRiO2foAwAc9DdSk/XC8tJwW3aseJx2z3PdxOXSuGAWijEpmGmoHzuuefijZdfjs2f/zyW9+2Lm265JT5w992x+u53t7V9QCJUNuF6ulvT6+L60cfCsongZkE8G4UDcjbttVAhNg0zBeWNV1+N9//Kr8RN731v7OzsxMs/+lH85LvfjY9+8Yuxb7/mNJTKQg5upLs1na6uH30tLBcNbhbEaVEUpi2zXAsVYtMwU7r98Oc+d92fj3/qU/HU3/xNXLxwId71/vc3umFAOizkYDjdrcm6un7kurDMdbtLpChMm2a5FirEpmGhNvCVra2IiNh38ODIv7N95UrsbG/f8G+AfFjIAfPq6vqR68Iy1+0ukaIwbRp1LRw1xaAQ27+5g/LOzk6c+ad/iptuuSUOHTky8u+df/75OPfss/P+GiABFnLAvLq8fuS6sMx1u0tTc1HYyHn7hl0LTTGkbe6gfOYHP4hLb74ZH/m3/3bs3zt6551x6x13XPvzla2t+NGjj877a4GeWMgB8yrp+iFQlKvWorCw1p2910JTDGmbKyi/9IMfxJs//Wnc8Zu/GQcPHRr7d5f37YvYt2+ujQOAFAhHRAgUNSipqDMtYa0/NU8x5GCmoLyzsxNnfvjDeOPll+Mjv/EbsXLYSQRA2YQjdgkUlEhY60+tUwy5mCkon/nBD+L1l16KX7n33ljevz+2Ll2KiIh9Bw5c7RwDQGGEI3YJFJRIWOtXjVMMuZgpKL/6wgsREfHj//bfrvvvH/zUp+KW48cb2ygASMW4cGQkuy4CBaUS1uBGMwXle7785ba2AwCSNCocGcmu06KBQnEFIA8LfY8yQGksYhlmWDhKaSTbcZsHxRVylPL1JeVtI3+CMsAvpbiItQhIVyrPq6Z43DJcSsUVmMb62kZ860//LlZXtuPS5nI88PUvJnPMuvbRNkEZ4JdSW8RaBKQtledVUztuGS2V4gpM69SJs7G6sh0REasr23HqxNn4y7++s+etusq1j7YJygC/lNoi1iIgfX19AM7gpEFqx+04tU9IpFJcgRLkdO0jT4IywC+ltoi1CGCYYZMGKR23u/aGYhMSV/l0YQWTnDz2xLH46leeuTZ6/dgTx/repGtSu2dTHkEZYEBKi1iLAIYZNmnwyOPHkzo+hoViExJEeKQkN2fOHY4Hvv7FZO9DKd2zKY+gDJAwiwD2ymHSYFgozmG7aZ+CSX7ch6iVoAwAGclh0mBYKE5hu4383qjr90TBBMiFoAzwSxbR5CL1Ds+oUNzndhv5vVEf70kKBROAaQjKAGERDU1LLcwb+b1RX+9JascGwDDLfW8AQAqGLRhrs762EfefPB3raxu9/gzK1tcxsjvyGxFGfn/Je1IX12eYjY4yQHhuromOuq78ZLWP9/d5jBj5vdE870ntx3CuXJ9hdoIyMJXSF0e1L6KbGME02jqehWr/x4iR3xvN8p44hvPV97kHORKUgYm6Whz1HcZrXkQ30VGvvSs/iYWqYyR3juF8OfdgdoIyMFEXiyOdin410VGvvSs/iYWqYyR30xzDTRc8+y6glsK5B7MTlIGJRi2OmlzA6FT0r4mOei1d+XmOfQvVq2o5Rko06RhuuuCpgNos5x7MRlAGJhq2OGp6AaPbRi5GHfvThGcLVXI37hhuuuC59+f97gPPxV986y7nUMd09amVoAxMZe/iqOkFkW4buRj1VWI6X/2xkE9D0wXPwZ+3sxPxwG+djvs+f8b51SFdfWomKANzaaMDrNtGDoYd+x4d6I+FfDqaLnju/rzffeC5eOC3TkeE86trrm3UTFAG5qIDTK1GHfseHehHqQv5XLvkTRc8z5w7HH/xrbvivs+fcX71wGNR1ExQBuamA0yt9h77Ckf9KXEhr0t+PedXf7z31ExQBoAGKBz1o8SFfKld8kU4v/rjvadWgjIAkLXSFvIldslnlevo+a6+t7/v3w8lEJQBgCRY3F9VYpd8FrmPnve9/X3//lS4nrAoQRkAMlTaItDi/nqldclnkfvoed/b3/fvT4HrCU0QlAEgMyUuAi3u2ZX76Hnf29/370+B6wlNEJQBIDMlLgIt7tmV++h539vf9+9PgesJTRCUASAzJS4CLe4ZlNLo+TSPOez9O31v/97fX9qjGpO4ntAEQRkAMlPqIrDtcJFKWEhlO2qw6Hs9zWMOqT8Kkfr2taXvYgX5E5QBIEMWgbNJJSyksh01aOK9nuYxh9QfhUh9+yBVy31vAFCm9bWNuP/k6Vhf2+h7UwCGhoWat2NeOV3bm3ivdx9ziIiRjzlM83f6lPr2Qap0lIHG6ZjAfIzktieV57pT2Y555HZtb+K9nuYxh9QfhUh9+yBVgjLQuL1V/FMnzsZf/vWdPW8VpC23EJKb3bBw6sTZJLajidDSdWEltxHept7raR5zSP1RiNS3D1IkKAON+/7T74tLm8uxurIdERFf/coz8dgTx9ykYYzcQkiuvvqVZ2J1ZTu++pVn4oGvf7GX97iJ0NJHYSXHbriACMzLM8pA486cOxx/9lcfu/bn1ZXt7J7Dg655jrA9u8/V/vb/7YVrBbzVle2h3eVcnsHt41nn3Q7tN/7kUyYegOLpKAONGRwDfOyJY/HQg89m1XmAPnmOsB2DndetraWp/27q4+99dXd1aIFaCMpAI4YtMC36J/PhTQwSQpo32Hk9cGAnLm8txcEDO3Fpczkee+LYyL+b+vi7wgpAuwRloBHDFpiPPH7c4m2MnLpXkKu9ndevPXxvHDt6cWi4zO0ZXIUVgPYIykAjcltgpiCn7hXkaljn9cmnpv+7ANRJUAYaYYE5O8WFchmpT8ssnVddWgAiBGWgQRaYs1FcKJORegDIn6AM0CPFhfIYqQeaUvp0Sumvj7wJygAVsBjpTioj9ans81S2Y1CK2wR7lT6dUvrrI3+CMrAQC870WYx0K4WR+lT2eSrbkfo2wTClT6eU/vrIn6AMzM2CMw8WI93re6Q+lX2eynakvk00r4QibirTKW0p/fWRP0EZmNrehYcFZx4sRuqTyj5PZTtS3yaaVUoRN4XplDa1/fpKKJbQL0EZmMqwhYcFZx5KX2w1qZSFVSr7PJXtSH2baFZJRdy+p1Pa1tbrK6VYQr8EZWAqwxYejzx+3IIzE6UvtprQxMIqpaCdyj5PZTsGpbhNNEcRl5KKJfRHUAamMmrhMbjgTCkk0L3c9/+iC6u+Ohi5v+/QNFMDKJbQBEEZmMqkhYcxp/LMEsBK2P+LLqz66GCU8L5DG0wN1G3YmkVRkVkJylCoNm4I4xYeJY05uZnOHsBK2P+LdqH66GDsfd9/94Hn4i++dVd27z3Ncf2Cq/ZOvH3rT/8uVle249Lmcjzw9S86P5hIUIYC9dFlGhYSclyw6dBdNWvwLWXMbZEuVB/jnoPv+85OxAO/dTru+/yZao/b2rl+wXCnTpyN1ZXtiIhYXdmOUyfOxl/+9Z09bxWpE5ShQH109/aGhIjIcsFWQme0CbMGX88EXtX1uOfu+/67DzwXD/zW6Yio+7it3akTZxd+zr72cxhgl6AMBeqruzcYEu4/eTrLwFlKZ3xR8wRfzwT248y5w/EX37or7vv8mew7+sxvfW0jvvqVZ679+dLm8kzHgW40JXvsiWPx1a88c230+rEnjvW9SWRAUIYCpdDdy3UUt5TOeBME3+mkUEhJ4ZynX5+++9Vro6UREX/2Vx+b6TgwTUPJzpw7HA98/YuukcxEUIZC9R1ycl64l9AZpxspdeH6PudLlEIRZFp7i5OzdsxyLW7CtFwjmZWgDLQm5ZvStAtgi0fG0YUrV0pFkGksWpzMubgJ0AZBGajOLAtgi0fGUUgpV45FkEWLkykXNwG6JigD1Zl1AWzxyCgKKfkxTQLANARloDoWwNPJ6fnMPimk5MM0CQDTEpSB6lgAT5bb85kwjXmnSdbXNuL+k6ddLwAqIigDVdIFHC/H5zNhknmmSVItGpn4AGiXoAzADYynU6J5pklSLBqlGt4BSiIoA72YthuiazKfRd834+ll6eM8mvQ7+zq3Z50mSbFolGJ4J1/uszCcoAx0btpuiK7JfJp634ynl6GP82jS7+xrm+YJAykWjVIM7+SphPusoE9bBGWgc9N2Q3RN5uN9Y1Afx8Ok39n1Ni0aBlIrGqUY3mleFwEw9/tFCUGfdAnKQOem7YbomszH+8agPo6HSb+z623KPQwMk1p4b1rtXcKuAmDu94sSz23SISgDnZu2G6JrMp9c3rfaF8Jd6eN4mPQ7u96m3MNAbXQJuwuAudwvRnFu0yZBGejFtN2Q0rsmbUn9fbMQ7lYfx8Ok39nlNuUeBmqjS9htAEz9fjGOc5s2CcoAdM5CmK7lHAZq00ZIzG2C5cy5w/G1h++N+77wUnz7O7dnsc19cW7TFkEZgM4ZlwNGabpLmOMEy/raRnzzG9+LQ6tX4r7Pn8lim6E0gjIAnTMuN15u3S9oWpNdwhwnWHLcZiiNoAxAL4zLDZdj9ytCuCddOU6w5LjNUBpBGQASkmMnKddwTx1ynGDJcZuhNIIyACQkx05SjuF+Ebrn+clxgiXHbYaSCMoAkJAcO0k5hvt56Z4D1EFQBoDE5NZJyjHczyul7rnONkB7BGUAYGG5hft5pdI919kGaJegDAAwpVS65yl1tgFKJCgDwADjrEySQvc8lc42QKkEZQD4JeOs5CKVzjbXU2iDcgjKAC2zcMqHcVaa1ub5n0Jnm3cotEFZBGWAFlk45cU4K01y/tdlb6Ht1Imz8fqbK4qkkClBGaBFOpRX5dJVL32cNZf9UIomzn/7LB+DhbZLm8vx1a88E6sr24okkClBGaBFOpTDu2oRkeziv9RxVt3N7i16/ttneRkstN18ZDP+4Heejoi6i6SQM0EZoEUldyin7XQNG0d86MFnLf47Zrqhe4ue//ZZfnYLbetrG9dd52oskkLuBGWAlpXYoZyl07W3qxYRFv89MN3Qj0XO/0X2mZHtfpVcJIVaCMpANSwcmzNLp2vvgjEidFp6YOGen3n3mZHtNJRYJIWaCMpAtmYJvhaOzZq107V3wSiw9SPXhXvNRa559pmRbYDFCcpAlmYNvhaOzVq0O5lrYKM9o8KwItfsjNkDLE5QBrI0a/C1cGyesEtTxoXhWotci3TRjdkDLE5QBrI0z+ivhSOkaVwYrrHI1UQXXSGLNtX8OAT1EJSBLM0TfC0cIU3jwnCNRa5au+gsrosA63EIaiEoA9kSfPOiA8Eok8Jwbed6jV10FtdVgFXIoRaCMgCty7UDMe4DpoT+ZtUWhsepsYvO4roKsAo51EJQBqB1OXYgRoX7XEM/eVE4YFZdBViFHGohKAPQuhw7EKPCfeqhX7cb6jwPugywCjnUQFAGoBHjFqY5diBGhfuUQ79uN9R9Hgiw0BxBGYCFTbMwzW0BNyrcpxz6++h219i5I22pT30AeRCUAVhYqQvTUeE+1dDfdbe7686dUM40Up76APIhKAOMYFE+PQvTNHTd7e6yQFLzOC2zSXnqA8iHoAwwhEX5bCxM09Flt7vLAkmpUwu0I9WpDyAfgjLAEBbls7MwrU+XBRJTCwB0SVAGGMKinLaVMtrfVYHE1AIAXRKUAYawKKdNRvvnY2oBgK4IygAjWJTTFqP9AJC25b43AABqszvaHxFG+wEgQTrKAC0p5RnUWnS5v2of7e/yvXYeAjAPQRmgBZ5BzUsf+2vYaH8boS61oNjle+08zFdqxy2T2WeURlAGaIFnUPOSwv5qI9SlGBS7fK+n+V0W9+lJ8bhlPPuMEnlGGaAFnkHNSwr7a1ioS/FnLqrL93rS79pd3D/8H/8x/sufPB7raxutbQvTS/G4ZTz7jBLpKAO0oPZnUHOTwv5q47u7U/w+8C7f60m/K4VJgj6l2k1P8bhlPPuMEi3d8+Uv73T5C69sbcU/ffvb8av33Rf7Dhzo8lcDQNJqeEZ5Fm1ve83joqm/9pyP21rZZ6Ru1hyqowwAiWjju7tz/T7wLoJcCpMEfUm9m973cSv0za7vfQZNE5QBaI3FJvPqKsjVurhPfVS2z2tH6t12oBuCMgCtSHWx2dQCXBGgXakHudyl3E3v+9qRYrfd9Qa6JygD0IpUF5tNLMD7XsjXIOUgV4pUu+l9XztSK9LUeL1RGCAFgjLAAtzMR0ttsRnR3AK874V8V/o+vlMNcrSr72tHakWaWq43u2osDJAmQRlgTm7m46W22IxobgHe90K+C45v+pLCtSOlIk0N15tBtRUGSJegDDCj3S7bzUc23cwnSGmxGdHcAnzen9N3h3YWFqv0KbVrR59SKBx0qbbCAOkSlAFmMNhlu7S5HJc2l2N1ZdvNPCNNLcBn/Tm5dWhLWqzmVKCAYWoqHNRWGCBdgjLADAa7bKsr2/Gf/vPd8fqbK27mTJRbhzaXxeqkEJxbgQJqtfdcdp7SN0EZYAZ7u2yPPXHMzZyp5NihTX2xOk0Izq1AATVS0CJFgjLADHLpspEex07zpgnBORYooDYKWqRIUAaYUepdNtJVwrGT0vO+04RgBYr8pXTM0Q4FLVIkKAPQiMHFbERY2BYotfHIaUNwCQWKWqV2zNEOBS1SJCgDdKD0jsjeTwOPiGufBp7jwrb0/RUx32vsYjxy1u0SgstmJLcezmVSIygDtKyGjsjeTwPflePCdnB/Xd5ajof++EQ8+dStfW9Wo+Y9Jtsej6zhXJlGDYWaaRnJBfoiKAO0rIaOyOBidm9HObeF7eD+OnhgO/78j74b//73TxW1z+Y9Jtsej6zhXJlk73TGn/3Vx6r+dH0juUBfBGWAltXQEdm7mI3I9xnl7z/9vri8tRwHD1ztjB88uFNcYFvkmGxzPLKGc2WSvdMZf/A7T8dDDz5bbXc9wkhuqUxOkDpBGaBBw278tXRE9i5mc32dZ84djof++ET8+R99Nw4e3CkysKVwTNZ8rowzWCzYVWt3PUfC33Q8ZkEOBGWAhoy78euI5OXJp26Nf//7p4pe8PZ5TDpXRtstFpw6cTa++pVnsn2EoUbC3/Q8ZkEOBGWAhrjxl6X2wNYm58p4Z84djr/86zvjsSeOFV2sKY3jenoesyAHgjJAQ9z4y9T1KGUNo5vOleko1uTFcT09j1mQA0EZoCFd3/hrCFR963qUspbRTYtkSuS4no1CEKkTlAEaMBhaH3n8eCe/r4ZA1beuRylrGt20SKZEJR3XirHUTlAGWFAfobWmQNWnrkcpjW52QwCA8RRjQVAGWFgfoVWg6kbXo5RGN9snAMBkirEgKAMsrI/QKlDNbt4u4qKjlLP+3pJGN1PUdgDQraYEirEgKAMsrK/QKlBNr68uou5letoMAPY3pVCMBUEZoBFCa9r6GiMscXwx945pmwGgxP1NvdzXqJ2gDEDx+hojLG188TOfeCX+/I++GwcP7mTdMW0rAJS2vwFqJigDULw+x+NLGV9cX9uIP//jJ+LggZ2I0DEdpqT9DYNynySBeQjKAB2y2OhPX2OEpYwvfvruV+Pgge1rf758eUnHdIhS9jfs8uw9tRKUATpisUGXmi7KDI4VX95ajof+nyccv1ABz95TK0EZoCMWG3SljaKMsWLoVioTSJ69p1aCMkBHLDboyt6izKkTZ+Mv//rOhX+usWIWkUrwy0FKE0iKZNRKUAboiMUGbdkbQL7/9Pvi0uZyrK5cfab4q195Jh574phjjt6kFPxy0NQEUlPFCUUyaiQoA3TIYoOmjQogf/ZXH4s/+J2nIyJidWXbqH9hcuvOevRkNk1MIKVUnMjteIUIQRmASpS6UBsVQB574lg89OCzRv0LlFIAmpZHT2bTxARSKsWJHI9XiBCUAahAyQu1UQHEqH+5UglAs3A8zm7RCaQuixPjCpE5Hq8QISgDUIGSF2rjAohR/zLl2p11PHarq+LEpEJkrscrCMoAFK/0hZoAUhfdWabVxbVhUiHS8UquBGUAimehVp5SnzmfluIIqZimEOl4JUeCMgBVsFArR8nPnNOs2gsqXVCIpFSCMkAiLOhgOiU/c05zFFS6s1uIXF/biPtPnnYfowiCMkACLOhgeqU/c86N5ikkNlFQaaKAWUsR1H2M0gjKAAnQIYPpGfWsy7wBbNGCShPBr6bw6D5GaQRlgATokMFscnrmfNGOYi0dyVHmDWCLFlSaCH7z/owc97n7GKURlAESoEMG+RoXahbtKNbUkRxlkQC2SEGlieA3z8/IdZ+7j1EaQRkgETl1yICrJoWaRbuSuYyzttkB7SuANfF75/kZuezzYdzHKImgDAD0JscR00GTQs2iXckcxlm76ID2FcCa+L2z/owc9jnUQFAGAHqRy4jpuDA/KdTM2lHc+7tyGGddpAOae6GkDTnsc6iBoAwA9CKHEdNJYX6aUDNtR3HU70p9nHXeDmguhZI+zLPPFR2gWYIyAHOxKGNROYyYThPmmwqyORQOhpm3A5rr602RogM0T1AGYGZdLsoE8vFyfn9yGDEdFubbes9zKByMMk+xIOfXuyuV80/RAZonKAMws64WZcMC+e7v73thmoISukipjxXvDfMR0dp7nkPhoEm5v96Uzr8Sig6QGkEZgJl1tSjbG8hPnTgbDz34bBIL0xToInVjMMzff/J0q+956oWDpuX8elM6/3IvOkCKBGUARho1VtjVomxvII+IZBamKcihi5TKaGpTcnjP6UZqx0LORQdIkaAMUKFpwss0n/bb9qJs2NjrYEe574Vp31LvIqU0mtqU1N9zuuNYgLIJygCVmTa8pDJWuDeQW5heL+UuUirHUNNSfs/plmMByrXc9wYA0K1h4WWY3bHCiOite7u+thH3nzwd62sb1/7bmXOH45HHj1ucZiCFYwhSMOxaBqRNRxmgY30/szntc3V9jxWWOLZbm76PIUiBaxnkaa6g/LOf/CTO//M/x9ubm3HoyJFY/7Vfi5tuvrnpbQMoTgoLplnCS59jhaWO7eaiqYJO18dQ34Uo2Mu1DPI0c1B+/cyZOPvUU3H7L8PxKz/5Sfzku9+Nj546FQdWVtrYRoBipLJgyuG5utQ+UbYmKRR05pHrdpOeJgsurmWQp5mD8s/++Z/jln/zb+KWf/NvIiLi9nvuiTfPnYvXXnwx1u66q/ENBCiJBdP0jO32J5WCzqxy3W7S0nTBxbUM8jRTUN7e3o633ngjjg4E4qWlpXj3rbfGW6+/PvzfXLkSO9vb1/58ZWtrzk0FyJ8F02xGdb6N17Yr14JOrttNWtoouOQwxQNcb6agfGVzM2JnJ/bvGbHev7ISmz//+dB/c/755+Pcs8/Ov4UAhbFgWsws3Z4mA3VN4TzXgk6u201aFFyAiA4+9fronXfGrXfcce3PV7a24kePPtr2rwWgUNN2e5ocn6zt2ddxRYHUCwYKUSxKwQWImDEo71tZiVhairc3N6/7729vbsb+1dWh/2Z5376Iffvm30IAGDBtt6fJ8cmann0dVxSorWCQk9QLGLlRcAFmCsrLy8tx03veEz9/5ZV4zwc+EBEROzs78YtXXon3/cqvtLKBADBo2m5Pk+OTNY1ijisK1FQwyIkCBkDzZh69fv9HPhL/+v3vx03vfe/Vr4f68Y9j+8qVuOX48Ta2DwBuME23p8nxyZpGMccVBWoqGOREAQOgeTMH5ZvX1+PK5mb89Jln4u3NzTh05Ej8yokTcWDE6DUA9KXJ8claRjHHFQXmKRgYCW6fAgZA8+b6MK/3f/jD8f4Pf7jpbQEAEjCuKDBLwcBIcDcUMACa1/qnXgMAdTIS3B0FDIBmLfe9AQBAmXZHgiMiLl7aF2fPH4r7T56O9bWNnresbsMKGABcT0cZgOoYO+3G4Ejw2fOH4pvf+J4u5gzaOk4905wW1yNIk6AMQFWMnXZrdyT4/pOnkxzDTjWktHmc1vQp7qlzPYJ0CcoAVMVzs/1IsYuZckhp+zit5VPcU+d6BOkSlAGoSoqBrQYpdjFTDimO0zpMu59TnXyAkgnKAFQlhcDWxaI3xYV1al3MlMNoCscp7ZtmP6c8+QAlE5QBqM5uYFtf24j7T57uNIh0sei1sJ5O6mG0rcJCikWU3DT5Hk7azylPPkDJBGUAqtRXmOxi0WthPb3UutxtU0RZXNfvYcqTD1AyQRmAKvUVJrtY9FpYM4oiyuK6fg9Tn3yAUgnKAFSprzDZxaLXwppRFFEW18d7WNvkA6RAUAagSn2GyS4WvTUurD17O5kiyuK8h1AHQRmAas0bJgWy8fp4fzx7O70aiyhNa/o9dE2B9AjKADADgWy8kj8kDdrgmgJpWu57AwCo0+5XM62vbfS9KTMZFsh4R1/vz+5zoxHh2Vuy4poCadJRBqBzOXdQSv8wpEVHQEv+kDRoQ+nXFMiVoAxA53Ieky05kDVRwCj9Q9LaVsOzqk29xlLeq5KvKZAzQRmAzuXeQSkhkA3TVAGj1PenbTlPWkyrqddY2nvlnIH0CMoAdK7UDkruHa7cCxi5y3nSYlpNvcYa3iugX4IyAL0orYMyqcOVQ4gutYCRqr3HRA2FiqZeYw3vFdAvQRkAGjCuwzUsRO/+m9QCaWkFjFSNKqyUXqho6jXW8F4B/RKUAaAB4zpce0P0qRNn46EHny3m+cp55dBlb8uowkruhYpp9mlTrzH39wpIm6AMAA0Y1+HaG6IjovrnK0v7MKZZlTg6XPs+BcoiKANAQ0Z1uPaG6Ii4rqOcS0hqsgNc+4cxlTg6XPs+BcoiKANAy4YFzNxCUtPdwhI7qrMqbXTYPgVKIigDQItGBczcQlLT3cISO6q1s0+BkgjKANCiUsZR2+gW5lYsaENpH2jW1T4t7X0D0iMoA0CLShlH1S1sng+/mk8T75ugDUwiKANJs5ghd2fOHY6vPXxv3PeFl+Lb37k96+N4nm6hc3i0UqYNurbI+7a+thGnTpyNr37lmVhd2VagAEYSlIFk6bZQgvW1jfjmN74Xh1avxH2fP1PVcewcHq/raYNSihbzvm+Dx+OuRQoUpbyfwHCCMpAs3RZKUPNx3OZrLyGkdDnOXlLRYt73bfB43DVvgaKk9xMYTlAGklXKs53UrebjuK3XXlJI6erDr0or2Mzzvg0ej5c2l+PP/upj8dgTx+Z6H0p7P4EbCcpAsnx4EE3ou/NY83Hc1mtvKqT0eWx0/btrLtjsavJ49H5C+QRlIGm+PoZFpNJ5rPk4buO1NxFS+jw2+vjdqRVs+ipSNHU8pvZ+As0TlAEolvHIMjURUvo8Nvr63akUbFIpYC0qlfcTaIegDECxjEeWa9GQ0uexkeNx2WQHWAELyIGgDMDC+n4OeBTjkYzS57GR03HZxvcO51goAOojKAOwkNTHKI1HMkqfx0YOx2XT3zu8K6dCAVAvQRmAhRijhMlSnboYp8nvHd4rh0IBUDdBGYCFzDpGmWNgYDz7dLzUpy5GafJ7hwFyIygD7GHRP5tZxihzDQyM1sc+ze0czXXqYtpzO7f9ATANQRlggCA3n2nHKHMNDIzW9T5N7RydJiSm+uFV02z7pHM7tf0B0BRBGWBATkEuxy5OqoEhNaP2bYr7vMt9ur62Eb/7wHPJnKPThsQUP7yqqYCb0zUTYBaCMsCAXIJcrl2cFANDakbt21T3eVf7dPD17+xELC0198FSg79jlteRc0hsattzuWYCzEpQBhiQS5DLeYHu027HG7VvU97nXezTwde/tBTxrb89Hn/xrbsa+73zFCKmDYkpFjmaCri5XDMBZiUoA+yRQ5DTxSnXqH1b+z7f+/qbDMkR8xWfpg2JKRY5mgy481wzU3yMAGCQoAyQuGELSl2cco3at7Xv80U/gXlSMJu3EDFNSEy1yNFXUTDFDjvAXoIyQMLGLShz6Hwzn1H7tvZ9Pu8nME8TzMYF8UW7nykWOfrs6KbYYQfYS1AGSFhtC0rjmOlKbd8M255pn+8+deJsvP7myg2vZVgQb6r7mVKRo++ObqoddoBBgjJAwmpaUPa9eGe0wX1zeWs5HvrjE/HkU7cmsT2Dx8o0z3df2lyOr37lmVhd2Z7qOCuxWNX0axosWuz+/Enfzdxkhz21Ig5QBkEZoAFtLdRSHNlsS4mBpBSD++bgge348z/6bvz73z/Vyf6ZpXM8zfPdNx/ZjD/4nadv+LejlFisavI1DRYtLm0uR0RMVYRoqsOuwAa0RVAGWFDbC7WURjbbVGIgKcX3n35fXN5ajoMHtiMi4uDBnU4KGbN0jgcD9SOPH7/hZ+2eR+trG/HQg89OfZwtWqxKsdvZZAFusGixurJ97b93VexSYAPaIigDLMhCrRk1dc9zc+bc4Xjoj0/En//Rd+PgwZ3OChnTdo4jYupi1TzH2bzFqpS7nU0V4PaOtUe801Hu4hhRYAPaIigD1Vu042Oh1pxauuc5evKpW+Pf//6pTgsZ486twWPl/pOnxxar9p7jixxns1wv+iiidd3B3lt4uO39b8V9X3gpvv2d23v5/a4fQFMEZaBqTXR8LNSoxeAzwoN/bvP3TXNujQvUTXZ1Z/1ZXRfR+upgD461f/Mb34tDq1fivs+fmer3NxHsFdiANgjKQNUmdXymXcRZqFGDPoLYNOfWuEA9b1d3lg8Rm2e72tD3YyCz/v6UR9MBBGWgal11oqAEfQexcUYF6kld3WGBeJoPEbt8eSnOnj8093a1oe/HQGb9/SkfTwCCMlC1NjpRUKq+g9g8hp3ju+H47PlD10aFBwPxuA8R+9rD98af//ETcfDgdnzzG99LqoA2qYPd9vPLs3bQczyegHoIykD15u1EQW1yfR5/8Bwf7BZfvrwUBw/uRMT1gXjcuX/s6MVrX5OVYgFt1PWsqwmZWTrouR5PQB0EZYARZlnEpfhdqeQll2Mo9+fxB7vFBw/uxNbWUhw4sBOXNpevBeJx536uBbRUJ2RyP56AcgnKAGNMs4jzLDOLauIYyiVo972de7/3dyl2hv69Ued+rl3QXAM+QF8EZYAFpdqpIR+LHkO5FGtS2M7BoHvzkc34g995OiIiVle2p37fc+yC5hrwAfqy3PcGAORut1MTETo1zGXRY2hY0E5RKtt55tzheOTx4/HYE8eqOnd3X7eQDDCZjjLAgnRqWNSix1AuY7VNbuekEe5pRryduwCMIigDNCDHUUzSssgxlEvga2o7J41wzzLi7dwFYBhBGQAKkEvga2I7Jz3T7XMDAFiUZ5QBgKxMeqa7pM8NWF/biPtPno71tY2+NwWgKjrKAECvZv3KqEkj3LmMok+SwqeEA9RKUAYAejNvGJw0wp3LKPo4RsgB+mP0GoCFGQ9lXql8ZVRbFjk3zp4/FJe3ri7Vch8hB8iNjjJAxmYdWW1rG4yHMq9cvtpqHoucG+trG/HNb3wvDh7YjsuXl+JrD9+b3HmVwvUHoC2CMkCmUgmoxkPL0FfoKeV54mEWOTcG/+3Bgztx7OjFePKp1jZ1ZqlcfwDaIigDZCqVgFpyR7AWfYeeEp4nHmaRcyP18yqV6w9AWwRlgEylspAuuSNYC6GnHYucG6mfV6lcfwDaIigDZCqlhXSpHcFaCD3tWeTcSPm8Sun6A9AGQRkgYykvpMmH0MM8XH+AkgnKAIDQAwADfI8yANAq37MNQG50lAEq5ntQaVvfn6gNAPMQlAEq1WSAEbgZxSdqA5AjQRmgUk0FmCYCt6BdLp+oDUCOBGWASjUVYBYN3EZzy+YTtQHIkaAMUKmmAsyigdtobvl8ojYAuRGUASrWRIBZNHAbzQUAUiMoA7CwRQK30VwAIDWCMgC9M5oLAKRkue8NAAAAgJQIygBExNVPn77/5OlYX9voe1PGmmc7c3ltAEAajF4DkM1XNM26netrG3HqxNn46leeidWV7aRfGwCQDkEZgGy+ommW7RwM1btSfm0AQDqMXgNw7SuaImKur2jqarR5lu0cDNW7fP0UADANHWUAFvqKpi7HtmfZzsHvZ760uRx/9lcfi8eeOKabDABMJCgDEBHzf0VT12Pbo7ZzfW3jugDt+5kBgHkJygAsZLBz29do86iutu9nBgDmISgDsJAUOre5fBgZAJAHQRmAhfXduU2hqw0AlENQBiB7i3a19z7fDADUTVAGoAjzdrW7/NRuACAPvkcZgKoNe74ZAKiboAxA1Xafb44IzzcDABFh9BqAyqXwqd0AQFoEZQCq1/endgMAaTF6DQAAAAMEZQAAABggKAMAAMAAQRkAAAAGCMoAAAAwQFAGAACAAYIyAAAADBCUAQAAYICgDAAAAAMEZQAAABggKAMAAMAAQRkAAAAGCMoAAAAwQFAGAACAAYIyAAAADBCUAQAAYICgDAAAAAMEZQAAABggKAMAAMAAQRkAAAAGCMoAAAAwQFAGAACAAYIyAAAADBCUAQAAYICgDAAAAAMEZQAAABggKAMAAMAAQRkAAAAGCMoAAAAwQFAGAACAAYIyAAAADBCUAQAAYICgDAAAAAMEZQAAABggKAMAAMAAQRkAAAAGCMoAAAAwYH/Xv3BnZyciIq5sbXX9qwEAAKjQbv7czaOTdB6Ut99+OyIifvToo13/agAAACq2/fbbEQcPTvx7nQfl/aurcdfJk/Hc44/Hx7/0pdh34EDXm0BCrmxtxY8efdSxQEQ4Hrie44FBjgd2ORYY5Hhg0LjjYWdnJ7bffjv2r65O9bM6D8rLy8tx8NChiIjYd+CAA5qIcCxwPccDgxwPDHI8sMuxwCDHA4NGHg9TdJJ3+TAvAAAAGCAoAwAAwIBegvLS8nKsffSjsbQsp9fOscAgxwODHA8Mcjywy7HAIMcDg5o8Hpbu+fKXp/t8bAAAAKiA0gsAAAAMEJQBAABggKAMAAAAAwRlAAAAGCAoAwAAwID9Xf2ip//2b2Pr4sUb/vv7PvShuP2ee7raDBKxs7MTP33mmbjw0kuxdelSHFhdjVuOH4+jd90VS0tLfW8ePbiytRU/feaZeOPll+Ptzc049J73xPonPxk33Xxz35tGy37xs5/FK//8z/HWhQvx9uZmfOizn433fOAD1/73nZ2dOPfMM/Hqiy/Gla2tOHzLLXH7PffEyrve1eNW04ZJx8KFs2fj1RdeiIsXLsSVra2469/9uzj0nvf0uMW0adzxsLO9HS//6Efx83Pn4vJbb8Xy/v3x7ltvjQ/cfXccOHSo5y2nDZOuDz995pm4cOZMbF28GEvLy3HoPe+J2z7+8Th8yy09bjVtmXQ8DHrp//w/49UXXohjv/qrcesdd0z9OzrrKN/1hS/E3f/D/3Dt/z78uc9FRMR719e72gQScv755+PVF16I9U9+Mj526lR84BOfiPPPPx8/+8lP+t40evKv/8f/ET9/5ZU4/ulPx0dPnox3Hz0aP/7v/31ogY2ybF+5EqvveU/c/mu/NvR/f+Wf/zle+clP4vZ77ok7P//5WN6/P37y3e/G9pUrHW8pbZt0LGxfuRKH3/e++MAnPtHxltGHccfD9pUrcfGNN2Ltox+NO7/whfjQZz8bm7/4RfzL977Xw5bShUnXh5V3vSvWP/nJuOvkyfjIb/5mHLzppvjJd78bb29udryldGHS8bDrjbNnY+O112L/6urMv6OzjvL+lZXr/nz++efj4OHDcfh97+tqE0jIxmuvxXtuuy2O3HZbREQcvOmmuPDSS/HWhQv9bhi92L5yJd54+eX4lc9+Nt71/vdHRMRtH/tYvPnTn8bPXnghPvDxj/e8hbTpyNpaHFlbG/q/7ezsxCs//nGsffSj1yrFxz/96Xjqb/4m3nj55bj59tu73FRaNu5YiIi45YMfjIiIy2+91dUm0aNxx8O+Awfijl//9ev+2/qv/Vo8/7//73H5rbfi4E03dbGJdGjS9WHv/eDYr/5qvHb6dFx888149623tr15dGzS8RARsXXxYpz54Q/jw5/7XPzkiSdm/h29PKO8vb0dr7/0Utxy/Lgx20odvuWW+Pkrr8TmL34REREX33gjNl57LY4cPdrzltGHne3tiJ2dWNq377r/vrRvX2y8+mpPW0UKLr/1Vry9uXndImffgQNx0803x1uvv97jlgGpubK1FRFXrxHUbXt7O1598cVY3r8/Dh050vfm0IOdnZ04/f3vx60f+UisznkMdNZRHvTmyy/Hla2ta5Vh6nP0zjvjytZWPPPYYxFLSxE7O3Hbxz8eNzsmqrQbfM49+2ysvutdsX919eqEwWuvxcrhw31vHj3aHZnbO5W0f2Ulti5d6mOTgARtX7kSLz/9dLz39tsF5Yq9+dOfxov/8A+xfeVK7F9djTt+/ddvuH9Qh/PPPx+xtBTv//CH5/4ZvQTlV198MY4cPerDFip24cyZuPDSS3H8M5+J1SNH4uIbb8TZH/7w2od6UZ/jn/lM/Os//mM8/bd/G7G0FIfe85547+23x0Xj+ACMsbO9HS/+wz9EREx8XpGyHX7/++Ouf/fv4u3Ll+O1F1+MF//hH+Ijn/98HBCWq/LWhQvxs5/8JO76whcWml7uPChffuut+MUrr8SHPvvZrn81CXn5qafi6J13Xnue5NCRI7H11ltx/vnnBeVKrRw+HB/5zd+MK2+/Hdtvvx0HVlfjhb//+zioo1y13U7A25ubcWDggzh2PxkdqNvO9na88Pd/H5ffeivu+I3f0E2u3L79+2Pfu94VK3H1Mb8f/W//W7z24ouxdtddfW8aHdp49dV4e3Mznn700Xf+485OnP2nf4pXfvzjuPu3fmuqn9N5UH7t9OnYv7Iy8eFryrZ95crVketBS0uxs7PTzwaRjH3798e+/fvj7cuX4+fnz8cxn25btYM33RT7V1bi56+8ci0YX9nairdefz3e96EP9btxQK+uheSNjbjjN34j9h882PcmkZqdnaufg0JVbv7gB+Ndez7A7Sff/W7cfPvtMzXkOg3KOzs78drp03HzBz8YS8u9fI4YiThy221x/rnn4uChQ1dHry9ciFd+/GPd5Iq9ef58xM5OrLzrXXF5YyPOPvVUrL773Y6JClx5++24vLFx7c+X33orLr7xRuw7cCAO3nRT3HrHHXH+uedi5fDhOHj4cPz0Rz+KA6urI78vkXxNOhbevnw5ti5evPZ8+qVffiDk/pWV6yYOKMO442F36ujihQvxKydOxM7OzrXjYt/Bg7FsnVmcccfDvoMH4/xzz8WR226LA6ur8fbly/Gzf/mX2Lp0Kd577FiPW01bJt0v9hbOlpaW4sDqaqy++91T/46le7785c5aeD8/fz5+8t3vxsdOnYqVd72rq19Lgq5sbcVPn3km3nj55Wsjle+9/fZY++hH3dwqdeHMmXj56adj69Kl2HfgQLzn2LH4wMc/boyuAr/42c/ix//tv93w32/+4Afj+Kc/HTs7O3HumWfi1RdfjCtbW3H4llvi9nvucR8p0KRj4bXTp+Nf//Efb/jf1z760bjtYx/rYhPp0Ljj4baPfSx+NDhWOeCO3/iNa181SDnGHQ+333NPnH7yydh4/fW4cvnytQ8JXbvrrrjp5pt72FraNul+sdfTf/u3cesdd8Std9wx9e/oNCgDAABA6rTuAAAAYICgDAAAAAMEZQAAABggKAMAAMAAQRkAAAAGCMoAAAAwQFAGAACAAYIyAAAADBCUAQAAYICgDAAAAAMEZQAAABjw/weXlVPiRRla8QAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 1200x1200 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -1364,31 +1785,253 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[2025-03-26 13:57:32,411 hyrax.data_sets.inference_dataset:INFO] Using most recent results dir /home/drew/code/fibad/docs/pre_executed/results/20250326-111626-umap-bFh- for lookup. Use the [results] inference_dir config to set a directory or pass it to this verb.\n"
+      "[2025-04-18 16:38:18,811 hyrax.data_sets.inference_dataset:INFO] Using most recent results dir /Users/mtauraso/src/fibad/docs/pre_executed/results/20250418-163802-umap-BMkM for lookup. Use the [results] inference_dir config to set a directory or pass it to this verb.\n",
+      "[2025-04-18 16:38:18,836 hyrax.config_utils:WARNING] Cannot find default_config.toml for torch.\n",
+      "[2025-04-18 16:38:18,836 hyrax.config_utils:WARNING] Cannot find default_config.toml for torch.\n",
+      "[2025-04-18 16:38:18,837 hyrax.config_utils:WARNING] Cannot find default_config.toml for umap.\n",
+      "[2025-04-18 16:38:18,856 hyrax.data_sets.hsc_data_set:INFO] Checking file dimensions to determine standard cutout size...\n",
+      "[2025-04-18 16:38:18,858 hyrax.data_sets.fits_image_dataset:INFO] FitsImageDataSet has 993 objects\n",
+      "[2025-04-18 16:38:18,867 hyrax.data_sets.hsc_data_set:INFO] Processed 993 objects for pruning\n"
      ]
     },
     {
-     "ename": "RuntimeError",
-     "evalue": "/home/drew/code/fibad/docs/pre_executed/results/20250326-111626-umap-bFh- is corrupt and lacks a batch index file.",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mRuntimeError\u001b[0m                              Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[20], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m \u001b[43mh\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mvisualize\u001b[49m\u001b[43m(\u001b[49m\u001b[43mwidth\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;241;43m1000\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mheight\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;241;43m1000\u001b[39;49m\u001b[43m)\u001b[49m\n",
-      "File \u001b[0;32m~/code/fibad/src/hyrax/verbs/visualize.py:63\u001b[0m, in \u001b[0;36mVisualize.run\u001b[0;34m(self, input_dir, **kwargs)\u001b[0m\n\u001b[1;32m     60\u001b[0m fields \u001b[38;5;241m=\u001b[39m [\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mobject_id\u001b[39m\u001b[38;5;124m\"\u001b[39m, \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mra\u001b[39m\u001b[38;5;124m\"\u001b[39m, \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mdec\u001b[39m\u001b[38;5;124m\"\u001b[39m]\n\u001b[1;32m     62\u001b[0m \u001b[38;5;66;03m# Get the umap data and put it in a kdtree for indexing.\u001b[39;00m\n\u001b[0;32m---> 63\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mumap_results \u001b[38;5;241m=\u001b[39m \u001b[43mInferenceDataSet\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mconfig\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mresults_dir\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43minput_dir\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mverb\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mumap\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m)\u001b[49m\n\u001b[1;32m     65\u001b[0m available_fields \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mumap_results\u001b[38;5;241m.\u001b[39mmetadata_fields()\n\u001b[1;32m     66\u001b[0m \u001b[38;5;28;01mfor\u001b[39;00m field \u001b[38;5;129;01min\u001b[39;00m fields\u001b[38;5;241m.\u001b[39mcopy():\n",
-      "File \u001b[0;32m~/code/fibad/src/hyrax/data_sets/inference_dataset.py:43\u001b[0m, in \u001b[0;36mInferenceDataSet.__init__\u001b[0;34m(self, config, results_dir, verb)\u001b[0m\n\u001b[1;32m     41\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m batch_index_path\u001b[38;5;241m.\u001b[39mexists():\n\u001b[1;32m     42\u001b[0m     msg \u001b[38;5;241m=\u001b[39m \u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;132;01m{\u001b[39;00m\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mresults_dir\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m is corrupt and lacks a batch index file.\u001b[39m\u001b[38;5;124m\"\u001b[39m\n\u001b[0;32m---> 43\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mRuntimeError\u001b[39;00m(msg)\n\u001b[1;32m     45\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mbatch_index \u001b[38;5;241m=\u001b[39m np\u001b[38;5;241m.\u001b[39mload(\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mresults_dir \u001b[38;5;241m/\u001b[39m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mbatch_index.npy\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n\u001b[1;32m     46\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mlength \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mlen\u001b[39m(\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mbatch_index)\n",
-      "\u001b[0;31mRuntimeError\u001b[0m: /home/drew/code/fibad/docs/pre_executed/results/20250326-111626-umap-bFh- is corrupt and lacks a batch index file."
-     ]
+     "data": {
+      "text/html": [
+       "<script type=\"esms-options\">{\"shimMode\": true}</script><style>*[data-root-id],\n",
+       "*[data-root-id] > * {\n",
+       "  box-sizing: border-box;\n",
+       "  font-family: var(--jp-ui-font-family);\n",
+       "  font-size: var(--jp-ui-font-size1);\n",
+       "  color: var(--vscode-editor-foreground, var(--jp-ui-font-color1));\n",
+       "}\n",
+       "\n",
+       "/* Override VSCode background color */\n",
+       ".cell-output-ipywidget-background:has(\n",
+       "    > .cell-output-ipywidget-background > .lm-Widget > *[data-root-id]\n",
+       "  ),\n",
+       ".cell-output-ipywidget-background:has(> .lm-Widget > *[data-root-id]) {\n",
+       "  background-color: transparent !important;\n",
+       "}\n",
+       "</style>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/javascript": "(function(root) {\n  function now() {\n    return new Date();\n  }\n\n  const force = true;\n  const py_version = '3.6.2'.replace('rc', '-rc.').replace('.dev', '-dev.');\n  const reloading = false;\n  const Bokeh = root.Bokeh;\n\n  // Set a timeout for this load but only if we are not already initializing\n  if (typeof (root._bokeh_timeout) === \"undefined\" || (force || !root._bokeh_is_initializing)) {\n    root._bokeh_timeout = Date.now() + 5000;\n    root._bokeh_failed_load = false;\n  }\n\n  function run_callbacks() {\n    try {\n      root._bokeh_onload_callbacks.forEach(function(callback) {\n        if (callback != null)\n          callback();\n      });\n    } finally {\n      delete root._bokeh_onload_callbacks;\n    }\n    console.debug(\"Bokeh: all callbacks have finished\");\n  }\n\n  function load_libs(css_urls, js_urls, js_modules, js_exports, callback) {\n    if (css_urls == null) css_urls = [];\n    if (js_urls == null) js_urls = [];\n    if (js_modules == null) js_modules = [];\n    if (js_exports == null) js_exports = {};\n\n    root._bokeh_onload_callbacks.push(callback);\n\n    if (root._bokeh_is_loading > 0) {\n      // Don't load bokeh if it is still initializing\n      console.debug(\"Bokeh: BokehJS is being loaded, scheduling callback at\", now());\n      return null;\n    } else if (js_urls.length === 0 && js_modules.length === 0 && Object.keys(js_exports).length === 0) {\n      // There is nothing to load\n      run_callbacks();\n      return null;\n    }\n\n    function on_load() {\n      root._bokeh_is_loading--;\n      if (root._bokeh_is_loading === 0) {\n        console.debug(\"Bokeh: all BokehJS libraries/stylesheets loaded\");\n        run_callbacks()\n      }\n    }\n    window._bokeh_on_load = on_load\n\n    function on_error(e) {\n      const src_el = e.srcElement\n      console.error(\"failed to load \" + (src_el.href || src_el.src));\n    }\n\n    const skip = [];\n    if (window.requirejs) {\n      window.requirejs.config({'packages': {}, 'paths': {}, 'shim': {}});\n      root._bokeh_is_loading = css_urls.length + 0;\n    } else {\n      root._bokeh_is_loading = css_urls.length + js_urls.length + js_modules.length + Object.keys(js_exports).length;\n    }\n\n    const existing_stylesheets = []\n    const links = document.getElementsByTagName('link')\n    for (let i = 0; i < links.length; i++) {\n      const link = links[i]\n      if (link.href != null) {\n        existing_stylesheets.push(link.href)\n      }\n    }\n    for (let i = 0; i < css_urls.length; i++) {\n      const url = css_urls[i];\n      const escaped = encodeURI(url)\n      if (existing_stylesheets.indexOf(escaped) !== -1) {\n        on_load()\n        continue;\n      }\n      const element = document.createElement(\"link\");\n      element.onload = on_load;\n      element.onerror = on_error;\n      element.rel = \"stylesheet\";\n      element.type = \"text/css\";\n      element.href = url;\n      console.debug(\"Bokeh: injecting link tag for BokehJS stylesheet: \", url);\n      document.body.appendChild(element);\n    }    var existing_scripts = []\n    const scripts = document.getElementsByTagName('script')\n    for (let i = 0; i < scripts.length; i++) {\n      var script = scripts[i]\n      if (script.src != null) {\n        existing_scripts.push(script.src)\n      }\n    }\n    for (let i = 0; i < js_urls.length; i++) {\n      const url = js_urls[i];\n      const escaped = encodeURI(url)\n      if (skip.indexOf(escaped) !== -1 || existing_scripts.indexOf(escaped) !== -1) {\n        if (!window.requirejs) {\n          on_load();\n        }\n        continue;\n      }\n      const element = document.createElement('script');\n      element.onload = on_load;\n      element.onerror = on_error;\n      element.async = false;\n      element.src = url;\n      console.debug(\"Bokeh: injecting script tag for BokehJS library: \", url);\n      document.head.appendChild(element);\n    }\n    for (let i = 0; i < js_modules.length; i++) {\n      const url = js_modules[i];\n      const escaped = encodeURI(url)\n      if (skip.indexOf(escaped) !== -1 || existing_scripts.indexOf(escaped) !== -1) {\n        if (!window.requirejs) {\n          on_load();\n        }\n        continue;\n      }\n      var element = document.createElement('script');\n      element.onload = on_load;\n      element.onerror = on_error;\n      element.async = false;\n      element.src = url;\n      element.type = \"module\";\n      console.debug(\"Bokeh: injecting script tag for BokehJS library: \", url);\n      document.head.appendChild(element);\n    }\n    for (const name in js_exports) {\n      const url = js_exports[name];\n      const escaped = encodeURI(url)\n      if (skip.indexOf(escaped) >= 0 || root[name] != null) {\n        if (!window.requirejs) {\n          on_load();\n        }\n        continue;\n      }\n      var element = document.createElement('script');\n      element.onerror = on_error;\n      element.async = false;\n      element.type = \"module\";\n      console.debug(\"Bokeh: injecting script tag for BokehJS library: \", url);\n      element.textContent = `\n      import ${name} from \"${url}\"\n      window.${name} = ${name}\n      window._bokeh_on_load()\n      `\n      document.head.appendChild(element);\n    }\n    if (!js_urls.length && !js_modules.length) {\n      on_load()\n    }\n  };\n\n  function inject_raw_css(css) {\n    const element = document.createElement(\"style\");\n    element.appendChild(document.createTextNode(css));\n    document.body.appendChild(element);\n  }\n\n  const js_urls = [\"https://cdn.holoviz.org/panel/1.5.4/dist/bundled/reactiveesm/es-module-shims@^1.10.0/dist/es-module-shims.min.js\", \"https://cdn.bokeh.org/bokeh/release/bokeh-3.6.2.min.js\", \"https://cdn.bokeh.org/bokeh/release/bokeh-gl-3.6.2.min.js\", \"https://cdn.bokeh.org/bokeh/release/bokeh-widgets-3.6.2.min.js\", \"https://cdn.bokeh.org/bokeh/release/bokeh-tables-3.6.2.min.js\", \"https://cdn.holoviz.org/panel/1.5.4/dist/panel.min.js\"];\n  const js_modules = [];\n  const js_exports = {};\n  const css_urls = [];\n  const inline_js = [    function(Bokeh) {\n      Bokeh.set_log_level(\"info\");\n    },\nfunction(Bokeh) {} // ensure no trailing comma for IE\n  ];\n\n  function run_inline_js() {\n    if ((root.Bokeh !== undefined) || (force === true)) {\n      for (let i = 0; i < inline_js.length; i++) {\n        try {\n          inline_js[i].call(root, root.Bokeh);\n        } catch(e) {\n          if (!reloading) {\n            throw e;\n          }\n        }\n      }\n      // Cache old bokeh versions\n      if (Bokeh != undefined && !reloading) {\n        var NewBokeh = root.Bokeh;\n        if (Bokeh.versions === undefined) {\n          Bokeh.versions = new Map();\n        }\n        if (NewBokeh.version !== Bokeh.version) {\n          Bokeh.versions.set(NewBokeh.version, NewBokeh)\n        }\n        root.Bokeh = Bokeh;\n      }\n    } else if (Date.now() < root._bokeh_timeout) {\n      setTimeout(run_inline_js, 100);\n    } else if (!root._bokeh_failed_load) {\n      console.log(\"Bokeh: BokehJS failed to load within specified timeout.\");\n      root._bokeh_failed_load = true;\n    }\n    root._bokeh_is_initializing = false\n  }\n\n  function load_or_wait() {\n    // Implement a backoff loop that tries to ensure we do not load multiple\n    // versions of Bokeh and its dependencies at the same time.\n    // In recent versions we use the root._bokeh_is_initializing flag\n    // to determine whether there is an ongoing attempt to initialize\n    // bokeh, however for backward compatibility we also try to ensure\n    // that we do not start loading a newer (Panel>=1.0 and Bokeh>3) version\n    // before older versions are fully initialized.\n    if (root._bokeh_is_initializing && Date.now() > root._bokeh_timeout) {\n      // If the timeout and bokeh was not successfully loaded we reset\n      // everything and try loading again\n      root._bokeh_timeout = Date.now() + 5000;\n      root._bokeh_is_initializing = false;\n      root._bokeh_onload_callbacks = undefined;\n      root._bokeh_is_loading = 0\n      console.log(\"Bokeh: BokehJS was loaded multiple times but one version failed to initialize.\");\n      load_or_wait();\n    } else if (root._bokeh_is_initializing || (typeof root._bokeh_is_initializing === \"undefined\" && root._bokeh_onload_callbacks !== undefined)) {\n      setTimeout(load_or_wait, 100);\n    } else {\n      root._bokeh_is_initializing = true\n      root._bokeh_onload_callbacks = []\n      const bokeh_loaded = root.Bokeh != null && (root.Bokeh.version === py_version || (root.Bokeh.versions !== undefined && root.Bokeh.versions.has(py_version)));\n      if (!reloading && !bokeh_loaded) {\n        if (root.Bokeh) {\n          root.Bokeh = undefined;\n        }\n        console.debug(\"Bokeh: BokehJS not loaded, scheduling load and callback at\", now());\n      }\n      load_libs(css_urls, js_urls, js_modules, js_exports, function() {\n        console.debug(\"Bokeh: BokehJS plotting callback run at\", now());\n        run_inline_js();\n      });\n    }\n  }\n  // Give older versions of the autoload script a head-start to ensure\n  // they initialize before we start loading newer version.\n  setTimeout(load_or_wait, 100)\n}(window));",
+      "application/vnd.holoviews_load.v0+json": ""
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/javascript": "\nif ((window.PyViz === undefined) || (window.PyViz instanceof HTMLElement)) {\n  window.PyViz = {comms: {}, comm_status:{}, kernels:{}, receivers: {}, plot_index: []}\n}\n\n\n    function JupyterCommManager() {\n    }\n\n    JupyterCommManager.prototype.register_target = function(plot_id, comm_id, msg_handler) {\n      if (window.comm_manager || ((window.Jupyter !== undefined) && (Jupyter.notebook.kernel != null))) {\n        var comm_manager = window.comm_manager || Jupyter.notebook.kernel.comm_manager;\n        comm_manager.register_target(comm_id, function(comm) {\n          comm.on_msg(msg_handler);\n        });\n      } else if ((plot_id in window.PyViz.kernels) && (window.PyViz.kernels[plot_id])) {\n        window.PyViz.kernels[plot_id].registerCommTarget(comm_id, function(comm) {\n          comm.onMsg = msg_handler;\n        });\n      } else if (typeof google != 'undefined' && google.colab.kernel != null) {\n        google.colab.kernel.comms.registerTarget(comm_id, (comm) => {\n          var messages = comm.messages[Symbol.asyncIterator]();\n          function processIteratorResult(result) {\n            var message = result.value;\n            console.log(message)\n            var content = {data: message.data, comm_id};\n            var buffers = []\n            for (var buffer of message.buffers || []) {\n              buffers.push(new DataView(buffer))\n            }\n            var metadata = message.metadata || {};\n            var msg = {content, buffers, metadata}\n            msg_handler(msg);\n            return messages.next().then(processIteratorResult);\n          }\n          return messages.next().then(processIteratorResult);\n        })\n      }\n    }\n\n    JupyterCommManager.prototype.get_client_comm = function(plot_id, comm_id, msg_handler) {\n      if (comm_id in window.PyViz.comms) {\n        return window.PyViz.comms[comm_id];\n      } else if (window.comm_manager || ((window.Jupyter !== undefined) && (Jupyter.notebook.kernel != null))) {\n        var comm_manager = window.comm_manager || Jupyter.notebook.kernel.comm_manager;\n        var comm = comm_manager.new_comm(comm_id, {}, {}, {}, comm_id);\n        if (msg_handler) {\n          comm.on_msg(msg_handler);\n        }\n      } else if ((plot_id in window.PyViz.kernels) && (window.PyViz.kernels[plot_id])) {\n        var comm = window.PyViz.kernels[plot_id].connectToComm(comm_id);\n        comm.open();\n        if (msg_handler) {\n          comm.onMsg = msg_handler;\n        }\n      } else if (typeof google != 'undefined' && google.colab.kernel != null) {\n        var comm_promise = google.colab.kernel.comms.open(comm_id)\n        comm_promise.then((comm) => {\n          window.PyViz.comms[comm_id] = comm;\n          if (msg_handler) {\n            var messages = comm.messages[Symbol.asyncIterator]();\n            function processIteratorResult(result) {\n              var message = result.value;\n              var content = {data: message.data};\n              var metadata = message.metadata || {comm_id};\n              var msg = {content, metadata}\n              msg_handler(msg);\n              return messages.next().then(processIteratorResult);\n            }\n            return messages.next().then(processIteratorResult);\n          }\n        }) \n        var sendClosure = (data, metadata, buffers, disposeOnDone) => {\n          return comm_promise.then((comm) => {\n            comm.send(data, metadata, buffers, disposeOnDone);\n          });\n        };\n        var comm = {\n          send: sendClosure\n        };\n      }\n      window.PyViz.comms[comm_id] = comm;\n      return comm;\n    }\n    window.PyViz.comm_manager = new JupyterCommManager();\n    \n\n\nvar JS_MIME_TYPE = 'application/javascript';\nvar HTML_MIME_TYPE = 'text/html';\nvar EXEC_MIME_TYPE = 'application/vnd.holoviews_exec.v0+json';\nvar CLASS_NAME = 'output';\n\n/**\n * Render data to the DOM node\n */\nfunction render(props, node) {\n  var div = document.createElement(\"div\");\n  var script = document.createElement(\"script\");\n  node.appendChild(div);\n  node.appendChild(script);\n}\n\n/**\n * Handle when a new output is added\n */\nfunction handle_add_output(event, handle) {\n  var output_area = handle.output_area;\n  var output = handle.output;\n  if ((output.data == undefined) || (!output.data.hasOwnProperty(EXEC_MIME_TYPE))) {\n    return\n  }\n  var id = output.metadata[EXEC_MIME_TYPE][\"id\"];\n  var toinsert = output_area.element.find(\".\" + CLASS_NAME.split(' ')[0]);\n  if (id !== undefined) {\n    var nchildren = toinsert.length;\n    var html_node = toinsert[nchildren-1].children[0];\n    html_node.innerHTML = output.data[HTML_MIME_TYPE];\n    var scripts = [];\n    var nodelist = html_node.querySelectorAll(\"script\");\n    for (var i in nodelist) {\n      if (nodelist.hasOwnProperty(i)) {\n        scripts.push(nodelist[i])\n      }\n    }\n\n    scripts.forEach( function (oldScript) {\n      var newScript = document.createElement(\"script\");\n      var attrs = [];\n      var nodemap = oldScript.attributes;\n      for (var j in nodemap) {\n        if (nodemap.hasOwnProperty(j)) {\n          attrs.push(nodemap[j])\n        }\n      }\n      attrs.forEach(function(attr) { newScript.setAttribute(attr.name, attr.value) });\n      newScript.appendChild(document.createTextNode(oldScript.innerHTML));\n      oldScript.parentNode.replaceChild(newScript, oldScript);\n    });\n    if (JS_MIME_TYPE in output.data) {\n      toinsert[nchildren-1].children[1].textContent = output.data[JS_MIME_TYPE];\n    }\n    output_area._hv_plot_id = id;\n    if ((window.Bokeh !== undefined) && (id in Bokeh.index)) {\n      window.PyViz.plot_index[id] = Bokeh.index[id];\n    } else {\n      window.PyViz.plot_index[id] = null;\n    }\n  } else if (output.metadata[EXEC_MIME_TYPE][\"server_id\"] !== undefined) {\n    var bk_div = document.createElement(\"div\");\n    bk_div.innerHTML = output.data[HTML_MIME_TYPE];\n    var script_attrs = bk_div.children[0].attributes;\n    for (var i = 0; i < script_attrs.length; i++) {\n      toinsert[toinsert.length - 1].childNodes[1].setAttribute(script_attrs[i].name, script_attrs[i].value);\n    }\n    // store reference to server id on output_area\n    output_area._bokeh_server_id = output.metadata[EXEC_MIME_TYPE][\"server_id\"];\n  }\n}\n\n/**\n * Handle when an output is cleared or removed\n */\nfunction handle_clear_output(event, handle) {\n  var id = handle.cell.output_area._hv_plot_id;\n  var server_id = handle.cell.output_area._bokeh_server_id;\n  if (((id === undefined) || !(id in PyViz.plot_index)) && (server_id !== undefined)) { return; }\n  var comm = window.PyViz.comm_manager.get_client_comm(\"hv-extension-comm\", \"hv-extension-comm\", function () {});\n  if (server_id !== null) {\n    comm.send({event_type: 'server_delete', 'id': server_id});\n    return;\n  } else if (comm !== null) {\n    comm.send({event_type: 'delete', 'id': id});\n  }\n  delete PyViz.plot_index[id];\n  if ((window.Bokeh !== undefined) & (id in window.Bokeh.index)) {\n    var doc = window.Bokeh.index[id].model.document\n    doc.clear();\n    const i = window.Bokeh.documents.indexOf(doc);\n    if (i > -1) {\n      window.Bokeh.documents.splice(i, 1);\n    }\n  }\n}\n\n/**\n * Handle kernel restart event\n */\nfunction handle_kernel_cleanup(event, handle) {\n  delete PyViz.comms[\"hv-extension-comm\"];\n  window.PyViz.plot_index = {}\n}\n\n/**\n * Handle update_display_data messages\n */\nfunction handle_update_output(event, handle) {\n  handle_clear_output(event, {cell: {output_area: handle.output_area}})\n  handle_add_output(event, handle)\n}\n\nfunction register_renderer(events, OutputArea) {\n  function append_mime(data, metadata, element) {\n    // create a DOM node to render to\n    var toinsert = this.create_output_subarea(\n    metadata,\n    CLASS_NAME,\n    EXEC_MIME_TYPE\n    );\n    this.keyboard_manager.register_events(toinsert);\n    // Render to node\n    var props = {data: data, metadata: metadata[EXEC_MIME_TYPE]};\n    render(props, toinsert[0]);\n    element.append(toinsert);\n    return toinsert\n  }\n\n  events.on('output_added.OutputArea', handle_add_output);\n  events.on('output_updated.OutputArea', handle_update_output);\n  events.on('clear_output.CodeCell', handle_clear_output);\n  events.on('delete.Cell', handle_clear_output);\n  events.on('kernel_ready.Kernel', handle_kernel_cleanup);\n\n  OutputArea.prototype.register_mime_type(EXEC_MIME_TYPE, append_mime, {\n    safe: true,\n    index: 0\n  });\n}\n\nif (window.Jupyter !== undefined) {\n  try {\n    var events = require('base/js/events');\n    var OutputArea = require('notebook/js/outputarea').OutputArea;\n    if (OutputArea.prototype.mime_types().indexOf(EXEC_MIME_TYPE) == -1) {\n      register_renderer(events, OutputArea);\n    }\n  } catch(err) {\n  }\n}\n",
+      "application/vnd.holoviews_load.v0+json": ""
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.holoviews_exec.v0+json": "",
+      "text/html": [
+       "<div id='049a21ec-0ac5-43e1-ad37-ed8ed85bc1f9'>\n",
+       "  <div id=\"ec2672a7-1134-422d-8713-104445b02604\" data-root-id=\"049a21ec-0ac5-43e1-ad37-ed8ed85bc1f9\" style=\"display: contents;\"></div>\n",
+       "</div>\n",
+       "<script type=\"application/javascript\">(function(root) {\n",
+       "  var docs_json = {\"52b33356-2971-48b2-b638-eb7f6293693f\":{\"version\":\"3.6.2\",\"title\":\"Bokeh Application\",\"roots\":[{\"type\":\"object\",\"name\":\"panel.models.browser.BrowserInfo\",\"id\":\"049a21ec-0ac5-43e1-ad37-ed8ed85bc1f9\"},{\"type\":\"object\",\"name\":\"panel.models.comm_manager.CommManager\",\"id\":\"12f856ce-3cf1-4802-9196-683cea6200b1\",\"attributes\":{\"plot_id\":\"049a21ec-0ac5-43e1-ad37-ed8ed85bc1f9\",\"comm_id\":\"4f380d77dc0941d48d1a0b30bd10510a\",\"client_comm_id\":\"c85fce9e87294a86a865d28b7875e886\"}}],\"defs\":[{\"type\":\"model\",\"name\":\"ReactiveHTML1\"},{\"type\":\"model\",\"name\":\"FlexBox1\",\"properties\":[{\"name\":\"align_content\",\"kind\":\"Any\",\"default\":\"flex-start\"},{\"name\":\"align_items\",\"kind\":\"Any\",\"default\":\"flex-start\"},{\"name\":\"flex_direction\",\"kind\":\"Any\",\"default\":\"row\"},{\"name\":\"flex_wrap\",\"kind\":\"Any\",\"default\":\"wrap\"},{\"name\":\"gap\",\"kind\":\"Any\",\"default\":\"\"},{\"name\":\"justify_content\",\"kind\":\"Any\",\"default\":\"flex-start\"}]},{\"type\":\"model\",\"name\":\"FloatPanel1\",\"properties\":[{\"name\":\"config\",\"kind\":\"Any\",\"default\":{\"type\":\"map\"}},{\"name\":\"contained\",\"kind\":\"Any\",\"default\":true},{\"name\":\"position\",\"kind\":\"Any\",\"default\":\"right-top\"},{\"name\":\"offsetx\",\"kind\":\"Any\",\"default\":null},{\"name\":\"offsety\",\"kind\":\"Any\",\"default\":null},{\"name\":\"theme\",\"kind\":\"Any\",\"default\":\"primary\"},{\"name\":\"status\",\"kind\":\"Any\",\"default\":\"normalized\"}]},{\"type\":\"model\",\"name\":\"GridStack1\",\"properties\":[{\"name\":\"mode\",\"kind\":\"Any\",\"default\":\"warn\"},{\"name\":\"ncols\",\"kind\":\"Any\",\"default\":null},{\"name\":\"nrows\",\"kind\":\"Any\",\"default\":null},{\"name\":\"allow_resize\",\"kind\":\"Any\",\"default\":true},{\"name\":\"allow_drag\",\"kind\":\"Any\",\"default\":true},{\"name\":\"state\",\"kind\":\"Any\",\"default\":[]}]},{\"type\":\"model\",\"name\":\"drag1\",\"properties\":[{\"name\":\"slider_width\",\"kind\":\"Any\",\"default\":5},{\"name\":\"slider_color\",\"kind\":\"Any\",\"default\":\"black\"},{\"name\":\"value\",\"kind\":\"Any\",\"default\":50}]},{\"type\":\"model\",\"name\":\"click1\",\"properties\":[{\"name\":\"terminal_output\",\"kind\":\"Any\",\"default\":\"\"},{\"name\":\"debug_name\",\"kind\":\"Any\",\"default\":\"\"},{\"name\":\"clears\",\"kind\":\"Any\",\"default\":0}]},{\"type\":\"model\",\"name\":\"FastWrapper1\",\"properties\":[{\"name\":\"object\",\"kind\":\"Any\",\"default\":null},{\"name\":\"style\",\"kind\":\"Any\",\"default\":null}]},{\"type\":\"model\",\"name\":\"NotificationAreaBase1\",\"properties\":[{\"name\":\"js_events\",\"kind\":\"Any\",\"default\":{\"type\":\"map\"}},{\"name\":\"position\",\"kind\":\"Any\",\"default\":\"bottom-right\"},{\"name\":\"_clear\",\"kind\":\"Any\",\"default\":0}]},{\"type\":\"model\",\"name\":\"NotificationArea1\",\"properties\":[{\"name\":\"js_events\",\"kind\":\"Any\",\"default\":{\"type\":\"map\"}},{\"name\":\"notifications\",\"kind\":\"Any\",\"default\":[]},{\"name\":\"position\",\"kind\":\"Any\",\"default\":\"bottom-right\"},{\"name\":\"_clear\",\"kind\":\"Any\",\"default\":0},{\"name\":\"types\",\"kind\":\"Any\",\"default\":[{\"type\":\"map\",\"entries\":[[\"type\",\"warning\"],[\"background\",\"#ffc107\"],[\"icon\",{\"type\":\"map\",\"entries\":[[\"className\",\"fas fa-exclamation-triangle\"],[\"tagName\",\"i\"],[\"color\",\"white\"]]}]]},{\"type\":\"map\",\"entries\":[[\"type\",\"info\"],[\"background\",\"#007bff\"],[\"icon\",{\"type\":\"map\",\"entries\":[[\"className\",\"fas fa-info-circle\"],[\"tagName\",\"i\"],[\"color\",\"white\"]]}]]}]}]},{\"type\":\"model\",\"name\":\"Notification\",\"properties\":[{\"name\":\"background\",\"kind\":\"Any\",\"default\":null},{\"name\":\"duration\",\"kind\":\"Any\",\"default\":3000},{\"name\":\"icon\",\"kind\":\"Any\",\"default\":null},{\"name\":\"message\",\"kind\":\"Any\",\"default\":\"\"},{\"name\":\"notification_type\",\"kind\":\"Any\",\"default\":null},{\"name\":\"_destroyed\",\"kind\":\"Any\",\"default\":false}]},{\"type\":\"model\",\"name\":\"TemplateActions1\",\"properties\":[{\"name\":\"open_modal\",\"kind\":\"Any\",\"default\":0},{\"name\":\"close_modal\",\"kind\":\"Any\",\"default\":0}]},{\"type\":\"model\",\"name\":\"BootstrapTemplateActions1\",\"properties\":[{\"name\":\"open_modal\",\"kind\":\"Any\",\"default\":0},{\"name\":\"close_modal\",\"kind\":\"Any\",\"default\":0}]},{\"type\":\"model\",\"name\":\"TemplateEditor1\",\"properties\":[{\"name\":\"layout\",\"kind\":\"Any\",\"default\":[]}]},{\"type\":\"model\",\"name\":\"MaterialTemplateActions1\",\"properties\":[{\"name\":\"open_modal\",\"kind\":\"Any\",\"default\":0},{\"name\":\"close_modal\",\"kind\":\"Any\",\"default\":0}]},{\"type\":\"model\",\"name\":\"ReactiveESM1\",\"properties\":[{\"name\":\"esm_constants\",\"kind\":\"Any\",\"default\":{\"type\":\"map\"}}]},{\"type\":\"model\",\"name\":\"JSComponent1\",\"properties\":[{\"name\":\"esm_constants\",\"kind\":\"Any\",\"default\":{\"type\":\"map\"}}]},{\"type\":\"model\",\"name\":\"ReactComponent1\",\"properties\":[{\"name\":\"esm_constants\",\"kind\":\"Any\",\"default\":{\"type\":\"map\"}}]},{\"type\":\"model\",\"name\":\"AnyWidgetComponent1\",\"properties\":[{\"name\":\"esm_constants\",\"kind\":\"Any\",\"default\":{\"type\":\"map\"}}]},{\"type\":\"model\",\"name\":\"request_value1\",\"properties\":[{\"name\":\"fill\",\"kind\":\"Any\",\"default\":\"none\"},{\"name\":\"_synced\",\"kind\":\"Any\",\"default\":null},{\"name\":\"_request_sync\",\"kind\":\"Any\",\"default\":0}]}]}};\n",
+       "  var render_items = [{\"docid\":\"52b33356-2971-48b2-b638-eb7f6293693f\",\"roots\":{\"049a21ec-0ac5-43e1-ad37-ed8ed85bc1f9\":\"ec2672a7-1134-422d-8713-104445b02604\"},\"root_ids\":[\"049a21ec-0ac5-43e1-ad37-ed8ed85bc1f9\"]}];\n",
+       "  var docs = Object.values(docs_json)\n",
+       "  if (!docs) {\n",
+       "    return\n",
+       "  }\n",
+       "  const py_version = docs[0].version.replace('rc', '-rc.').replace('.dev', '-dev.')\n",
+       "  async function embed_document(root) {\n",
+       "    var Bokeh = get_bokeh(root)\n",
+       "    await Bokeh.embed.embed_items_notebook(docs_json, render_items);\n",
+       "    for (const render_item of render_items) {\n",
+       "      for (const root_id of render_item.root_ids) {\n",
+       "\tconst id_el = document.getElementById(root_id)\n",
+       "\tif (id_el.children.length && id_el.children[0].hasAttribute('data-root-id')) {\n",
+       "\t  const root_el = id_el.children[0]\n",
+       "\t  root_el.id = root_el.id + '-rendered'\n",
+       "\t  for (const child of root_el.children) {\n",
+       "            // Ensure JupyterLab does not capture keyboard shortcuts\n",
+       "            // see: https://jupyterlab.readthedocs.io/en/4.1.x/extension/notebook.html#keyboard-interaction-model\n",
+       "\t    child.setAttribute('data-lm-suppress-shortcuts', 'true')\n",
+       "\t  }\n",
+       "\t}\n",
+       "      }\n",
+       "    }\n",
+       "  }\n",
+       "  function get_bokeh(root) {\n",
+       "    if (root.Bokeh === undefined) {\n",
+       "      return null\n",
+       "    } else if (root.Bokeh.version !== py_version) {\n",
+       "      if (root.Bokeh.versions === undefined || !root.Bokeh.versions.has(py_version)) {\n",
+       "\treturn null\n",
+       "      }\n",
+       "      return root.Bokeh.versions.get(py_version);\n",
+       "    } else if (root.Bokeh.version === py_version) {\n",
+       "      return root.Bokeh\n",
+       "    }\n",
+       "    return null\n",
+       "  }\n",
+       "  function is_loaded(root) {\n",
+       "    var Bokeh = get_bokeh(root)\n",
+       "    return (Bokeh != null && Bokeh.Panel !== undefined)\n",
+       "  }\n",
+       "  if (is_loaded(root)) {\n",
+       "    embed_document(root);\n",
+       "  } else {\n",
+       "    var attempts = 0;\n",
+       "    var timer = setInterval(function(root) {\n",
+       "      if (is_loaded(root)) {\n",
+       "        clearInterval(timer);\n",
+       "        embed_document(root);\n",
+       "      } else if (document.readyState == \"complete\") {\n",
+       "        attempts++;\n",
+       "        if (attempts > 200) {\n",
+       "          clearInterval(timer);\n",
+       "\t  var Bokeh = get_bokeh(root)\n",
+       "\t  if (Bokeh == null || Bokeh.Panel == null) {\n",
+       "            console.warn(\"Panel: ERROR: Unable to run Panel code because Bokeh or Panel library is missing\");\n",
+       "\t  } else {\n",
+       "\t    console.warn(\"Panel: WARNING: Attempting to render but not all required libraries could be resolved.\")\n",
+       "\t    embed_document(root)\n",
+       "\t  }\n",
+       "        }\n",
+       "      }\n",
+       "    }, 25, root)\n",
+       "  }\n",
+       "})(window);</script>"
+      ]
+     },
+     "metadata": {
+      "application/vnd.holoviews_exec.v0+json": {
+       "id": "049a21ec-0ac5-43e1-ad37-ed8ed85bc1f9"
+      }
+     },
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "<div class=\"logo-block\">\n",
+       "<img src='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAYAAACqaXHeAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\n",
+       "AAAB+wAAAfsBxc2miwAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9yZ5vuPBoAAA6zSURB\n",
+       "VHic7ZtpeFRVmsf/5966taWqUlUJ2UioBBJiIBAwCZtog9IOgjqACsogKtqirT2ttt069nQ/zDzt\n",
+       "tI4+CrJIREFaFgWhBXpUNhHZQoKBkIUASchWla1S+3ar7r1nPkDaCAnZKoQP/D7mnPOe9/xy76n3\n",
+       "nFSAW9ziFoPFNED2LLK5wcyBDObkb8ZkxuaoSYlI6ZcOKq1eWFdedqNzGHQBk9RMEwFAASkk0Xw3\n",
+       "ETacDNi2vtvc7L0ROdw0AjoSotQVkKSvHQz/wRO1lScGModBFbDMaNRN1A4tUBCS3lk7BWhQkgpD\n",
+       "lG4852/+7DWr1R3uHAZVQDsbh6ZPN7CyxUrCzJMRouusj0ipRwD2uKm0Zn5d2dFwzX1TCGhnmdGo\n",
+       "G62Nna+isiUqhkzuKrkQaJlPEv5mFl2fvGg2t/VnzkEV8F5ioioOEWkLG86fvbpthynjdhXYZziQ\n",
+       "x1hC9J2NFyi8vCTt91Fh04KGip0AaG9zuCk2wQCVyoNU3Hjezee9bq92duzzTmxsRJoy+jEZZZYo\n",
+       "GTKJ6SJngdJqAfRzpze0+jHreUtPc7gpBLQnIYK6BYp/uGhw9YK688eu7v95ysgshcg9qSLMo3JC\n",
+       "4jqLKQFBgdKDPoQ+Pltb8dUyQLpeDjeVgI6EgLIQFT5tEl3rn2losHVsexbZ3EyT9wE1uGdkIPcy\n",
+       "BGxn8QUq1QrA5nqW5i2tLqvrrM9NK6AdkVIvL9E9bZL/oyfMVd/jqvc8LylzRBKDJSzIExwhQzuL\n",
+       "QYGQj4rHfFTc8mUdu3E7yoLtbTe9gI4EqVgVkug2i5+uXGo919ixbRog+3fTbQ8qJe4ZOYNfMoTI\n",
+       "OoshUNosgO60AisX15aeI2PSIp5KiFLI9ubb1vV3Qb2ltwLakUCDAkWX7/nHKRmmGIl9VgYsUhJm\n",
+       "2NXjKYADtM1ygne9QQDIXlk49FBstMKx66D1v4+XuQr7vqTe0VcBHQlRWiOCbmmSYe2SqtL6q5rJ\n",
+       "zsTb7lKx3FKOYC4DoqyS/B5bvLPxvD9Qtf6saxYLQGJErmDOdOMr/zo96km1nElr8bmPOBwI9COv\n",
+       "HnFPRIwmkSOv9kcAS4heRsidOkpeWBgZM+UBrTFAXNYL5Vf2ii9c1trNzpYdaoVil3WIc+wdk+gQ\n",
+       "noie3ecCcxt9ITcLAPWt/laGEO/9U6PmzZkenTtsSMQ8uYywJVW+grCstAvCIaAdArAsIWkRDDs/\n",
+       "KzLm2YcjY1Lv0UdW73HabE9n6V66cxSzfEmuJssTpKGVp+0vHq73FwL46eOjpMpbRAnNmJFrGJNu\n",
+       "Ukf9Yrz+3rghiumCKNXXWPhLYcjxGsIpoCMsIRoFITkW8AuyM8jC1+/QLx4bozCEJIq38+1rtpR6\n",
+       "V/yzb8eBlRb3fo5l783N0CWolAzJHaVNzkrTzlEp2bQ2q3TC5gn6wpnoQAmwSiGh2GitnTmVMc5O\n",
+       "UyfKWUKCIsU7+fZDKwqdT6DDpvkzAX4/+AMFjk0tDp5GRXLpQ2MUmhgDp5gxQT8+Y7hyPsMi8uxF\n",
+       "71H0oebujHALECjFKaW9Lm68n18wXp2kVzIcABytD5iXFzg+WVXkegpAsOOYziqo0OkK76GyquC3\n",
+       "ltZAzMhhqlSNmmWTE5T6e3IN05ITFLM4GdN0vtZ3ob8Jh1NAKXFbm5PtLU/eqTSlGjkNAJjdgn/N\n",
+       "aedXa0tdi7+t9G0FIF49rtMSEgAs1kDLkTPO7ebm4IUWeyh1bKomXqlgMG6kJmHcSM0clYLJ8XtR\n",
+       "1GTnbV3F6I5wCGikAb402npp1h1s7LQUZZSMIfALFOuL3UUrfnS8+rez7v9qcold5tilgHbO1fjK\n",
+       "9ubb17u9oshxzMiUBKXWqJNxd+fqb0tLVs4lILFnK71H0Ind7uiPgACVcFJlrb0tV6DzxqqTIhUM\n",
+       "CwDf1/rrVhTa33/3pGPxJYdQ2l2cbgVcQSosdx8uqnDtbGjh9SlDVSMNWhlnilfqZk42Th2ZpLpf\n",
+       "xrHec5e815zrr0dfBZSwzkZfqsv+1FS1KUknUwPARVvItfKUY+cn57yP7qv07UE3p8B2uhUwLk09\n",
+       "e0SCOrK+hbdYHYLjRIl71wWzv9jpEoeOHhGRrJAzyEyNiJuUqX0g2sBN5kGK6y2Blp5M3lsB9Qh4\n",
+       "y2Ja6x6+i0ucmKgwMATwhSjdUu49tKrQ/pvN5d53ml2CGwCmJipmKjgmyuaXzNeL2a0AkQ01Th5j\n",
+       "2DktO3Jyk8f9vcOBQHV94OK+fPumJmvQHxJoWkaKWq9Vs+yUsbq0zGT1I4RgeH2b5wef7+c7bl8F\n",
+       "eKgoHVVZa8ZPEORzR6sT1BzDUAD/d9F78e2Tzv99v8D+fLVTqAKAsbGamKey1Mt9Ann4eH3gTXTz\n",
+       "idWtAJ8PQWOk7NzSeQn/OTHDuEikVF1R4z8BQCy+6D1aWRfY0tTGG2OM8rRoPaeIj5ZHzJxszElN\n",
+       "VM8K8JS5WOfv8mzRnQAKoEhmt8gyPM4lU9SmBK1MCQBnW4KONT86v1hZ1PbwSXPw4JWussVjtH9Y\n",
+       "NCoiL9UoH/6PSu8jFrfY2t36erQHXLIEakMi1SydmzB31h3GGXFDFNPaK8Rme9B79Ixrd0WN+1ij\n",
+       "NRQ/doRmuFLBkHSTOm5GruG+pFjFdAmorG4IXH1Qua6ASniclfFtDYt+oUjKipPrCQB7QBQ2lrgP\n",
+       "fFzm+9XWUtcqJ3/5vDLDpJ79XHZk3u8nGZ42qlj1+ydtbxysCezrydp6ugmipNJ7WBPB5tydY0jP\n",
+       "HaVNzs3QzeE4ZpTbI+ZbnSFPbVOw9vsfnVvqWnirPyCNGD08IlqtYkh2hjZ5dErEQzoNm+6ykyOt\n",
+       "Lt5/PQEuSRRKo22VkydK+vvS1XEKlhCJAnsqvcVvH7f/ZU2R67eXbMEGAMiIV5oWZWiWvz5Fv2xG\n",
+       "sjqNJQRvn3Rs2lji/lNP19VjAQDgD7FHhujZB9OGqYxRkZxixgRDVlqS6uEOFaJUVu0rPFzctrnF\n",
+       "JqijImVp8dEKVWyUXDk92zAuMZ6bFwpBU1HrOw6AdhQgUooChb0+ItMbWJitSo5Ws3IAOGEOtL53\n",
+       "0vHZih9sC4vtofZ7Qu6523V/fmGcds1TY3V36pUsBwAbSlxnVh2xLfAD/IAIMDf7XYIkNmXfpp2l\n",
+       "18rkAJAy9HKFaIr/qULkeQQKy9zf1JgDB2uaeFNGijo5QsUyacNUUTOnGO42xSnv4oOwpDi1zYkc\n",
+       "efUc3I5Gk6PhyTuVKaOGyLUAYPGIoY9Pu/atL/L92+4q9wbflRJ2Trpm/jPjdBtfnqB/dIThcl8A\n",
+       "KG7hbRuKnb8qsQsVvVlTrwQAQMUlf3kwJI24Z4JhPMtcfng5GcH49GsrxJpGvvHIaeem2ma+KSjQ\n",
+       "lIwUdYyCY8j4dE1KzijNnIP2llF2wcXNnsoapw9XxsgYAl6k+KzUXbi2yP3KR2ecf6z3BFsBICdW\n",
+       "nvnIaG3eHybqX7vbpEqUMT+9OL4Qpe8VON7dXuFd39v19FoAABRVePbGGuXTszO0P7tu6lghUonE\n",
+       "llRdrhArLvmKdh9u29jcFiRRkfLUxBiFNiqSU9icoZQHo5mYBI1MBgBH6wMNb+U7Pnw337H4gi1Y\n",
+       "ciWs+uks3Z9fztUvfzxTm9Ne8XXkvQLHNytOOZeiD4e0PgkAIAYCYknKUNUDSXEKzdWNpnil7r4p\n",
+       "xqkjTarZMtk/K8TQ6Qve78qqvXurGwIJqcOUKfUWHsm8KGvxSP68YudXq4pcj39X49uOK2X142O0\n",
+       "Tz5/u/7TVybqH0rSya6ZBwD21/gubbrgWdDgEOx9WUhfBaC2ibcEBYm7a7x+ukrBMNcEZggyR0TE\n",
+       "T8zUPjikQ4VosQZbTpS4vqizBKvqmvjsqnpfzaZyx9JPiz1/bfGKdgD45XB1zoIMzYbfTdS/NClB\n",
+       "Gct0USiY3YL/g0LHy/uq/Ef6uo5+n0R/vyhp17Klpge763f8rMu6YU/zrn2nml+2WtH+Z+5IAAFc\n",
+       "2bUTdTDOSNa9+cQY7YLsOIXhevEkCvzph7a8laecz/Un/z4/Ae04XeL3UQb57IwU9ZDr9UuKVajv\n",
+       "nxp1+1UVIo/LjztZkKH59fO3G/JemqCfmaCRqbqbd90ZZ8FfjtkfAyD0J/9+C2h1hDwsSxvGjNDc\n",
+       "b4zk5NfrSwiQblLHzZhg+Jf4aPlUwpDqkQqa9nimbt1/TDH8OitGMaQnj+RJS6B1fbF7SY1TqO5v\n",
+       "/v0WAADl1f7zokgS7s7VT2DZ7pegUjBM7mjtiDZbcN4j0YrHH0rXpCtY0qPX0cVL0rv5jv/ZXend\n",
+       "0u/EESYBAFBU4T4Qa5TflZOhTe7pmKpaP8kCVUVw1+yhXfJWvn1P3hnXi33JsTN6PnP3hHZ8Z3/h\n",
+       "aLHzmkNPuPj7Bc/F/Q38CwjTpSwQXgE4Vmwry9tpfq/ZFgqFMy4AVDtCvi8rvMvOmv0N4YwbVgEA\n",
+       "sPM72/KVnzfspmH7HQGCRLG2yL1+z8XwvPcdCbsAANh+xPzstgMtxeGKt+6MK3/tacfvwhWvIwMi\n",
+       "oKEBtm0H7W+UVfkc/Y1V0BhoPlDr/w1w/eu1vjIgAgDg22OtX6/eYfnEz/focrZTHAFR+PSs56/7\n",
+       "q32nwpjazxgwAQCwcU/T62t3WL7r6/jVRa6/byp1rei+Z98ZUAEAhEPHPc8fKnTU9nbgtnOe8h0l\n",
+       "9hcGIqmODLQAHCy2Xti6v/XNRivf43f4fFvIteu854+VHnR7q9tfBlwAAGz+pnndB9vM26UebAe8\n",
+       "SLHujPOTPVW+rwY+sxskAAC2HrA8t2Vvc7ffP1r9o+vwR2dcr92InIAbKKC1FZ5tB1tf+/G8p8sv\n",
+       "N/9Q5zd/XR34LYCwV5JdccMEAMDBk45DH243r/X4xGvqxFa/GNpS7n6rwOwNWwHVE26oAADYurf1\n",
+       "zx/utOzt+DMKYM0p17YtZZ5VNzqfsB2HewG1WXE8PoZ7gOclbTIvynZf9JV+fqZtfgs/8F/Nu5rB\n",
+       "EIBmJ+8QRMmpU7EzGRsf2FzuePqYRbzh/zE26EwdrT10f6r6o8HOYzCJB9Dpff8tbnGLG8L/A/WE\n",
+       "roTBs2RqAAAAAElFTkSuQmCC'\n",
+       "     style='height:25px; border-radius:12px; display: inline-block; float: left; vertical-align: middle'></img>\n",
+       "\n",
+       "\n",
+       "  <img src='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACMAAAAjCAYAAAAe2bNZAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAAK6wAACusBgosNWgAAABx0RVh0U29mdHdhcmUAQWRvYmUgRmlyZXdvcmtzIENTNui8sowAAAf9SURBVFiFvZh7cFTVHcc/59y7793sJiFAwkvAYDRqFWwdraLVlj61diRYsDjqCFbFKrYo0CltlSq1tLaC2GprGIriGwqjFu10OlrGv8RiK/IICYECSWBDkt3s695zTv9IAtlHeOn0O7Mzu797z+/3Ob/z+p0VfBq9doNFljuABwAXw2PcvGHt6bgwxhz7Ls4YZNVXxxANLENwE2D1W9PAGmAhszZ0/X9gll5yCbHoOirLzmaQs0F6F8QMZq1v/8xgNm7DYwwjgXJLYL4witQ16+sv/U9HdDmV4WrKw6B06cZC/RMrM4MZ7xz61DAbtzEXmAvUAX4pMOVecg9/MFFu3j3Gz7gQBLygS2RGumBkL0cubiFRsR3LzVBV1UMk3IrW73PT9C2lYOwhQB4ClhX1AuKpjLcV27oEjyUpNUJCg1CvcejykWTCXyQgzic2HIIBjg3pS6+uRLKAhumZvD4U+tq0jTrgkVKQQtLekfTtxIPAkhTNF6G7kZm7aPp6M9myKVQEoaYaIhEQYvD781DML/RfBGNZXAl4irJiwBa07e/y7cQnBaJghIX6ENl2GR/fGCBoz6cm5qeyEqQA5ZYA5x5eeiV0Qph4gjFAUSwAr6QllQgcxS/Jm25Cr2Tmpsk03XI9NfI31FTZBEOgVOk51adqDBNPCNPSRlkiDXbBEwOU2WxH+I7itQZ62g56OjM33suq1YsZHVtGZSUI2QdyYgkgOthQNIF7BIGDnRAJgJSgj69cUx1gB8PkOGwL4E1gPrM27gIg7NlGKLQApc7BmEnAxP5g/rw4YqBrCDB5xHkw5rdR/1qTrN/hKNo6YUwVDNpFsnjYS8RbidBPcPXFP6R6yfExuOXmN4A3jv1+8ZUwgY9D2OWjUZE6lO88jDwHI8ZixGiMKSeYTBamCoDk6kDAb6y1OcH1a6KpD/fZesoFw5FlIXAVCIiH4PxrV+p2npVDToTBmtjY8t1swh2V61E9KqWiyuPEjM8dbfxuvfa49Zayf9R136Wr8mBSf/T7bNteA8zwaGEUbFpckWwq95n59dUIywKl2fbOIS5e8bWSu0tJ1a5redAYfqkdjesodFajcgaVNWhXo1C9SrkN3Usmv3UMJrc6/DDwkwEntkEJLe67tSLhvyzK8rHDQWleve5CGk4VZEB1r+5bg2E2si+Y0QatDK6jUVkX5eg2YYlp++ZM+rfMNYamAj8Y7MAVWFqaR1f/t2xzU4IHjybBtthzuiAASqv7jTF7jOqDMAakFHgDNsFyP+FhwZHBmH9F7cutIYkQCylYYv1AZSqsn1/+bX51OMMjPSl2nAnM7hnjOx2v53YgNWAzHM9Q/9l0lQWPSCBSyokAtOBC1Rj+w/1Xs+STDp4/E5g7Rs2zm2+oeVd7PUuHKDf6A4r5EsPT5K3gfCnBXNUYnvGzb+KcCczYYWOnLpy4eOXuG2oec0PBN8XQQAnpvS35AvAykr56rWhPBiV4MvtceGLxk5Mr6A1O8IfK7rl7xJ0r9kyumuP4fa0lMqTBLJIAJqEf1J3qE92lMBndlyfRD2YBghHC4hlny7ASqCeWo5zaoDdIWfnIefNGTb9fC73QDfhyBUCNOxrGPSUBfPem9us253YTV+3mcBbdkUYfzmHiLqZbYdIGHHON2ZlemXouaJUOO6TqtdHEQuXYY8Yt+EbDgmlS6RdzkaDTv2P9A3gICiq93sWhb5mc5wVhuU3Y7m5hOc3So7qFT3SLgOXHb/cyOfMn7xROegoC/PTcn3v8gbKPgDopJFk3R/uBPWQiwQ+2/GJevRMObLUzqe/saJjQUQTTftEVMW9tWxPgAocwcj9abNcZe7s+6t2R2xXZG7zyYLp8Q1PiRBBHym5bYuXi8Qt+/LvGu9f/5YDAxABsaRNPH6Xr4D4Sk87a897SOy9v/fKwjoF2eQel95yDESGEF6gEMwKhLwKus3wOVjTtes7qzgLdXTMnNCNoEpbcrtNuq6N7Xh/+eqcbj94xQkp7mdKpW5XbtbR8Z26kgMCAf2UU5YEovRUVRHbu2b3vK1UdDFkDCyMRQxbpdv8nhKAGIa7QaQedzT07fFPny53R738JoVYBdVrnsNx9XZ9v33UeGO+AA2MMUkgqQ5UcdDLZSFeVgONnXeHqSAC5Ew1BXwko0D1Zct3dT1duOjS3MzZnEUJtBuoQAq3SGOLR4ekjn9NC5nVOaYXf9lETrUkmOJy3pOz8OKIb2A1cWhJCCEzOxU2mUPror+2/L3yyM3pkM7jTjr1nBOgkGeyQ7erxpdJsMAS9wb2F9rzMxNY1K2PMU0WtZV82VU8Wp6vbKJVo9Lx/+4cydORdxCCQ/kDGTZCWsRpLu7VD7bfKqL8V2orKTp/PtzaXy42jr6TwAuisi+7JolUG4wY+8vyrISCMtRrLKWpvjAOqx/QGhp0rjRo5xD3x98CWQuOQN8qumRMmI7jKZPUEpzNVZsj4Zbaq1to5tZZsKIydLWojhIXrJnES79EaOzv3du2NytKuxzJKAA6wF8xqEE8s2jo/1wd/khslQGxd81Zg62Bbp31XBH+iETt7Y3ELA0iU6iGDlQ5mexe0VEx4a3x8V1AaYwFJgTiwaOsDmeK2J8nMUOqsnB1A+dcA04ucCYt0urkjmflk9iT2v30q/gZn5rQPvor4n9Ou634PeBzoznes/iot/7WnClKoM/+zCIjH5kwT8ChQjTHPIPTjFV3PpU/Hx+DM/A9U3IXI4SPCYAAAAABJRU5ErkJggg=='\n",
+       "       style='height:15px; border-radius:12px; display: inline-block; float: left'></img>\n",
+       "  \n",
+       "\n",
+       "\n",
+       "\n",
+       "\n",
+       "</div>\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "7c2c20420047499983e8b450a0736e99",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "BokehModel(combine_events=True, render_bundle={'docs_json': {'0417ab3c-8701-4fa6-8088-449d6c92a042': {'version…"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
+    "h.config[\"visualize\"][\"fields\"] = [\"ra\", \"dec\"]\n",
     "h.visualize(width=1000, height=1000)"
    ]
   },

--- a/docs/pre_executed/visualize.ipynb
+++ b/docs/pre_executed/visualize.ipynb
@@ -13,7 +13,16 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/mtauraso/miniforge3/envs/hyrax/lib/python3.10/site-packages/ignite/handlers/checkpoint.py:16: DeprecationWarning: `TorchScript` support for functional optimizers is deprecated and will be removed in a future PyTorch release. Consider using the `torch.compile` optimizer instead.\n",
+      "  from torch.distributed.optim import ZeroRedundancyOptimizer\n"
+     ]
+    }
+   ],
    "source": [
     "import pooch\n",
     "import hyrax"
@@ -37,30 +46,41 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[2025-03-28 16:07:09,156 hyrax:INFO] Runtime Config read from: /Users/mtauraso/src/fibad/src/hyrax/hyrax_default_config.toml\n",
-      "/Users/mtauraso/miniforge3/envs/fibad/lib/python3.10/site-packages/ignite/handlers/checkpoint.py:16: DeprecationWarning: `TorchScript` support for functional optimizers is deprecated and will be removed in a future PyTorch release. Consider using the `torch.compile` optimizer instead.\n",
-      "  from torch.distributed.optim import ZeroRedundancyOptimizer\n",
-      "[2025-03-28 16:07:11,497 hyrax.data_sets.hsc_data_set:INFO] Processed 993 objects for pruning\n",
-      "[2025-03-28 16:07:11,498 hyrax.data_sets.hsc_data_set:INFO] Checking file dimensions to determine standard cutout size...\n",
-      "[2025-03-28 16:07:11,499 hyrax.data_sets.hsc_data_set:INFO] HSC Data set loader has 993 objects\n",
-      "[2025-03-28 16:07:11,520 hyrax.data_sets.hsc_data_set:INFO] Preloading HSCDataSet cache...\n",
-      "[2025-03-28 16:07:11,530 hyrax.models.model_registry:INFO] Using criterion: torch.nn.CrossEntropyLoss with default arguments.\n",
-      "2025-03-28 16:07:11,544 ignite.distributed.auto.auto_dataloader INFO: Use data loader kwargs for dataset '<hyrax.data_sets.hsc': \n",
-      "\t{'sampler': <torch.utils.data.sampler.SubsetRandomSampler object at 0x16db21c60>, 'batch_size': 512, 'pin_memory': False}\n",
-      "2025-03-28 16:07:11,545 ignite.distributed.auto.auto_dataloader INFO: Use data loader kwargs for dataset '<hyrax.data_sets.hsc': \n",
-      "\t{'sampler': <torch.utils.data.sampler.SubsetRandomSampler object at 0x16dd64430>, 'batch_size': 512, 'pin_memory': False}\n",
-      "/Users/mtauraso/miniforge3/envs/fibad/lib/python3.10/site-packages/ignite/handlers/tqdm_logger.py:127: TqdmExperimentalWarning: Using `tqdm.autonotebook.tqdm` in notebook mode. Use `tqdm.tqdm` instead to force console mode (e.g. in jupyter console)\n",
-      "  from tqdm.autonotebook import tqdm\n",
-      "2025/03/28 16:07:11 WARNING mlflow.system_metrics.system_metrics_monitor: Skip logging GPU metrics because creating `GPUMonitor` failed with error: Failed to initialize NVML, skip logging GPU metrics: NVML Shared Library Not Found.\n",
-      "2025/03/28 16:07:11 INFO mlflow.system_metrics.system_metrics_monitor: Started monitoring system metrics.\n",
-      "[2025-03-28 16:07:12,043 hyrax.pytorch_ignite:INFO] Training model on device: mps\n",
-      "[2025-03-28 16:07:14,946 hyrax.data_sets.hsc_data_set:INFO] Processed 992 objects\n"
+      "[2025-04-18 16:39:31,471 hyrax:INFO] Runtime Config read from: /Users/mtauraso/src/fibad/src/hyrax/hyrax_default_config.toml\n",
+      "[2025-04-18 16:39:31,499 hyrax.data_sets.hsc_data_set:INFO] Checking file dimensions to determine standard cutout size...\n",
+      "[2025-04-18 16:39:31,501 hyrax.data_sets.fits_image_dataset:INFO] FitsImageDataSet has 993 objects\n",
+      "[2025-04-18 16:39:31,510 hyrax.data_sets.hsc_data_set:INFO] Processed 993 objects for pruning\n",
+      "[2025-04-18 16:39:31,511 hyrax.data_sets.fits_image_dataset:INFO] Preloading FitsImageDataSet cache...\n",
+      "[2025-04-18 16:39:31,559 hyrax.models.model_registry:INFO] Using criterion: torch.nn.CrossEntropyLoss with default arguments.\n",
+      "2025-04-18 16:39:31,683 ignite.distributed.auto.auto_dataloader INFO: Use data loader kwargs for dataset '<hyrax.data_sets.hsc': \n",
+      "\t{'sampler': <hyrax.pytorch_ignite.SubsetSequentialSampler object at 0x30fa615a0>, 'batch_size': 512, 'shuffle': False, 'pin_memory': False}\n",
+      "2025-04-18 16:39:31,688 ignite.distributed.auto.auto_dataloader INFO: Use data loader kwargs for dataset '<hyrax.data_sets.hsc': \n",
+      "\t{'sampler': <hyrax.pytorch_ignite.SubsetSequentialSampler object at 0x30fa622c0>, 'batch_size': 512, 'shuffle': False, 'pin_memory': False}\n",
+      "/Users/mtauraso/miniforge3/envs/hyrax/lib/python3.10/site-packages/ignite/handlers/tqdm_logger.py:127: TqdmExperimentalWarning: Using `tqdm.autonotebook.tqdm` in notebook mode. Use `tqdm.tqdm` instead to force console mode (e.g. in jupyter console)\n",
+      "  from tqdm.autonotebook import tqdm\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'train': (<torch.utils.data.dataloader.DataLoader object at 0x3039a4460>, [282, 129, 641, 72, 527, 791, 359, 949, 12, 36, 647, 419, 174, 837, 552, 461, 522, 318, 948, 192, 554, 640, 781, 775, 358, 793, 478, 645, 127, 60, 725, 119, 557, 892, 607, 609, 2, 443, 481, 630, 761, 120, 20, 342, 305, 786, 539, 327, 789, 853, 560, 158, 881, 295, 660, 917, 896, 679, 108, 161, 389, 695, 650, 462, 15, 783, 260, 149, 1, 579, 449, 710, 215, 354, 900, 226, 397, 612, 734, 431, 577, 548, 337, 835, 773, 733, 581, 624, 848, 309, 651, 861, 720, 740, 673, 3, 411, 106, 929, 420, 90, 83, 728, 580, 524, 741, 644, 65, 99, 872, 132, 169, 543, 684, 537, 933, 413, 614, 475, 768, 237, 756, 320, 248, 600, 107, 605, 906, 232, 795, 531, 414, 217, 146, 170, 439, 14, 505, 667, 494, 816, 29, 235, 841, 484, 561, 131, 24, 975, 556, 263, 654, 417, 227, 745, 743, 921, 401, 867, 373, 911, 288, 281, 367, 986, 229, 176, 564, 559, 815, 754, 84, 30, 136, 68, 727, 140, 489, 52, 444, 758, 770, 249, 425, 7, 53, 308, 787, 459, 64, 840, 716, 207, 377, 396, 456, 779, 255, 150, 441, 338, 213, 46, 378, 519, 59, 45, 574, 510, 57, 910, 803, 5, 40, 638, 178, 674, 204, 409, 717, 568, 268, 676, 376, 978, 253, 172, 976, 648, 830, 889, 200, 326, 44, 56, 950, 737, 813, 633, 876, 862, 732, 751, 70, 502, 639, 518, 405, 919, 575, 332, 681, 572, 81, 898, 504, 270, 485, 922, 811, 280, 448, 144, 116, 261, 880, 763, 800, 391, 196, 704, 946, 985, 370, 677, 516, 252, 706, 203, 76, 464, 356, 423, 603, 296, 141, 406, 187, 25, 526, 954, 230, 708, 247, 884, 808, 944, 901, 845, 63, 118, 142, 769, 100, 32, 777, 824, 285, 764, 128, 380, 79, 402, 345, 664, 347, 856, 538, 408, 617, 299, 195, 873, 866, 422, 233, 765, 671, 635, 838, 719, 752, 626, 488, 805, 682, 871, 508, 382, 55, 669, 221, 604, 168, 801, 785, 333, 825, 541, 988, 930, 91, 981, 167, 148, 163, 493, 307, 92, 254, 968, 102, 595, 550, 957, 379, 798, 188, 153, 173, 86, 826, 652, 23, 593, 855, 399, 109, 966, 259, 582, 189, 171, 199, 907, 611, 625, 58, 703, 385, 339, 613, 536, 82, 821, 962, 300, 492, 774, 615, 468, 662, 301, 344, 663, 839, 598, 438, 653, 360, 569, 74, 432, 211, 224, 34, 473, 620, 827, 42, 62, 860, 275, 666, 902, 963, 819, 96, 482, 739, 721, 817, 829, 104, 476, 700, 135, 822, 222, 424, 155, 231, 746, 205, 323, 298, 184, 480, 48, 250, 567, 384, 166, 599, 799, 361, 646, 869, 210, 469, 363, 974, 886, 661, 115, 13, 622, 718, 246, 616, 302, 678, 530, 17, 130, 602, 343, 186, 989, 181, 697, 33, 54, 794, 330, 589, 629, 591, 440, 88, 844, 336, 77, 472, 156, 967, 390, 19, 797, 731, 316, 101, 709, 80, 460, 209, 372, 403, 375, 514, 258, 507, 283, 279, 736, 689, 193, 694, 315, 938, 139, 225, 265, 742, 562, 705, 289, 965, 947, 400, 22, 578, 692, 924, 366, 154, 458, 784, 587, 374, 891, 854, 665, 435, 428, 499, 555, 103, 331, 573, 450, 955, 245, 529, 238, 874, 534, 586, 636, 878, 521, 276, 553, 964, 39, 251, 932, 454, 685, 218, 445, 533, 515, 549, 455, 771, 41, 486, 436, 329, 956, 895, 10, 85, 688, 937, 21, 93, 412, 983, 656, 121, 26, 78, 812, 747]), 'validate': (<torch.utils.data.dataloader.DataLoader object at 0x30396ba90>, [487, 180, 686, 340, 269, 159, 619, 297, 850, 287, 905, 834, 271, 970, 643, 828, 675, 312, 418, 304, 890, 693, 551, 352, 290, 597, 792, 165, 623, 257, 877, 294, 726, 220, 753, 509, 398, 0, 610, 642, 566, 865, 162, 523, 852, 847, 477, 532, 500, 341, 219, 576, 780, 277, 392, 349, 387, 707, 303, 465, 696, 767, 145, 776, 960, 4, 407, 940, 535, 497, 383, 273, 958, 655, 943, 27, 433, 143, 117, 588, 918, 234, 31, 467, 365, 973, 755, 814, 89, 722, 164, 766, 807, 851, 198, 863, 818, 913, 346, 506, 893, 842, 979, 916, 133, 335, 393, 256, 416, 113, 691, 179, 160, 177, 278, 868, 545, 18, 915, 6, 941, 266, 353, 738, 565, 702, 355, 749, 214, 75, 833, 859, 724, 908, 772, 313, 503, 242, 328, 447, 123, 272, 243, 687, 804, 286, 951, 236, 698, 50, 61, 760, 570, 935, 528, 594, 925, 931, 657, 558, 809, 357, 496, 823, 820, 525, 69, 991, 984, 134, 887, 627, 73, 267, 212, 631, 137, 191, 470, 802, 452, 628, 368, 442, 110, 658, 857, 453, 122, 571, 138, 592, 759, 244, 474, 849, 386, 585])}\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025/04/18 16:39:32 WARNING mlflow.system_metrics.system_metrics_monitor: Skip logging GPU metrics because creating `GPUMonitor` failed with error: Failed to initialize NVML, skip logging GPU metrics: NVML Shared Library Not Found.\n",
+      "2025/04/18 16:39:32 INFO mlflow.system_metrics.system_metrics_monitor: Started monitoring system metrics.\n",
+      "[2025-04-18 16:39:32,261 hyrax.pytorch_ignite:INFO] Training model on device: mps\n",
+      "[2025-04-18 16:39:35,080 hyrax.data_sets.fits_image_dataset:INFO] Processed 992 objects\n"
      ]
     },
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "338a8abbf3c0435fa410fdaf2241fb5d",
+       "model_id": "8bd55d6764164a13a45d36c284f4836b",
        "version_major": 2,
        "version_minor": 0
       },
@@ -72,9 +92,27 @@
      "output_type": "display_data"
     },
     {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "State:\n",
+      "\titeration: 2\n",
+      "\tepoch: 1\n",
+      "\tepoch_length: 2\n",
+      "\tmax_epochs: 10\n",
+      "\toutput: <class 'dict'>\n",
+      "\tbatch: <class 'torch.Tensor'>\n",
+      "\tmetrics: <class 'dict'>\n",
+      "\tdataloader: <class 'torch.utils.data.dataloader.DataLoader'>\n",
+      "\tseed: <class 'NoneType'>\n",
+      "\ttimes: <class 'dict'>\n",
+      "\n"
+     ]
+    },
+    {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "1cdad9dde78046f682d04289f974e2e0",
+       "model_id": "832092a73bc549b09dab243f21170656",
        "version_major": 2,
        "version_minor": 0
       },
@@ -86,9 +124,27 @@
      "output_type": "display_data"
     },
     {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "State:\n",
+      "\titeration: 4\n",
+      "\tepoch: 2\n",
+      "\tepoch_length: 2\n",
+      "\tmax_epochs: 10\n",
+      "\toutput: <class 'dict'>\n",
+      "\tbatch: <class 'torch.Tensor'>\n",
+      "\tmetrics: <class 'dict'>\n",
+      "\tdataloader: <class 'torch.utils.data.dataloader.DataLoader'>\n",
+      "\tseed: <class 'NoneType'>\n",
+      "\ttimes: <class 'dict'>\n",
+      "\n"
+     ]
+    },
+    {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "776f1b909cc04a8e88ffc5e77cb4bac3",
+       "model_id": "6fff6c70be1344bfb177a9eafddbe43b",
        "version_major": 2,
        "version_minor": 0
       },
@@ -100,9 +156,27 @@
      "output_type": "display_data"
     },
     {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "State:\n",
+      "\titeration: 6\n",
+      "\tepoch: 3\n",
+      "\tepoch_length: 2\n",
+      "\tmax_epochs: 10\n",
+      "\toutput: <class 'dict'>\n",
+      "\tbatch: <class 'torch.Tensor'>\n",
+      "\tmetrics: <class 'dict'>\n",
+      "\tdataloader: <class 'torch.utils.data.dataloader.DataLoader'>\n",
+      "\tseed: <class 'NoneType'>\n",
+      "\ttimes: <class 'dict'>\n",
+      "\n"
+     ]
+    },
+    {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "54d26d86fabd4fa5bbc7b616aa9443bc",
+       "model_id": "9accab8e96334e12a15ae2c31cadf4b2",
        "version_major": 2,
        "version_minor": 0
       },
@@ -114,9 +188,27 @@
      "output_type": "display_data"
     },
     {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "State:\n",
+      "\titeration: 8\n",
+      "\tepoch: 4\n",
+      "\tepoch_length: 2\n",
+      "\tmax_epochs: 10\n",
+      "\toutput: <class 'dict'>\n",
+      "\tbatch: <class 'torch.Tensor'>\n",
+      "\tmetrics: <class 'dict'>\n",
+      "\tdataloader: <class 'torch.utils.data.dataloader.DataLoader'>\n",
+      "\tseed: <class 'NoneType'>\n",
+      "\ttimes: <class 'dict'>\n",
+      "\n"
+     ]
+    },
+    {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "91dd60d3b74a48eda0a2ffe7ae547aee",
+       "model_id": "79a4d486fdf34ad893f77923a1443a7a",
        "version_major": 2,
        "version_minor": 0
       },
@@ -128,9 +220,27 @@
      "output_type": "display_data"
     },
     {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "State:\n",
+      "\titeration: 10\n",
+      "\tepoch: 5\n",
+      "\tepoch_length: 2\n",
+      "\tmax_epochs: 10\n",
+      "\toutput: <class 'dict'>\n",
+      "\tbatch: <class 'torch.Tensor'>\n",
+      "\tmetrics: <class 'dict'>\n",
+      "\tdataloader: <class 'torch.utils.data.dataloader.DataLoader'>\n",
+      "\tseed: <class 'NoneType'>\n",
+      "\ttimes: <class 'dict'>\n",
+      "\n"
+     ]
+    },
+    {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "93399c942c8f4a1489507088da113b5c",
+       "model_id": "afa237cb62d7493da9da18d1b57099b4",
        "version_major": 2,
        "version_minor": 0
       },
@@ -142,9 +252,27 @@
      "output_type": "display_data"
     },
     {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "State:\n",
+      "\titeration: 12\n",
+      "\tepoch: 6\n",
+      "\tepoch_length: 2\n",
+      "\tmax_epochs: 10\n",
+      "\toutput: <class 'dict'>\n",
+      "\tbatch: <class 'torch.Tensor'>\n",
+      "\tmetrics: <class 'dict'>\n",
+      "\tdataloader: <class 'torch.utils.data.dataloader.DataLoader'>\n",
+      "\tseed: <class 'NoneType'>\n",
+      "\ttimes: <class 'dict'>\n",
+      "\n"
+     ]
+    },
+    {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "ffe1bea4eede4b19b791bc62752ed094",
+       "model_id": "aff59297c78a43de90391c25c2a6f8b8",
        "version_major": 2,
        "version_minor": 0
       },
@@ -156,9 +284,27 @@
      "output_type": "display_data"
     },
     {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "State:\n",
+      "\titeration: 14\n",
+      "\tepoch: 7\n",
+      "\tepoch_length: 2\n",
+      "\tmax_epochs: 10\n",
+      "\toutput: <class 'dict'>\n",
+      "\tbatch: <class 'torch.Tensor'>\n",
+      "\tmetrics: <class 'dict'>\n",
+      "\tdataloader: <class 'torch.utils.data.dataloader.DataLoader'>\n",
+      "\tseed: <class 'NoneType'>\n",
+      "\ttimes: <class 'dict'>\n",
+      "\n"
+     ]
+    },
+    {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "2201cb41f6ea4c86913a67c875c6f5b1",
+       "model_id": "6ca2a0c4c9d249bda4f977d9606928c4",
        "version_major": 2,
        "version_minor": 0
       },
@@ -170,9 +316,27 @@
      "output_type": "display_data"
     },
     {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "State:\n",
+      "\titeration: 16\n",
+      "\tepoch: 8\n",
+      "\tepoch_length: 2\n",
+      "\tmax_epochs: 10\n",
+      "\toutput: <class 'dict'>\n",
+      "\tbatch: <class 'torch.Tensor'>\n",
+      "\tmetrics: <class 'dict'>\n",
+      "\tdataloader: <class 'torch.utils.data.dataloader.DataLoader'>\n",
+      "\tseed: <class 'NoneType'>\n",
+      "\ttimes: <class 'dict'>\n",
+      "\n"
+     ]
+    },
+    {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "46b1a52475bf4511b59af8f6cb14a13d",
+       "model_id": "8f1aa658e9e2413dabf8966675723b58",
        "version_major": 2,
        "version_minor": 0
       },
@@ -184,9 +348,27 @@
      "output_type": "display_data"
     },
     {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "State:\n",
+      "\titeration: 18\n",
+      "\tepoch: 9\n",
+      "\tepoch_length: 2\n",
+      "\tmax_epochs: 10\n",
+      "\toutput: <class 'dict'>\n",
+      "\tbatch: <class 'torch.Tensor'>\n",
+      "\tmetrics: <class 'dict'>\n",
+      "\tdataloader: <class 'torch.utils.data.dataloader.DataLoader'>\n",
+      "\tseed: <class 'NoneType'>\n",
+      "\ttimes: <class 'dict'>\n",
+      "\n"
+     ]
+    },
+    {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "4856558cad5e444a85127bbf259c4e32",
+       "model_id": "ac0836622d684cb7916ebc3de7e55969",
        "version_major": 2,
        "version_minor": 0
       },
@@ -201,13 +383,37 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[2025-03-28 16:07:19,810 hyrax.pytorch_ignite:INFO] Total training time: 7.77[s]\n",
-      "[2025-03-28 16:07:19,811 hyrax.pytorch_ignite:INFO] Latest checkpoint saved as: /Users/mtauraso/src/fibad/docs/pre_executed/results/20250328-160711-train-MWGA/checkpoint_epoch_10.pt\n",
-      "[2025-03-28 16:07:19,811 hyrax.pytorch_ignite:INFO] Best metric checkpoint saved as: /Users/mtauraso/src/fibad/docs/pre_executed/results/20250328-160711-train-MWGA/checkpoint_8_loss=-813.8177.pt\n",
-      "2025/03/28 16:07:19 INFO mlflow.system_metrics.system_metrics_monitor: Stopping system metrics monitoring...\n",
-      "2025/03/28 16:07:19 INFO mlflow.system_metrics.system_metrics_monitor: Successfully terminated system metrics monitoring!\n",
-      "[2025-03-28 16:07:19,828 hyrax.train:INFO] Finished Training\n",
-      "[2025-03-28 16:07:21,684 hyrax.model_exporters:INFO] Exported model to ONNX format: /Users/mtauraso/src/fibad/docs/pre_executed/results/20250328-160711-train-MWGA/example_model_opset_20.onnx\n"
+      "[2025-04-18 16:39:40,369 hyrax.pytorch_ignite:INFO] Total training time: 8.11[s]\n",
+      "[2025-04-18 16:39:40,369 hyrax.pytorch_ignite:INFO] Latest checkpoint saved as: /Users/mtauraso/src/fibad/docs/pre_executed/results/20250418-163931-train-hbLp/checkpoint_epoch_10.pt\n",
+      "[2025-04-18 16:39:40,370 hyrax.pytorch_ignite:INFO] Best metric checkpoint saved as: /Users/mtauraso/src/fibad/docs/pre_executed/results/20250418-163931-train-hbLp/checkpoint_10_loss=-884.4800.pt\n",
+      "2025/04/18 16:39:40 INFO mlflow.system_metrics.system_metrics_monitor: Stopping system metrics monitoring...\n",
+      "2025/04/18 16:39:40 INFO mlflow.system_metrics.system_metrics_monitor: Successfully terminated system metrics monitoring!\n",
+      "[2025-04-18 16:39:40,389 hyrax.train:INFO] Finished Training\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "State:\n",
+      "\titeration: 20\n",
+      "\tepoch: 10\n",
+      "\tepoch_length: 2\n",
+      "\tmax_epochs: 10\n",
+      "\toutput: <class 'dict'>\n",
+      "\tbatch: <class 'torch.Tensor'>\n",
+      "\tmetrics: <class 'dict'>\n",
+      "\tdataloader: <class 'torch.utils.data.dataloader.DataLoader'>\n",
+      "\tseed: <class 'NoneType'>\n",
+      "\ttimes: <class 'dict'>\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[2025-04-18 16:39:42,374 hyrax.model_exporters:INFO] Exported model to ONNX format: /Users/mtauraso/src/fibad/docs/pre_executed/results/20250418-163931-train-hbLp/example_model_opset_20.onnx\n"
      ]
     }
    ],
@@ -246,20 +452,57 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[2025-03-28 16:07:21,923 hyrax.data_sets.hsc_data_set:INFO] Processed 993 objects for pruning\n",
-      "[2025-03-28 16:07:21,923 hyrax.data_sets.hsc_data_set:INFO] Checking file dimensions to determine standard cutout size...\n",
-      "[2025-03-28 16:07:21,924 hyrax.data_sets.hsc_data_set:INFO] HSC Data set loader has 993 objects\n",
-      "[2025-03-28 16:07:21,946 hyrax.data_sets.hsc_data_set:INFO] Preloading HSCDataSet cache...\n",
-      "[2025-03-28 16:07:21,958 hyrax.models.model_registry:INFO] Using criterion: torch.nn.CrossEntropyLoss with default arguments.\n",
-      "[2025-03-28 16:07:21,959 hyrax.infer:INFO] data set has length 993\n",
-      "2025-03-28 16:07:21,961 ignite.distributed.auto.auto_dataloader INFO: Use data loader kwargs for dataset '<hyrax.data_sets.hsc': \n",
-      "\t{'sampler': None, 'batch_size': 512, 'pin_memory': False}\n",
-      "[2025-03-28 16:07:22,709 hyrax.pytorch_ignite:INFO] Evaluating model on device: mps\n",
-      "[2025-03-28 16:07:22,709 hyrax.pytorch_ignite:INFO] Total epochs: 1\n",
-      "[2025-03-28 16:07:25,536 hyrax.data_sets.hsc_data_set:INFO] Processed 992 objects\n",
-      "[2025-03-28 16:07:25,771 hyrax.pytorch_ignite:INFO] Total evaluation time: 3.06[s]\n",
-      "[2025-03-28 16:07:25,812 hyrax.infer:INFO] Inference results saved in: /Users/mtauraso/src/fibad/docs/pre_executed/results/20250328-160721-infer-1nKY\n"
+      "[2025-04-18 16:39:42,409 hyrax.data_sets.hsc_data_set:INFO] Checking file dimensions to determine standard cutout size...\n",
+      "[2025-04-18 16:39:42,411 hyrax.data_sets.fits_image_dataset:INFO] FitsImageDataSet has 993 objects\n",
+      "[2025-04-18 16:39:42,421 hyrax.data_sets.hsc_data_set:INFO] Processed 993 objects for pruning\n",
+      "[2025-04-18 16:39:42,422 hyrax.data_sets.fits_image_dataset:INFO] Preloading FitsImageDataSet cache...\n",
+      "[2025-04-18 16:39:42,434 hyrax.models.model_registry:INFO] Using criterion: torch.nn.CrossEntropyLoss with default arguments.\n",
+      "[2025-04-18 16:39:42,437 hyrax.verbs.infer:INFO] data set has length 993\n",
+      "2025-04-18 16:39:42,439 ignite.distributed.auto.auto_dataloader INFO: Use data loader kwargs for dataset '<hyrax.data_sets.hsc': \n",
+      "\t{'sampler': None, 'batch_size': 512, 'shuffle': False, 'pin_memory': False}\n",
+      "[2025-04-18 16:39:42,515 hyrax.verbs.infer:INFO] Saving inference results at: /Users/mtauraso/src/fibad/docs/pre_executed/results/20250418-163942-infer-T6lm\n",
+      "[2025-04-18 16:39:42,867 hyrax.pytorch_ignite:INFO] Evaluating model on device: mps\n",
+      "[2025-04-18 16:39:42,871 hyrax.pytorch_ignite:INFO] Total epochs: 1\n"
      ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "8e8535312a2d43b5b7503a9015ee6927",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       " 50%|#####     | 1/2 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[2025-04-18 16:39:46,333 hyrax.data_sets.fits_image_dataset:INFO] Processed 992 objects\n",
+      "[2025-04-18 16:39:46,557 hyrax.pytorch_ignite:INFO] Total evaluation time: 3.69[s]\n",
+      "[2025-04-18 16:39:46,620 hyrax.verbs.infer:INFO] Inference Complete.\n",
+      "[2025-04-18 16:39:46,664 hyrax.config_utils:WARNING] Cannot find default_config.toml for torch.\n",
+      "[2025-04-18 16:39:46,665 hyrax.config_utils:WARNING] Cannot find default_config.toml for torch.\n",
+      "[2025-04-18 16:39:49,029 hyrax.config_utils:WARNING] Cannot find default_config.toml for umap.\n",
+      "[2025-04-18 16:39:49,049 hyrax.data_sets.hsc_data_set:INFO] Checking file dimensions to determine standard cutout size...\n",
+      "[2025-04-18 16:39:49,050 hyrax.data_sets.fits_image_dataset:INFO] FitsImageDataSet has 993 objects\n",
+      "[2025-04-18 16:39:49,060 hyrax.data_sets.hsc_data_set:INFO] Processed 993 objects for pruning\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<hyrax.data_sets.inference_dataset.InferenceDataSet at 0x17f250f70>"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -275,22 +518,21 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[2025-03-28 16:07:28,221 hyrax.data_sets.inference_dataset:INFO] Using most recent results dir /Users/mtauraso/src/fibad/docs/pre_executed/results/20250328-160721-infer-1nKY for lookup. Use the [results] inference_dir config to set a directory or pass it to this verb.\n",
-      "[2025-03-28 16:07:28,243 hyrax.config_utils:WARNING] Cannot find default_config.toml for torch.\n",
-      "[2025-03-28 16:07:28,243 hyrax.config_utils:WARNING] Cannot find default_config.toml for torch.\n",
-      "[2025-03-28 16:07:28,244 hyrax.config_utils:WARNING] Cannot find default_config.toml for umap.\n",
-      "[2025-03-28 16:07:28,259 hyrax.data_sets.hsc_data_set:INFO] Processed 993 objects for pruning\n",
-      "[2025-03-28 16:07:28,260 hyrax.data_sets.hsc_data_set:INFO] Checking file dimensions to determine standard cutout size...\n",
-      "[2025-03-28 16:07:28,261 hyrax.data_sets.hsc_data_set:INFO] HSC Data set loader has 993 objects\n",
-      "[2025-03-28 16:07:28,283 hyrax.data_sets.hsc_data_set:INFO] Preloading HSCDataSet cache...\n",
-      "[2025-03-28 16:07:28,283 hyrax.verbs.umap:INFO] Saving UMAP results to /Users/mtauraso/src/fibad/docs/pre_executed/results/20250328-160728-umap-RC-F\n",
+      "[2025-04-18 16:39:49,071 hyrax.data_sets.inference_dataset:INFO] Using most recent results dir /Users/mtauraso/src/fibad/docs/pre_executed/results/20250418-163942-infer-T6lm for lookup. Use the [results] inference_dir config to set a directory or pass it to this verb.\n",
+      "[2025-04-18 16:39:49,097 hyrax.config_utils:WARNING] Cannot find default_config.toml for torch.\n",
+      "[2025-04-18 16:39:49,097 hyrax.config_utils:WARNING] Cannot find default_config.toml for torch.\n",
+      "[2025-04-18 16:39:49,098 hyrax.config_utils:WARNING] Cannot find default_config.toml for umap.\n",
+      "[2025-04-18 16:39:49,118 hyrax.data_sets.hsc_data_set:INFO] Checking file dimensions to determine standard cutout size...\n",
+      "[2025-04-18 16:39:49,120 hyrax.data_sets.fits_image_dataset:INFO] FitsImageDataSet has 993 objects\n",
+      "[2025-04-18 16:39:49,130 hyrax.data_sets.hsc_data_set:INFO] Processed 993 objects for pruning\n",
+      "[2025-04-18 16:39:49,131 hyrax.verbs.umap:INFO] Saving UMAP results to /Users/mtauraso/src/fibad/docs/pre_executed/results/20250418-163949-umap-DoyB\n",
       "OMP: Info #276: omp_set_nested routine deprecated, please use omp_set_max_active_levels instead.\n"
      ]
     },
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "a4e5701758494f708a986244f695d82b",
+       "model_id": "e94479171bd04826b7d6e3f4da32b814",
        "version_major": 2,
        "version_minor": 0
       },
@@ -305,7 +547,10 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[2025-03-28 16:07:34,062 hyrax.data_sets.hsc_data_set:INFO] Processed 992 objects\n",
+      "/Users/mtauraso/miniforge3/envs/hyrax/lib/python3.10/site-packages/ignite/handlers/checkpoint.py:16: DeprecationWarning: `TorchScript` support for functional optimizers is deprecated and will be removed in a future PyTorch release. Consider using the `torch.compile` optimizer instead.\n",
+      "  from torch.distributed.optim import ZeroRedundancyOptimizer\n",
+      "/Users/mtauraso/miniforge3/envs/hyrax/lib/python3.10/site-packages/ignite/handlers/checkpoint.py:16: DeprecationWarning: `TorchScript` support for functional optimizers is deprecated and will be removed in a future PyTorch release. Consider using the `torch.compile` optimizer instead.\n",
+      "  from torch.distributed.optim import ZeroRedundancyOptimizer\n",
       "OMP: Info #276: omp_set_nested routine deprecated, please use omp_set_max_active_levels instead.\n",
       "OMP: Info #276: omp_set_nested routine deprecated, please use omp_set_max_active_levels instead.\n"
      ]
@@ -333,14 +578,13 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[2025-03-28 16:07:40,363 hyrax.data_sets.inference_dataset:INFO] Using most recent results dir /Users/mtauraso/src/fibad/docs/pre_executed/results/20250328-160728-umap-RC-F for lookup. Use the [results] inference_dir config to set a directory or pass it to this verb.\n",
-      "[2025-03-28 16:07:40,386 hyrax.config_utils:WARNING] Cannot find default_config.toml for torch.\n",
-      "[2025-03-28 16:07:40,386 hyrax.config_utils:WARNING] Cannot find default_config.toml for torch.\n",
-      "[2025-03-28 16:07:40,386 hyrax.config_utils:WARNING] Cannot find default_config.toml for umap.\n",
-      "[2025-03-28 16:07:40,403 hyrax.data_sets.hsc_data_set:INFO] Processed 993 objects for pruning\n",
-      "[2025-03-28 16:07:40,403 hyrax.data_sets.hsc_data_set:INFO] Checking file dimensions to determine standard cutout size...\n",
-      "[2025-03-28 16:07:40,405 hyrax.data_sets.hsc_data_set:INFO] HSC Data set loader has 993 objects\n",
-      "[2025-03-28 16:07:40,426 hyrax.data_sets.hsc_data_set:INFO] Preloading HSCDataSet cache...\n"
+      "[2025-04-18 16:40:09,880 hyrax.data_sets.inference_dataset:INFO] Using most recent results dir /Users/mtauraso/src/fibad/docs/pre_executed/results/20250418-163949-umap-DoyB for lookup. Use the [results] inference_dir config to set a directory or pass it to this verb.\n",
+      "[2025-04-18 16:40:10,066 hyrax.config_utils:WARNING] Cannot find default_config.toml for torch.\n",
+      "[2025-04-18 16:40:10,066 hyrax.config_utils:WARNING] Cannot find default_config.toml for torch.\n",
+      "[2025-04-18 16:40:10,067 hyrax.config_utils:WARNING] Cannot find default_config.toml for umap.\n",
+      "[2025-04-18 16:40:10,088 hyrax.data_sets.hsc_data_set:INFO] Checking file dimensions to determine standard cutout size...\n",
+      "[2025-04-18 16:40:10,089 hyrax.data_sets.fits_image_dataset:INFO] FitsImageDataSet has 993 objects\n",
+      "[2025-04-18 16:40:10,098 hyrax.data_sets.hsc_data_set:INFO] Processed 993 objects for pruning\n"
      ]
     },
     {
@@ -387,12 +631,12 @@
      "data": {
       "application/vnd.holoviews_exec.v0+json": "",
       "text/html": [
-       "<div id='94bcd32f-2b79-4f07-a3fa-c023c82aa117'>\n",
-       "  <div id=\"ae2e6ec2-d92b-4d08-959f-44fab1825c62\" data-root-id=\"94bcd32f-2b79-4f07-a3fa-c023c82aa117\" style=\"display: contents;\"></div>\n",
+       "<div id='146e3880-ec3a-4f78-a060-a96e2b0bcad2'>\n",
+       "  <div id=\"cc7a7c56-14eb-40b0-ab49-4aadbf523740\" data-root-id=\"146e3880-ec3a-4f78-a060-a96e2b0bcad2\" style=\"display: contents;\"></div>\n",
        "</div>\n",
        "<script type=\"application/javascript\">(function(root) {\n",
-       "  var docs_json = {\"4a6bac5d-aac1-45be-a9c3-617cbd8dff6a\":{\"version\":\"3.6.2\",\"title\":\"Bokeh Application\",\"roots\":[{\"type\":\"object\",\"name\":\"panel.models.browser.BrowserInfo\",\"id\":\"94bcd32f-2b79-4f07-a3fa-c023c82aa117\"},{\"type\":\"object\",\"name\":\"panel.models.comm_manager.CommManager\",\"id\":\"74631b3e-ad74-4ac5-a314-a1c1ebbf808f\",\"attributes\":{\"plot_id\":\"94bcd32f-2b79-4f07-a3fa-c023c82aa117\",\"comm_id\":\"6ba38ae40f464b89a0d4e694bdac69d8\",\"client_comm_id\":\"f6a8fb92bde14e2b9a38bde526c58b26\"}}],\"defs\":[{\"type\":\"model\",\"name\":\"ReactiveHTML1\"},{\"type\":\"model\",\"name\":\"FlexBox1\",\"properties\":[{\"name\":\"align_content\",\"kind\":\"Any\",\"default\":\"flex-start\"},{\"name\":\"align_items\",\"kind\":\"Any\",\"default\":\"flex-start\"},{\"name\":\"flex_direction\",\"kind\":\"Any\",\"default\":\"row\"},{\"name\":\"flex_wrap\",\"kind\":\"Any\",\"default\":\"wrap\"},{\"name\":\"gap\",\"kind\":\"Any\",\"default\":\"\"},{\"name\":\"justify_content\",\"kind\":\"Any\",\"default\":\"flex-start\"}]},{\"type\":\"model\",\"name\":\"FloatPanel1\",\"properties\":[{\"name\":\"config\",\"kind\":\"Any\",\"default\":{\"type\":\"map\"}},{\"name\":\"contained\",\"kind\":\"Any\",\"default\":true},{\"name\":\"position\",\"kind\":\"Any\",\"default\":\"right-top\"},{\"name\":\"offsetx\",\"kind\":\"Any\",\"default\":null},{\"name\":\"offsety\",\"kind\":\"Any\",\"default\":null},{\"name\":\"theme\",\"kind\":\"Any\",\"default\":\"primary\"},{\"name\":\"status\",\"kind\":\"Any\",\"default\":\"normalized\"}]},{\"type\":\"model\",\"name\":\"GridStack1\",\"properties\":[{\"name\":\"mode\",\"kind\":\"Any\",\"default\":\"warn\"},{\"name\":\"ncols\",\"kind\":\"Any\",\"default\":null},{\"name\":\"nrows\",\"kind\":\"Any\",\"default\":null},{\"name\":\"allow_resize\",\"kind\":\"Any\",\"default\":true},{\"name\":\"allow_drag\",\"kind\":\"Any\",\"default\":true},{\"name\":\"state\",\"kind\":\"Any\",\"default\":[]}]},{\"type\":\"model\",\"name\":\"drag1\",\"properties\":[{\"name\":\"slider_width\",\"kind\":\"Any\",\"default\":5},{\"name\":\"slider_color\",\"kind\":\"Any\",\"default\":\"black\"},{\"name\":\"value\",\"kind\":\"Any\",\"default\":50}]},{\"type\":\"model\",\"name\":\"click1\",\"properties\":[{\"name\":\"terminal_output\",\"kind\":\"Any\",\"default\":\"\"},{\"name\":\"debug_name\",\"kind\":\"Any\",\"default\":\"\"},{\"name\":\"clears\",\"kind\":\"Any\",\"default\":0}]},{\"type\":\"model\",\"name\":\"FastWrapper1\",\"properties\":[{\"name\":\"object\",\"kind\":\"Any\",\"default\":null},{\"name\":\"style\",\"kind\":\"Any\",\"default\":null}]},{\"type\":\"model\",\"name\":\"NotificationAreaBase1\",\"properties\":[{\"name\":\"js_events\",\"kind\":\"Any\",\"default\":{\"type\":\"map\"}},{\"name\":\"position\",\"kind\":\"Any\",\"default\":\"bottom-right\"},{\"name\":\"_clear\",\"kind\":\"Any\",\"default\":0}]},{\"type\":\"model\",\"name\":\"NotificationArea1\",\"properties\":[{\"name\":\"js_events\",\"kind\":\"Any\",\"default\":{\"type\":\"map\"}},{\"name\":\"notifications\",\"kind\":\"Any\",\"default\":[]},{\"name\":\"position\",\"kind\":\"Any\",\"default\":\"bottom-right\"},{\"name\":\"_clear\",\"kind\":\"Any\",\"default\":0},{\"name\":\"types\",\"kind\":\"Any\",\"default\":[{\"type\":\"map\",\"entries\":[[\"type\",\"warning\"],[\"background\",\"#ffc107\"],[\"icon\",{\"type\":\"map\",\"entries\":[[\"className\",\"fas fa-exclamation-triangle\"],[\"tagName\",\"i\"],[\"color\",\"white\"]]}]]},{\"type\":\"map\",\"entries\":[[\"type\",\"info\"],[\"background\",\"#007bff\"],[\"icon\",{\"type\":\"map\",\"entries\":[[\"className\",\"fas fa-info-circle\"],[\"tagName\",\"i\"],[\"color\",\"white\"]]}]]}]}]},{\"type\":\"model\",\"name\":\"Notification\",\"properties\":[{\"name\":\"background\",\"kind\":\"Any\",\"default\":null},{\"name\":\"duration\",\"kind\":\"Any\",\"default\":3000},{\"name\":\"icon\",\"kind\":\"Any\",\"default\":null},{\"name\":\"message\",\"kind\":\"Any\",\"default\":\"\"},{\"name\":\"notification_type\",\"kind\":\"Any\",\"default\":null},{\"name\":\"_destroyed\",\"kind\":\"Any\",\"default\":false}]},{\"type\":\"model\",\"name\":\"TemplateActions1\",\"properties\":[{\"name\":\"open_modal\",\"kind\":\"Any\",\"default\":0},{\"name\":\"close_modal\",\"kind\":\"Any\",\"default\":0}]},{\"type\":\"model\",\"name\":\"BootstrapTemplateActions1\",\"properties\":[{\"name\":\"open_modal\",\"kind\":\"Any\",\"default\":0},{\"name\":\"close_modal\",\"kind\":\"Any\",\"default\":0}]},{\"type\":\"model\",\"name\":\"TemplateEditor1\",\"properties\":[{\"name\":\"layout\",\"kind\":\"Any\",\"default\":[]}]},{\"type\":\"model\",\"name\":\"MaterialTemplateActions1\",\"properties\":[{\"name\":\"open_modal\",\"kind\":\"Any\",\"default\":0},{\"name\":\"close_modal\",\"kind\":\"Any\",\"default\":0}]},{\"type\":\"model\",\"name\":\"ReactiveESM1\",\"properties\":[{\"name\":\"esm_constants\",\"kind\":\"Any\",\"default\":{\"type\":\"map\"}}]},{\"type\":\"model\",\"name\":\"JSComponent1\",\"properties\":[{\"name\":\"esm_constants\",\"kind\":\"Any\",\"default\":{\"type\":\"map\"}}]},{\"type\":\"model\",\"name\":\"ReactComponent1\",\"properties\":[{\"name\":\"esm_constants\",\"kind\":\"Any\",\"default\":{\"type\":\"map\"}}]},{\"type\":\"model\",\"name\":\"AnyWidgetComponent1\",\"properties\":[{\"name\":\"esm_constants\",\"kind\":\"Any\",\"default\":{\"type\":\"map\"}}]},{\"type\":\"model\",\"name\":\"request_value1\",\"properties\":[{\"name\":\"fill\",\"kind\":\"Any\",\"default\":\"none\"},{\"name\":\"_synced\",\"kind\":\"Any\",\"default\":null},{\"name\":\"_request_sync\",\"kind\":\"Any\",\"default\":0}]}]}};\n",
-       "  var render_items = [{\"docid\":\"4a6bac5d-aac1-45be-a9c3-617cbd8dff6a\",\"roots\":{\"94bcd32f-2b79-4f07-a3fa-c023c82aa117\":\"ae2e6ec2-d92b-4d08-959f-44fab1825c62\"},\"root_ids\":[\"94bcd32f-2b79-4f07-a3fa-c023c82aa117\"]}];\n",
+       "  var docs_json = {\"577a21c2-4874-47c6-b13c-3d8684156645\":{\"version\":\"3.6.2\",\"title\":\"Bokeh Application\",\"roots\":[{\"type\":\"object\",\"name\":\"panel.models.browser.BrowserInfo\",\"id\":\"146e3880-ec3a-4f78-a060-a96e2b0bcad2\"},{\"type\":\"object\",\"name\":\"panel.models.comm_manager.CommManager\",\"id\":\"eb3a03ac-6fd0-4a61-ada2-14317d0a45a5\",\"attributes\":{\"plot_id\":\"146e3880-ec3a-4f78-a060-a96e2b0bcad2\",\"comm_id\":\"593eca720ec64c5e840d27244055f01d\",\"client_comm_id\":\"ee273bef679f46ce93d5d3c23ee17208\"}}],\"defs\":[{\"type\":\"model\",\"name\":\"ReactiveHTML1\"},{\"type\":\"model\",\"name\":\"FlexBox1\",\"properties\":[{\"name\":\"align_content\",\"kind\":\"Any\",\"default\":\"flex-start\"},{\"name\":\"align_items\",\"kind\":\"Any\",\"default\":\"flex-start\"},{\"name\":\"flex_direction\",\"kind\":\"Any\",\"default\":\"row\"},{\"name\":\"flex_wrap\",\"kind\":\"Any\",\"default\":\"wrap\"},{\"name\":\"gap\",\"kind\":\"Any\",\"default\":\"\"},{\"name\":\"justify_content\",\"kind\":\"Any\",\"default\":\"flex-start\"}]},{\"type\":\"model\",\"name\":\"FloatPanel1\",\"properties\":[{\"name\":\"config\",\"kind\":\"Any\",\"default\":{\"type\":\"map\"}},{\"name\":\"contained\",\"kind\":\"Any\",\"default\":true},{\"name\":\"position\",\"kind\":\"Any\",\"default\":\"right-top\"},{\"name\":\"offsetx\",\"kind\":\"Any\",\"default\":null},{\"name\":\"offsety\",\"kind\":\"Any\",\"default\":null},{\"name\":\"theme\",\"kind\":\"Any\",\"default\":\"primary\"},{\"name\":\"status\",\"kind\":\"Any\",\"default\":\"normalized\"}]},{\"type\":\"model\",\"name\":\"GridStack1\",\"properties\":[{\"name\":\"mode\",\"kind\":\"Any\",\"default\":\"warn\"},{\"name\":\"ncols\",\"kind\":\"Any\",\"default\":null},{\"name\":\"nrows\",\"kind\":\"Any\",\"default\":null},{\"name\":\"allow_resize\",\"kind\":\"Any\",\"default\":true},{\"name\":\"allow_drag\",\"kind\":\"Any\",\"default\":true},{\"name\":\"state\",\"kind\":\"Any\",\"default\":[]}]},{\"type\":\"model\",\"name\":\"drag1\",\"properties\":[{\"name\":\"slider_width\",\"kind\":\"Any\",\"default\":5},{\"name\":\"slider_color\",\"kind\":\"Any\",\"default\":\"black\"},{\"name\":\"value\",\"kind\":\"Any\",\"default\":50}]},{\"type\":\"model\",\"name\":\"click1\",\"properties\":[{\"name\":\"terminal_output\",\"kind\":\"Any\",\"default\":\"\"},{\"name\":\"debug_name\",\"kind\":\"Any\",\"default\":\"\"},{\"name\":\"clears\",\"kind\":\"Any\",\"default\":0}]},{\"type\":\"model\",\"name\":\"FastWrapper1\",\"properties\":[{\"name\":\"object\",\"kind\":\"Any\",\"default\":null},{\"name\":\"style\",\"kind\":\"Any\",\"default\":null}]},{\"type\":\"model\",\"name\":\"NotificationAreaBase1\",\"properties\":[{\"name\":\"js_events\",\"kind\":\"Any\",\"default\":{\"type\":\"map\"}},{\"name\":\"position\",\"kind\":\"Any\",\"default\":\"bottom-right\"},{\"name\":\"_clear\",\"kind\":\"Any\",\"default\":0}]},{\"type\":\"model\",\"name\":\"NotificationArea1\",\"properties\":[{\"name\":\"js_events\",\"kind\":\"Any\",\"default\":{\"type\":\"map\"}},{\"name\":\"notifications\",\"kind\":\"Any\",\"default\":[]},{\"name\":\"position\",\"kind\":\"Any\",\"default\":\"bottom-right\"},{\"name\":\"_clear\",\"kind\":\"Any\",\"default\":0},{\"name\":\"types\",\"kind\":\"Any\",\"default\":[{\"type\":\"map\",\"entries\":[[\"type\",\"warning\"],[\"background\",\"#ffc107\"],[\"icon\",{\"type\":\"map\",\"entries\":[[\"className\",\"fas fa-exclamation-triangle\"],[\"tagName\",\"i\"],[\"color\",\"white\"]]}]]},{\"type\":\"map\",\"entries\":[[\"type\",\"info\"],[\"background\",\"#007bff\"],[\"icon\",{\"type\":\"map\",\"entries\":[[\"className\",\"fas fa-info-circle\"],[\"tagName\",\"i\"],[\"color\",\"white\"]]}]]}]}]},{\"type\":\"model\",\"name\":\"Notification\",\"properties\":[{\"name\":\"background\",\"kind\":\"Any\",\"default\":null},{\"name\":\"duration\",\"kind\":\"Any\",\"default\":3000},{\"name\":\"icon\",\"kind\":\"Any\",\"default\":null},{\"name\":\"message\",\"kind\":\"Any\",\"default\":\"\"},{\"name\":\"notification_type\",\"kind\":\"Any\",\"default\":null},{\"name\":\"_destroyed\",\"kind\":\"Any\",\"default\":false}]},{\"type\":\"model\",\"name\":\"TemplateActions1\",\"properties\":[{\"name\":\"open_modal\",\"kind\":\"Any\",\"default\":0},{\"name\":\"close_modal\",\"kind\":\"Any\",\"default\":0}]},{\"type\":\"model\",\"name\":\"BootstrapTemplateActions1\",\"properties\":[{\"name\":\"open_modal\",\"kind\":\"Any\",\"default\":0},{\"name\":\"close_modal\",\"kind\":\"Any\",\"default\":0}]},{\"type\":\"model\",\"name\":\"TemplateEditor1\",\"properties\":[{\"name\":\"layout\",\"kind\":\"Any\",\"default\":[]}]},{\"type\":\"model\",\"name\":\"MaterialTemplateActions1\",\"properties\":[{\"name\":\"open_modal\",\"kind\":\"Any\",\"default\":0},{\"name\":\"close_modal\",\"kind\":\"Any\",\"default\":0}]},{\"type\":\"model\",\"name\":\"ReactiveESM1\",\"properties\":[{\"name\":\"esm_constants\",\"kind\":\"Any\",\"default\":{\"type\":\"map\"}}]},{\"type\":\"model\",\"name\":\"JSComponent1\",\"properties\":[{\"name\":\"esm_constants\",\"kind\":\"Any\",\"default\":{\"type\":\"map\"}}]},{\"type\":\"model\",\"name\":\"ReactComponent1\",\"properties\":[{\"name\":\"esm_constants\",\"kind\":\"Any\",\"default\":{\"type\":\"map\"}}]},{\"type\":\"model\",\"name\":\"AnyWidgetComponent1\",\"properties\":[{\"name\":\"esm_constants\",\"kind\":\"Any\",\"default\":{\"type\":\"map\"}}]},{\"type\":\"model\",\"name\":\"request_value1\",\"properties\":[{\"name\":\"fill\",\"kind\":\"Any\",\"default\":\"none\"},{\"name\":\"_synced\",\"kind\":\"Any\",\"default\":null},{\"name\":\"_request_sync\",\"kind\":\"Any\",\"default\":0}]}]}};\n",
+       "  var render_items = [{\"docid\":\"577a21c2-4874-47c6-b13c-3d8684156645\",\"roots\":{\"146e3880-ec3a-4f78-a060-a96e2b0bcad2\":\"cc7a7c56-14eb-40b0-ab49-4aadbf523740\"},\"root_ids\":[\"146e3880-ec3a-4f78-a060-a96e2b0bcad2\"]}];\n",
        "  var docs = Object.values(docs_json)\n",
        "  if (!docs) {\n",
        "    return\n",
@@ -461,7 +705,7 @@
      },
      "metadata": {
       "application/vnd.holoviews_exec.v0+json": {
-       "id": "94bcd32f-2b79-4f07-a3fa-c023c82aa117"
+       "id": "146e3880-ec3a-4f78-a060-a96e2b0bcad2"
       }
      },
      "output_type": "display_data"
@@ -559,27 +803,21 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "1997ff4a8e9b47baa6ed84f66c0176c1",
+       "model_id": "68377a21bfde4329a5881f6a88bfc09d",
        "version_major": 2,
        "version_minor": 0
       },
       "text/plain": [
-       "BokehModel(combine_events=True, render_bundle={'docs_json': {'bf8e0dd0-efc2-4b9c-8a6f-890020accf02': {'version…"
+       "BokehModel(combine_events=True, render_bundle={'docs_json': {'2c88dc70-a2e6-4347-b498-a1022ac4a80d': {'version…"
       ]
      },
      "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "[2025-03-28 16:07:44,434 hyrax.data_sets.hsc_data_set:INFO] Processed 992 objects\n"
-     ]
     }
    ],
    "source": [
+    "h.config[\"visualize\"][\"fields\"] = [\"ra\", \"dec\"]\n",
     "h.visualize(width=800, height=800)"
    ]
   },
@@ -593,7 +831,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "fibad",
+   "display_name": "hyrax",
    "language": "python",
    "name": "python3"
   },

--- a/src/hyrax/data_sets/data_set_registry.py
+++ b/src/hyrax/data_sets/data_set_registry.py
@@ -83,8 +83,19 @@ class HyraxDataset:
             1. the metadata columns desired for visualization AND
             2. in the order your data will be enumerated.
         """
+        import numpy as np
+
         self._config = config
         self._metadata_table = metadata_table
+
+        # If your metadata does not contain an object_id field
+        # we use your required .ids() method to create the column
+        if self._metadata_table is not None:
+            colnames = self._metadata_table.colnames
+            if "object_id" not in colnames:
+                ids = np.array(list(self.ids()))
+                self._metadata_table.add_column(ids, name="object_id")
+
         self.tensorboardx_logger = None
 
     def is_iterable(self):

--- a/src/hyrax/hyrax_default_config.toml
+++ b/src/hyrax/hyrax_default_config.toml
@@ -238,3 +238,8 @@ n_components = 2
 # Controls how UMAP balances local versus global structure in the data.
 # See official documentation for details.
 n_neighbors = 15
+
+[visualize]
+
+# List of metadata field names to use in visualizer. Must be available as metadata in your dataset
+fields = []

--- a/src/hyrax/verbs/infer.py
+++ b/src/hyrax/verbs/infer.py
@@ -72,7 +72,7 @@ class Infer(Verb):
         if config["data_loader"]["shuffle"]:
             msg = "Data loader shuffling not supported in inference mode. "
             msg += "Setting config['data_loader']['shuffle'] = False"
-            logger.warn(msg)
+            logger.warning(msg)
             config["data_loader"]["shuffle"] = False
 
         data_loader, data_loader_indexes = dist_data_loader(data_set, config, split=config["infer"]["split"])

--- a/src/hyrax/verbs/visualize.py
+++ b/src/hyrax/verbs/visualize.py
@@ -56,8 +56,8 @@ class Visualize(Verb):
 
         from hyrax.data_sets.inference_dataset import InferenceDataSet
 
-        # TODO Is this an argument or config to visualize?
-        fields = ["object_id", "ra", "dec"]
+        fields = ["object_id"]
+        fields += self.config["visualize"]["fields"]
 
         # Get the umap data and put it in a kdtree for indexing.
         self.umap_results = InferenceDataSet(self.config, results_dir=input_dir, verb="umap")

--- a/tests/hyrax/test_e2e.py
+++ b/tests/hyrax/test_e2e.py
@@ -97,4 +97,4 @@ def test_getting_started(hyrax_instance):
     hyrax_instance.train()
     hyrax_instance.infer()
     hyrax_instance.umap()
-    # hyrax_instance.visualize()
+    hyrax_instance.visualize()


### PR DESCRIPTION
- Getting started steps should work now out of the box
- You now must set config['visualize']['fields'] to a list of the metadata fields you'd like the visualizer to use
- End to end tests now also test the visualizer
- Classes deriving from HyraxDataset who do not specify an "object_id" column in their metadata will now have that column pre-filled with the contents of their .ids() member.
- Minor changes to HSCDataSet tests to enable end-to-end testing since metadata is normally disabled on HSCDataSet for unit testing

Closes #282 
