### PR TITLE
Adding support for dict-based datasets.

### DIFF
--- a/src/hyrax/data_sets/data_set_registry.py
+++ b/src/hyrax/data_sets/data_set_registry.py
@@ -167,25 +167,6 @@ class HyraxDataset:
         else:
             return NotImplementedError("You must define __len__ or __iter__ to use automatic id()")
 
-    def shape(self) -> tuple:
-        """Returns the shape tuple of the tensors this dataset will return.
-
-        This default implementation uses the first item in the dataset to determine the shape.
-
-        Returns
-        -------
-        tuple
-            Shape tuple of the tensor that will be returned from the dataset.
-        """
-        if self.is_map():
-            data_sample = self[0]
-            return data_sample[0].shape if isinstance(data_sample, tuple) else data_sample.shape
-        elif self.is_iterable():
-            data_sample = next(iter(self))
-            return data_sample[0].shape if isinstance(data_sample, tuple) else data_sample.shape
-        else:
-            return NotImplementedError("You must define __getitem__ or __iter__ to use automatic shape()")
-
     def metadata_fields(self) -> list[str]:
         """Returns a list of metadata fields supported by this object
 

--- a/src/hyrax/data_sets/hyrax_cifar_data_set.py
+++ b/src/hyrax/data_sets/hyrax_cifar_data_set.py
@@ -4,7 +4,7 @@ import logging
 import numpy as np
 import torchvision.transforms as transforms
 from astropy.table import Table
-from torch.utils.data import IterableDataset
+from torch.utils.data import Dataset, IterableDataset
 from torchvision.datasets import CIFAR10
 
 from hyrax.config_utils import ConfigDict
@@ -14,33 +14,7 @@ from .data_set_registry import HyraxDataset
 logger = logging.getLogger(__name__)
 
 
-class HyraxCifarDataSet(HyraxDataset, CIFAR10):
-    """This is simply a version of CIFAR10 that is initialized using Hyrax config with a transformation
-    that works well for example code.
-
-    We only use the training split in the data, because it is larger (50k images). Hyrax will then divide that
-    into Train/test/Validate according to configuration.
-    """
-
-    def __init__(self, config: ConfigDict):
-        transform = transforms.Compose(
-            [transforms.ToTensor(), transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5))]
-        )
-        CIFAR10.__init__(
-            self, root=config["general"]["data_dir"], train=True, download=True, transform=transform
-        )
-        metadata_table = Table({"label": np.array([self[index][1] for index in range(len(self))])})
-        super().__init__(config, metadata_table)
-
-
-class HyraxCifarIterableDataSet(HyraxDataset, IterableDataset):
-    """This is simply a version of CIFAR10 that is initialized using Hyrax config with a transformation
-    that works well for example code. This version only supports iteration, and not map-style access
-
-    We only use the training split in the data, because it is larger (50k images). Hyrax will then divide that
-    into Train/test/Validate according to configuration.
-    """
-
+class HyraxCifarBase:
     def __init__(self, config: ConfigDict):
         transform = transforms.Compose(
             [transforms.ToTensor(), transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5))]
@@ -53,6 +27,39 @@ class HyraxCifarIterableDataSet(HyraxDataset, IterableDataset):
         )
         super().__init__(config, metadata_table)
 
+
+class HyraxCifarDataSet(HyraxCifarBase, HyraxDataset, Dataset):
+    """This is simply a version of CIFAR10 that is initialized using Hyrax config with a transformation
+    that works well for example code.
+
+    We only use the training split in the data, because it is larger (50k images). Hyrax will then divide that
+    into Train/test/Validate according to configuration.
+    """
+
+    def __len__(self):
+        return len(self.cifar)
+
+    def __getitem__(self, idx):
+        image, label = self.cifar[idx]
+        return {
+            "object_id": idx,
+            "image": image,
+            "label": label,
+        }
+
+
+class HyraxCifarIterableDataSet(HyraxCifarBase, HyraxDataset, IterableDataset):
+    """This is simply a version of CIFAR10 that is initialized using Hyrax config with a transformation
+    that works well for example code. This version only supports iteration, and not map-style access
+
+    We only use the training split in the data, because it is larger (50k images). Hyrax will then divide that
+    into Train/test/Validate according to configuration.
+    """
+
     def __iter__(self):
-        for item in self.cifar:
-            yield item
+        for idx, (image, label) in enumerate(self.cifar):
+            yield {
+                "object_id": idx,
+                "image": image,
+                "label": label,
+            }

--- a/src/hyrax/data_sets/inference_dataset.py
+++ b/src/hyrax/data_sets/inference_dataset.py
@@ -67,7 +67,7 @@ class InferenceDataSet(HyraxDataset, Dataset):
         self._original_dataset_config["data_set"]["preload_cache"] = False
         self.original_dataset = setup_dataset(self._original_dataset_config)  # type: ignore[arg-type]
 
-    def shape(self):
+    def _shape(self):
         """The shape of the dataset (Discovered from files)
 
         Note: our __getitem__() needs self.shape() to work. We cannot use HraxDataset.shape()
@@ -106,7 +106,7 @@ class InferenceDataSet(HyraxDataset, Dataset):
 
         # Allocate a numpy array to hold all the tensors we will get in order
         # Needs to be the appropriate shape
-        shape_tuple = tuple([len(idx)] + list(self.shape()))
+        shape_tuple = tuple([len(idx)] + list(self._shape()))
         all_tensors = np.zeros(shape=shape_tuple)
 
         # We need to look up all the batches for the ids we get

--- a/src/hyrax/models/hyrax_autoencoder.py
+++ b/src/hyrax/models/hyrax_autoencoder.py
@@ -8,6 +8,7 @@
 import torch.nn as nn
 import torch.nn.functional as F  # noqa N812
 import torch.optim as optim
+from torch import Tensor
 from torchvision.transforms.v2 import CenterCrop
 
 # extra long import here to address a circular import issue
@@ -131,6 +132,22 @@ class HyraxAutoencoder(nn.Module):
         self.optimizer.step()
 
         return {"loss": loss.item()}
+
+    @staticmethod
+    def to_tensor(data_dict) -> tuple[Tensor]:
+        """This function converts structured data to the input tensor we need to run
+
+        Parameters
+        ----------
+        data_dict : dict
+            The dictionary returned from our data source
+        """
+        if "image" in data_dict and "label" in data_dict:
+            image = data_dict["image"]
+            label = data_dict["label"]
+            return (image, label)
+        else:
+            raise RuntimeError("Data dict did not contain both image and label keys.")
 
     def _optimizer(self):
         return optim.Adam(self.parameters(), lr=1e-3)

--- a/src/hyrax/train.py
+++ b/src/hyrax/train.py
@@ -85,6 +85,8 @@ def run(config):
 
     # Get a sample of input data. If the data is labeled, only return the input data.
     batch_sample = next(iter(train_data_loader))
+    if isinstance(batch_sample, dict):
+        batch_sample = model.to_tensor(batch_sample)
     sample = batch_sample[0] if isinstance(batch_sample, (list, tuple)) else batch_sample
 
     export_to_onnx(model, sample, config, context)


### PR DESCRIPTION
- HyraxCifarDataSet is converted as an example
- Changes to Hyrax are backwards compatible to datasets returning Tensors or tuples of tensors directly.
- Models can now write a to_tensor() static method which converts a dict from whatever dataset to an approprite tensor.
- Torch's batching unifies the first level of dictionary keys so batches are now of type dict with tensor-y values representing the entirety of the batch for each top level dict key. (This is less a change and more just what torch does. We now rely on it)
- Dataset classes now no longer must define a shape() method. the backend simply pulls a sample element and determines the shape when needed. This operation unfortunately now requires both a model and a dataset, but it does not occur very often in code.
