### PR TITLE
Reducing umap memory footprint

### DIFF
--- a/src/hyrax/hyrax_default_config.toml
+++ b/src/hyrax/hyrax_default_config.toml
@@ -226,6 +226,12 @@ inference_dir = false
 # Number of data points used to fit the umap transform.
 fit_sample_size = 1024
 
+# Save the fitted umap as a pickle file 
+save_fit_umap = true
+
+# Use multiprocessing during transforming to umap space (More memory intensive)
+parallel = false
+
 # Name of the umap implementation to use
 name = "umap.UMAP"
 


### PR DESCRIPTION
Creates a `config["umap"]["reduce_memory_usage"]` flag that users can use to run the `umap` process only as a single-threaded operation, along with Python garbage collection and other memory-saving behaviour.

`["umap"]["reduce_memory_usage"]` is set to `False` by default, which replicates previous behaviour.  

To give a scale of numbers:- 
- with the flag set to `True`; 100k infer points can be fitted by a umap with ~250GBs of RAM
- Without the flag, this requirement balloons to more than 500GB