### PR TITLE
LSST Dataset uses a LSDB/Hats catalog to create cutouts.

### DIFF
--- a/docs/pre_executed/hyrax_hats_cutouts.ipynb
+++ b/docs/pre_executed/hyrax_hats_cutouts.ipynb
@@ -1,0 +1,420 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "82078a97-475a-436d-93f7-f8ff6c2d8b62",
+   "metadata": {},
+   "source": [
+    "# Installs and imports\n",
+    "We do a source install of hyrax and import the major libraries we will need, as well as define constants so all our database accesses are on the same dataset."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "27a9c823-0fb5-4fa8-ae4d-59731c603e09",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-04-22T21:44:52.549191Z",
+     "iopub.status.busy": "2025-04-22T21:44:52.548491Z",
+     "iopub.status.idle": "2025-04-22T21:45:04.994818Z",
+     "shell.execute_reply": "2025-04-22T21:45:04.994236Z",
+     "shell.execute_reply.started": "2025-04-22T21:44:52.549171Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[0m\n",
+      "Note: you may need to restart the kernel to use updated packages.\n",
+      "\u001b[0m\n",
+      "Note: you may need to restart the kernel to use updated packages.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# You must git check out hyrax to ~/rubin-user/hyrax for this to work.\n",
+    "%pip install -q -e ~/rubin-user/hyrax 2>&1 | grep -vE 'WARNING: Error parsing dependencies of (lsst-|astshim|astro-)'\n",
+    "%pip install -q lsdb 2>&1 | grep -vE 'WARNING: Error parsing dependencies of (lsst-|astshim|astro-)'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "ab7c0163-5b56-47dd-a19f-c1e5604c0ac2",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-04-23T00:16:50.912226Z",
+     "iopub.status.busy": "2025-04-23T00:16:50.911905Z",
+     "iopub.status.idle": "2025-04-23T00:16:50.915794Z",
+     "shell.execute_reply": "2025-04-23T00:16:50.915367Z",
+     "shell.execute_reply.started": "2025-04-23T00:16:50.912206Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import lsdb\n",
+    "import hyrax\n",
+    "from lsst.daf.butler import Butler\n",
+    "import numpy as np\n",
+    "import astropy.units as u\n",
+    "\n",
+    "butler_config = {\n",
+    "    \"config\": \"/repo/main\",\n",
+    "    \"collections\": \"LSSTComCam/runs/DRP/DP1/v29_0_0_rc5/DM-49865\",\n",
+    "}\n",
+    "lsdb_config = {\n",
+    "    \"path\": \"/sdf/data/rubin/shared/lsdb_commissioning/hats/v29_0_0_rc5/object_lc\",\n",
+    "    \"margin_cache\": \"/sdf/data/rubin/shared/lsdb_commissioning/hats/v29_0_0_rc5/object_lc_5arcs\",\n",
+    "    \"columns\": [\n",
+    "        \"objectId\",\n",
+    "        \"coord_ra\",\n",
+    "        \"coord_dec\",\n",
+    "        \"shape_flag\",\n",
+    "        \"g_kronMag\",\n",
+    "        \"g_psfMag\",\n",
+    "        \"shape_xx\",\n",
+    "        \"shape_yy\",\n",
+    "        \"shape_xy\",\n",
+    "    ],\n",
+    "}\n",
+    "sky_config = {\n",
+    "    \"skymap\": \"lsst_cells_v1\",\n",
+    "    \"tract\": 5063,\n",
+    "    \"patch\": 4,\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "15d6cb96-2d8e-4670-a12a-8acc1cb6ad29",
+   "metadata": {},
+   "source": [
+    "# Create a Hats catalog with objects of interest\n",
+    "\n",
+    "In order that this is compatible with DP1 ComCam data, we will pick a tract/patch where there is a deep field, cone search in hats slightly smaller than the patch to avoid edge-of-patch/edge-of-tract cutouts which are not yet handled by LSSTCutout, and then save the catalog file"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "c521bcb4-7104-43a9-a699-0a16edcde148",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-04-22T23:55:10.345871Z",
+     "iopub.status.busy": "2025-04-22T23:55:10.345717Z",
+     "iopub.status.idle": "2025-04-22T23:55:12.669618Z",
+     "shell.execute_reply": "2025-04-22T23:55:12.669175Z",
+     "shell.execute_reply.started": "2025-04-22T23:55:10.345855Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>objectId</th>\n",
+       "      <th>coord_ra</th>\n",
+       "      <th>coord_dec</th>\n",
+       "      <th>shape_flag</th>\n",
+       "      <th>g_kronMag</th>\n",
+       "      <th>g_psfMag</th>\n",
+       "      <th>shape_xx</th>\n",
+       "      <th>shape_yy</th>\n",
+       "      <th>shape_xy</th>\n",
+       "      <th>area_sqpx</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>_healpix_29</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>2528665042651534972</th>\n",
+       "      <td>2132999781327330046</td>\n",
+       "      <td>53.149835</td>\n",
+       "      <td>-28.353579</td>\n",
+       "      <td>False</td>\n",
+       "      <td>26.862612</td>\n",
+       "      <td>27.239223</td>\n",
+       "      <td>5.770088</td>\n",
+       "      <td>3.617737</td>\n",
+       "      <td>-1.410515</td>\n",
+       "      <td>19.307438</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2528665044302456614</th>\n",
+       "      <td>2132999781327330243</td>\n",
+       "      <td>53.147271</td>\n",
+       "      <td>-28.352482</td>\n",
+       "      <td>False</td>\n",
+       "      <td>24.923187</td>\n",
+       "      <td>25.08605</td>\n",
+       "      <td>7.937774</td>\n",
+       "      <td>8.092479</td>\n",
+       "      <td>-1.153888</td>\n",
+       "      <td>35.237640</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2528737149810927662</th>\n",
+       "      <td>2226792521223120438</td>\n",
+       "      <td>53.15675</td>\n",
+       "      <td>-28.187247</td>\n",
+       "      <td>False</td>\n",
+       "      <td>24.898371</td>\n",
+       "      <td>26.014616</td>\n",
+       "      <td>5.029204</td>\n",
+       "      <td>6.267774</td>\n",
+       "      <td>-0.069132</td>\n",
+       "      <td>24.942400</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2528737151063122411</th>\n",
+       "      <td>2226748540758023356</td>\n",
+       "      <td>53.15478</td>\n",
+       "      <td>-28.187289</td>\n",
+       "      <td>False</td>\n",
+       "      <td>23.721519</td>\n",
+       "      <td>24.283817</td>\n",
+       "      <td>14.342004</td>\n",
+       "      <td>12.251507</td>\n",
+       "      <td>2.401523</td>\n",
+       "      <td>57.918537</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>10302 rows × 10 columns</p>"
+      ],
+      "text/plain": [
+       "                                objectId   coord_ra  coord_dec shape_flag  \\\n",
+       "_healpix_29                                                                 \n",
+       "2528665042651534972  2132999781327330046  53.149835 -28.353579      False   \n",
+       "2528665044302456614  2132999781327330243  53.147271 -28.352482      False   \n",
+       "...                                  ...        ...        ...        ...   \n",
+       "2528737149810927662  2226792521223120438   53.15675 -28.187247      False   \n",
+       "2528737151063122411  2226748540758023356   53.15478 -28.187289      False   \n",
+       "\n",
+       "                     g_kronMag   g_psfMag   shape_xx   shape_yy  shape_xy  \\\n",
+       "_healpix_29                                                                 \n",
+       "2528665042651534972  26.862612  27.239223   5.770088   3.617737 -1.410515   \n",
+       "2528665044302456614  24.923187   25.08605   7.937774   8.092479 -1.153888   \n",
+       "...                        ...        ...        ...        ...       ...   \n",
+       "2528737149810927662  24.898371  26.014616   5.029204   6.267774 -0.069132   \n",
+       "2528737151063122411  23.721519  24.283817  14.342004  12.251507  2.401523   \n",
+       "\n",
+       "                     area_sqpx  \n",
+       "_healpix_29                     \n",
+       "2528665042651534972  19.307438  \n",
+       "2528665044302456614  35.237640  \n",
+       "...                        ...  \n",
+       "2528737149810927662  24.942400  \n",
+       "2528737151063122411  57.918537  \n",
+       "\n",
+       "[10302 rows x 10 columns]"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Find the tract/patch dimensions we want\n",
+    "butler = Butler.from_config(**butler_config)\n",
+    "skymap = butler.get(\"skyMap\", sky_config)\n",
+    "tract = skymap[sky_config[\"tract\"]]\n",
+    "patch = tract.getPatchInfo(sky_config[\"patch\"])\n",
+    "wcs = patch.getWcs()\n",
+    "patch_bbox = patch.getInnerBBox()\n",
+    "\n",
+    "sky_max = wcs.pixelToSky(patch_bbox.minX, patch_bbox.maxY)\n",
+    "sky_min = wcs.pixelToSky(patch_bbox.maxX, patch_bbox.minY)\n",
+    "\n",
+    "ra_range = [sky_min.getLongitude().asDegrees(), sky_max.getLongitude().asDegrees()]\n",
+    "dec_range = [sky_min.getLatitude().asDegrees(), sky_max.getLatitude().asDegrees()]\n",
+    "\n",
+    "# Query the catalog and save out the restricted catalog\n",
+    "catalog = lsdb.read_hats(**lsdb_config)\n",
+    "catalog = catalog.box_search(ra=ra_range, dec=dec_range)\n",
+    "catalog = catalog.query(\"g_psfMag > 20 & g_psfMag < 30\")\n",
+    "catalog = catalog.query(\"shape_flag == False\")\n",
+    "\n",
+    "catalog._ddf[\"area_sqpx\"] = np.pi * np.sqrt(\n",
+    "    2 * (catalog._ddf[\"shape_xx\"] * catalog._ddf[\"shape_yy\"] - catalog._ddf[\"shape_xy\"] ** 2)\n",
+    ")\n",
+    "catalog = catalog.query(\"area_sqpx > 5\")\n",
+    "res = catalog.compute()\n",
+    "catalog.to_hats(base_catalog_path=\"./hyrax_catalog\", catalog_name=\"hyrax_catalog\", overwrite=\"True\")\n",
+    "# catalog.columns\n",
+    "res"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "77b6cbea-b9e7-495c-97b9-603b3245bf80",
+   "metadata": {},
+   "source": [
+    "# Setup Hyrax to use the hats catalog\n",
+    "Configure hyrax to use the hats catalog "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "f95c0174-16fb-4672-ad42-c207a31614bc",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-04-23T00:17:09.176676Z",
+     "iopub.status.busy": "2025-04-23T00:17:09.176193Z",
+     "iopub.status.idle": "2025-04-23T00:17:14.819721Z",
+     "shell.execute_reply": "2025-04-23T00:17:14.819272Z",
+     "shell.execute_reply.started": "2025-04-23T00:17:09.176657Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[2025-04-23 00:17:09,220 hyrax:INFO] Runtime Config read from: /sdf/data/rubin/user/mtauraso/hyrax/src/hyrax/hyrax_default_config.toml\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"margin: 0.1em;\n",
+       "padding-left: 0.25em;\n",
+       "border-left-style: solid;\n",
+       "font-family: var(--jp-code-font-family);\n",
+       "font-size: var(--jp-code-font-size);\n",
+       "line-height: var(--jp-code-line-height);\n",
+       "\"><span style=\"color: var(--jp-warn-color2)\">hyrax</span> <span style=\"color: var(--jp-info-color0)\">INFO</span>: Runtime Config read from: /sdf/data/rubin/user/mtauraso/hyrax/src/hyrax/hyrax_default_config.toml</pre>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/m/mtauraso/.local/lib/python3.12/site-packages/ignite/handlers/checkpoint.py:16: DeprecationWarning: `TorchScript` support for functional optimizers is deprecated and will be removed in a future PyTorch release. Consider using the `torch.compile` optimizer instead.\n",
+      "  from torch.distributed.optim import ZeroRedundancyOptimizer\n",
+      "[2025-04-23 00:17:14,816 hyrax.prepare:INFO] Finished Prepare\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"margin: 0.1em;\n",
+       "padding-left: 0.25em;\n",
+       "border-left-style: solid;\n",
+       "font-family: var(--jp-code-font-family);\n",
+       "font-size: var(--jp-code-font-size);\n",
+       "line-height: var(--jp-code-line-height);\n",
+       "\"><span style=\"color: var(--jp-warn-color2)\">hyrax.prepare</span> <span style=\"color: var(--jp-info-color0)\">INFO</span>: Finished Prepare</pre>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "h = hyrax.Hyrax()\n",
+    "h.config[\"data_set\"][\"name\"] = \"LSSTDataset\"\n",
+    "h.config[\"data_set\"][\"hats_catalog\"] = \"./hyrax_catalog/\"\n",
+    "h.config[\"data_set\"][\"butler_repo\"] = butler_config[\"config\"]\n",
+    "h.config[\"data_set\"][\"butler_collection\"] = butler_config[\"collections\"]\n",
+    "h.config[\"data_set\"][\"skymap\"] = sky_config[\"skymap\"]\n",
+    "h.config[\"data_set\"][\"semi_width_deg\"] = (20 * u.arcsec).to(u.deg).value\n",
+    "h.config[\"data_set\"][\"semi_height_deg\"] = (20 * u.arcsec).to(u.deg).value\n",
+    "\n",
+    "a = h.prepare()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "0ed25731-d408-488f-aec0-cd988ec73c17",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-04-23T00:18:35.624925Z",
+     "iopub.status.busy": "2025-04-23T00:18:35.624604Z",
+     "iopub.status.idle": "2025-04-23T00:18:35.629829Z",
+     "shell.execute_reply": "2025-04-23T00:18:35.629357Z",
+     "shell.execute_reply.started": "2025-04-23T00:18:35.624905Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "torch.Size([3, 200, 202])"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "a[3].shape"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "LSST",
+   "language": "python",
+   "name": "lsst"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
LSST Dataset uses a LSDB/Hats catalog to create cutouts.

- LSSTDataset can be configured to use a hats catalog
- An example of preparing and using a hats catalog is in docs/pre_executed/hyrax_hats_cutouts.ipynb
- LSSTDataset now accepts butler, skymap, and sw/sh dimensions for cutouts as config.