### PR TITLE
Add umap ordering tests and use pytest-xdist

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -108,7 +108,7 @@ repos:
       - id: pytest-check
         name: Run unit tests
         description: Run unit tests with pytest.
-        entry: bash -c "if python -m pytest --co -qq -m 'not slow'; then python -m pytest --cov=./src --cov-report=html -m 'not slow'; fi"
+        entry: bash -c "if python -m pytest -n auto --co -qq -m 'not slow'; then python -m pytest -n auto --cov=./src --cov-report=html -m 'not slow'; fi"
         language: system
         pass_filenames: false
         always_run: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,7 @@ dev = [
     "pytest",
     "pytest-cov", # Used to report total code coverage
     "pytest-env", # Used to set environment variables in testing
+    "pytest-xdist", # Used to parallelize unit tests
     "ruff", # Used for static linting of files
 ]
 

--- a/src/hyrax/verbs/umap.py
+++ b/src/hyrax/verbs/umap.py
@@ -130,7 +130,7 @@ class Umap(Verb):
                 # We flatten all dimensions of the input array except the dimension
                 # corresponding to batch elements. This ensures that all inputs to
                 # the UMAP algorithm are flattend per input item in the batch
-                inference_results[batch_indexes].reshape(len(batch_indexes), -1),
+                inference_results[batch_indexes].numpy().reshape(len(batch_indexes), -1),
             )
             for batch_indexes in np.array_split(all_indexes, num_batches)
         )

--- a/tests/hyrax/conftest.py
+++ b/tests/hyrax/conftest.py
@@ -1,8 +1,10 @@
 import numpy as np
+import pytest
 import torch.nn as nn
 from torch import from_numpy
 from torch.utils.data import Dataset, IterableDataset
 
+import hyrax
 from hyrax.data_sets import HyraxDataset
 from hyrax.models import hyrax_model
 
@@ -12,10 +14,22 @@ class LoopbackModel(nn.Module):
     """Simple model for testing which returns its own input"""
 
     def __init__(self, config, shape):
+        from functools import partial
+
         super().__init__()
         # This is created so the optimizier can find at least one weight
         self.unused_module = nn.Conv2d(1, 1, kernel_size=1, stride=0, padding=0)
         self.config = config
+
+        def load(self, weight_file):
+            """Load Weights, we have no weights so we do nothing"""
+            print("got here")
+            pass
+
+        # We override this way rather than defining a method because
+        # Torch has some __init__ related cleverness which stomps our
+        # load definition when performed in the usual fashion.
+        self.load = partial(load, self)
 
     def forward(self, x):
         """We simply return our input"""
@@ -60,3 +74,47 @@ class RandomIterableDataset(RandomDataset, IterableDataset):
     def __iter__(self):
         for item in self.data:
             yield from_numpy(item)
+
+
+@pytest.fixture(scope="function", params=["RandomDataset", "RandomIterableDataset"])
+def loopback_hyrax(tmp_path_factory, request):
+    """This generates a loopback hyrax instance
+    which is configured to use the loopback model
+    and a simple dataset yielding random numbers
+    """
+    results_dir = tmp_path_factory.mktemp(f"loopback_hyrax_{request.param}")
+
+    h = hyrax.Hyrax()
+    h.config["model"]["name"] = "LoopbackModel"
+    h.config["train"]["epochs"] = 1
+    h.config["data_loader"]["batch_size"] = 5
+    h.config["general"]["results_dir"] = str(results_dir)
+
+    h.config["general"]["dev_mode"] = True
+    h.config["data_set"]["name"] = request.param
+    h.config["data_set"]["size"] = 20
+    h.config["data_set"]["seed"] = 0
+
+    h.config["data_set"]["validate_size"] = 0.2
+    h.config["data_set"]["test_size"] = 0.2
+    h.config["data_set"]["train_size"] = 0.6
+
+    weights_file = results_dir / "fakeweights"
+    with open(weights_file, "a"):
+        pass
+    h.config["infer"]["model_weights_file"] = str(weights_file)
+
+    dataset = h.prepare()
+    return h, dataset
+
+
+@pytest.fixture(scope="function")
+def loopback_inferred_hyrax(loopback_hyrax):
+    """This generates a loopback hyrax instance which is configured to use the
+    loopback model and a simple dataset yielding random numbers. It includes a call
+    to hyrax.infer which will produce the output consumed by vdb_index or umap."""
+
+    h, dataset = loopback_hyrax
+    inference_results = h.infer()
+
+    return h, dataset, inference_results

--- a/tests/hyrax/conftest.py
+++ b/tests/hyrax/conftest.py
@@ -23,7 +23,6 @@ class LoopbackModel(nn.Module):
 
         def load(self, weight_file):
             """Load Weights, we have no weights so we do nothing"""
-            print("got here")
             pass
 
         # We override this way rather than defining a method because

--- a/tests/hyrax/test_infer.py
+++ b/tests/hyrax/test_infer.py
@@ -10,11 +10,13 @@ def loopback_hyrax(tmp_path_factory, request):
     which is configured to use the loopback model
     and a simple dataset yielding random numbers
     """
+    results_dir = tmp_path_factory.mktemp(f"loopback_hyrax_{request.param}")
+
     h = hyrax.Hyrax()
     h.config["model"]["name"] = "LoopbackModel"
     h.config["train"]["epochs"] = 1
     h.config["data_loader"]["batch_size"] = 5
-    h.config["general"]["results_dir"] = str(tmp_path_factory.mktemp(f"loopback_hyrax_{request.param}"))
+    h.config["general"]["results_dir"] = str(results_dir)
 
     h.config["general"]["dev_mode"] = True
     h.config["data_set"]["name"] = request.param
@@ -25,9 +27,12 @@ def loopback_hyrax(tmp_path_factory, request):
     h.config["data_set"]["test_size"] = 0.2
     h.config["data_set"]["train_size"] = 0.6
 
-    dataset = h.prepare()
-    h.train()
+    weights_file = results_dir / "fakeweights"
+    with open(weights_file, "a"):
+        pass
+    h.config["infer"]["model_weights_file"] = str(weights_file)
 
+    dataset = h.prepare()
     return h, dataset
 
 

--- a/tests/hyrax/test_train.py
+++ b/tests/hyrax/test_train.py
@@ -1,0 +1,7 @@
+def test_train(loopback_hyrax):
+    """
+    Simple test that training succeeds with the loopback
+    model in use.
+    """
+    h, _ = loopback_hyrax
+    h.train()

--- a/tests/hyrax/test_umap.py
+++ b/tests/hyrax/test_umap.py
@@ -1,0 +1,58 @@
+import unittest.mock as mock
+
+import numpy as np
+
+
+class FakeUmap:
+    """
+    A Fake implementation of umap.UMAP which simply returns what is passed to it.
+    This works with the loopback model and random dataset since they both output
+    pairs of points, so the umap output is also pairs of points
+
+    Install on a test like
+
+    @mock.patch("umap.UMAP", FakeUmap)
+    def test_blah():
+        pass
+    """
+
+    def __init__(self, *args, **kwargs):
+        print("Called FakeUmap init")
+
+    def fit(self, data):
+        """We do nothing when fit on data. Prints are purely to help debug tests"""
+        print("Called FakeUmap fit:")
+        print(f"shape: {data.shape}")
+        print(f"dtype: {data.dtype}")
+
+    def transform(self, data):
+        """We return our input when called to transform. Prints are purely to help debug tests"""
+        print("Called FakeUmap transform:")
+        print(f"shape: {data.shape}")
+        print(f"dtype: {data.dtype}")
+        return data
+
+
+@mock.patch("umap.UMAP", FakeUmap)
+def test_umap_order(loopback_inferred_hyrax):
+    """Test that the order of data run through infer
+    is correct in the presence of several splits
+    """
+    h, dataset, _ = loopback_inferred_hyrax
+
+    umap_results = h.umap()
+    umap_result_ids = list(umap_results.ids())
+    original_dataset_ids = list(dataset.ids())
+
+    for idx, result_id in enumerate(umap_result_ids):
+        dataset_idx = None
+        for i, orig_id in enumerate(original_dataset_ids):
+            if orig_id == result_id:
+                dataset_idx = i
+                break
+        else:
+            raise AssertionError("Failed to find a corresponding ID")
+
+        print(f"orig idx: {dataset_idx}, umap idx: {idx}")
+        print(f"orig data: {dataset[dataset_idx]}, umap data: {umap_results[idx]}")
+        assert all(np.isclose(dataset[dataset_idx], umap_results[idx]))

--- a/tests/hyrax/test_vdb_index.py
+++ b/tests/hyrax/test_vdb_index.py
@@ -1,44 +1,17 @@
 import numpy as np
-import pytest
 
-import hyrax
 from hyrax.vector_dbs.chromadb_impl import ChromaDB
 
 
-@pytest.fixture(scope="function", params=["RandomDataset"])  # , "RandomIterableDataset"])
-def loopback_hyrax(tmp_path_factory, request):
-    """This generates a loopback hyrax instance which is configured to use the
-    loopback model and a simple dataset yielding random numbers. It includes a call
-    to hyrax.infer which will produce the output consumed by vdb_index."""
-    h = hyrax.Hyrax()
-    h.config["model"]["name"] = "LoopbackModel"
-    h.config["train"]["epochs"] = 1
-    h.config["data_loader"]["batch_size"] = 5
-    h.config["general"]["results_dir"] = str(tmp_path_factory.mktemp(f"loopback_hyrax_{request.param}"))
-
-    h.config["general"]["dev_mode"] = True
-    h.config["data_set"]["name"] = request.param
-    h.config["data_set"]["size"] = 20
-    h.config["data_set"]["seed"] = 0
-
-    h.config["data_set"]["validate_size"] = 0.2
-    h.config["data_set"]["test_size"] = 0.2
-    h.config["data_set"]["train_size"] = 0.6
-
-    dataset = h.prepare()
-    h.train()
-    inference_results = h.infer()
-
-    return h, dataset, inference_results
-
-
-def test_vdb_index(loopback_hyrax):
+def test_vdb_index(loopback_inferred_hyrax):
     """Test that the data inserted into the vector database is not corrupted. i.e.
     that we can match ids to input vectors for all values."""
 
-    h, dataset, inference_results = loopback_hyrax
+    h, dataset, inference_results = loopback_inferred_hyrax
     inference_result_ids = list(inference_results.ids())
     original_dataset_ids = list(dataset.ids())
+
+    h.config["vector_db"]["name"] = "chromadb"
 
     # Populate the vector database with the results of inference
     vdb_path = h.config["general"]["results_dir"]


### PR DESCRIPTION
- Added pytest-xdist to our standard pre-commit. shaves ~6s off a pytest run. After pip installing dev dependencies, run 'pytest -n auto -m "not slow"' to run parallelized.
- Added a Umap ordering/data identity test
- Factored more of our fixtures for infer/index/umap tests into conftest.py
