### PR TITLE
Polishing the vector db user experience

### DIFF
--- a/docs/notebooks.rst
+++ b/docs/notebooks.rst
@@ -7,3 +7,4 @@ Example notebooks
     Getting started with Hyrax <pre_executed/train_model>
     Getting started with Hyrax Custom Datasets <pre_executed/custom_dataset>
     Training to Similarity Search <pre_executed/hsc_train_to_similarity_search>
+    Working with a vector database <pre_executed/vector_db_demo>

--- a/docs/pre_executed/vector_db_demo.ipynb
+++ b/docs/pre_executed/vector_db_demo.ipynb
@@ -5,12 +5,22 @@
    "id": "f163b281",
    "metadata": {},
    "source": [
-    "# Vector DB Demo"
+    "# Vector Database Demo\n",
+    "\n",
+    "A vector database allows for efficient similarity searches by managing a data structure on behalf of the user that defines a distant between any two vectors. This allows the user to query the database for similar vectors given an input vector. In this notebook, we'll see how to use the Hyrax to work with the built in vector database."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5f174ad0",
+   "metadata": {},
+   "source": [
+    "As usual, we'll start by creating an instance of a `Hyrax` object and then quickly `train` the default HyraxAutoencoder. After than we'll run some data through `infer` to produce our encoded vectors."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "id": "44b00d84",
    "metadata": {},
    "outputs": [
@@ -18,7 +28,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[2025-05-06 20:38:01,176 hyrax:INFO] Runtime Config read from: /home/drew/code/hyrax/src/hyrax/hyrax_default_config.toml\n"
+      "[2025-05-20 12:13:30,438 hyrax:INFO] Runtime Config read from: /home/drew/code/hyrax/src/hyrax/hyrax_default_config.toml\n"
      ]
     }
    ],
@@ -29,16 +39,8 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "ebd2eaa8",
-   "metadata": {},
-   "source": [
-    "Quickly train a model using the default CiFAR dataset and then use the model to run inference."
-   ]
-  },
-  {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": 2,
    "id": "e214de6f",
    "metadata": {},
    "outputs": [
@@ -46,19 +48,21 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[2025-05-05 21:24:13,608 hyrax.models.model_registry:INFO] Using criterion: torch.nn.CrossEntropyLoss with default arguments.\n",
-      "2025-05-05 21:24:13,614 ignite.distributed.auto.auto_dataloader INFO: Use data loader kwargs for dataset '<hyrax.data_sets.hyr': \n",
-      "\t{'sampler': <hyrax.pytorch_ignite.SubsetSequentialSampler object at 0x7f11bdcdb3b0>, 'batch_size': 512, 'shuffle': False, 'pin_memory': True}\n",
-      "2025-05-05 21:24:13,616 ignite.distributed.auto.auto_dataloader INFO: Use data loader kwargs for dataset '<hyrax.data_sets.hyr': \n",
-      "\t{'sampler': <hyrax.pytorch_ignite.SubsetSequentialSampler object at 0x7f11bdcd9b80>, 'batch_size': 512, 'shuffle': False, 'pin_memory': True}\n",
-      "2025/05/05 21:24:13 INFO mlflow.system_metrics.system_metrics_monitor: Started monitoring system metrics.\n",
-      "[2025-05-05 21:24:13,665 hyrax.pytorch_ignite:INFO] Training model on device: cuda\n"
+      "[2025-05-20 12:13:42,566 hyrax.models.model_registry:INFO] Using criterion: torch.nn.CrossEntropyLoss with default arguments.\n",
+      "2025-05-20 12:13:42,836 ignite.distributed.auto.auto_dataloader INFO: Use data loader kwargs for dataset '<hyrax.data_sets.hyr': \n",
+      "\t{'sampler': <hyrax.pytorch_ignite.SubsetSequentialSampler object at 0x7f513f564cb0>, 'batch_size': 512, 'shuffle': False, 'pin_memory': True}\n",
+      "2025-05-20 12:13:42,837 ignite.distributed.auto.auto_dataloader INFO: Use data loader kwargs for dataset '<hyrax.data_sets.hyr': \n",
+      "\t{'sampler': <hyrax.pytorch_ignite.SubsetSequentialSampler object at 0x7f513ea93740>, 'batch_size': 512, 'shuffle': False, 'pin_memory': True}\n",
+      "/home/drew/miniconda3/envs/hyrax/lib/python3.12/site-packages/ignite/handlers/tqdm_logger.py:127: TqdmExperimentalWarning: Using `tqdm.autonotebook.tqdm` in notebook mode. Use `tqdm.tqdm` instead to force console mode (e.g. in jupyter console)\n",
+      "  from tqdm.autonotebook import tqdm\n",
+      "2025/05/20 12:13:43 INFO mlflow.system_metrics.system_metrics_monitor: Started monitoring system metrics.\n",
+      "[2025-05-20 12:13:43,260 hyrax.pytorch_ignite:INFO] Training model on device: cuda\n"
      ]
     },
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "625519c4d81949e788557cfbfdec5d20",
+       "model_id": "71a15190ee064854ba4ccd481895491e",
        "version_major": 2,
        "version_minor": 0
       },
@@ -72,7 +76,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "65ebeb0a1a864e908a17a956e09e6539",
+       "model_id": "9c6aaea9ef9a4ccd9a7d3658d1ba13b1",
        "version_major": 2,
        "version_minor": 0
       },
@@ -86,7 +90,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "a777435382eb4d799d34abee19f0e055",
+       "model_id": "dbb3c0d7e69448a6b5c3d1b373dd5157",
        "version_major": 2,
        "version_minor": 0
       },
@@ -100,7 +104,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "fe5ee658ef514229a6ad2a12be1b051b",
+       "model_id": "db143c17030e446abf0908719750d799",
        "version_major": 2,
        "version_minor": 0
       },
@@ -114,7 +118,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "d85d41dd67fd493283af72312424b9f6",
+       "model_id": "1dc77cbcabb04e8cafa6490829e3668e",
        "version_major": 2,
        "version_minor": 0
       },
@@ -128,7 +132,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "b499dce67f0949a1b14ded2e39798053",
+       "model_id": "9b2036dcc30c402887f202d83a162dfa",
        "version_major": 2,
        "version_minor": 0
       },
@@ -142,7 +146,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "a8514e6f1abc4a448ef16787422bd9d0",
+       "model_id": "2c313299934b4673906f89322f3cb20c",
        "version_major": 2,
        "version_minor": 0
       },
@@ -156,7 +160,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "ac73aff785604719a2bc8f3eef2f759b",
+       "model_id": "eeba8d3331c24b6a970666718e0ca792",
        "version_major": 2,
        "version_minor": 0
       },
@@ -170,7 +174,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "155bd3935b52428b94f5db13da9b803c",
+       "model_id": "73f73eb95c434b65902c6ba1e4e68248",
        "version_major": 2,
        "version_minor": 0
       },
@@ -184,7 +188,567 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "ac22e100d2f74d29b4ab20d32545a3dd",
+       "model_id": "44543a54f7a849068f6700f0583eda4d",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  2%|1         | 1/59 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "b482c063e7cf4e2a8f01e3f0288e03f7",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  2%|1         | 1/59 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "6c8ce04941e544339b4ccb00b896ae4c",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  2%|1         | 1/59 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "9fb6e3737f304356a212fd16b74bf2b9",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  2%|1         | 1/59 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "437c2398c327491991748cbf26fdde5d",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  2%|1         | 1/59 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "a27690d19f1440d3a53dc79999ff6d63",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  2%|1         | 1/59 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "721f7768fe814377827003930dbef042",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  2%|1         | 1/59 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "bb08d6c8e4ee4616816f4f4d5d787df6",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  2%|1         | 1/59 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "69b337b9b2f1472a90844e3551130e7e",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  2%|1         | 1/59 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "55ec042bea16448dbc8451fd56cf8c2a",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  2%|1         | 1/59 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "f9a555742890498dbc1a85c920c836eb",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  2%|1         | 1/59 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "d757d418e7c94fcda26c9caa32d2fb0c",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  2%|1         | 1/59 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "f0a8d7ed30384a07a0b455ff3d07d87f",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  2%|1         | 1/59 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "88d4c25d06874fa8b347855de4cdbf0e",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  2%|1         | 1/59 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "555908069121498f94872824874aae26",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  2%|1         | 1/59 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "4d3b882d1e6e45ad8459e922c0020322",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  2%|1         | 1/59 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "c1fc9ff22e1844418e57655d107b3a9d",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  2%|1         | 1/59 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "a55c62307a7a4f43aa1ef363840249f1",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  2%|1         | 1/59 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "68bcde48e5d54b88a1899cb36056e5ae",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  2%|1         | 1/59 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "ca4813296832442eae8f8efc653bc26f",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  2%|1         | 1/59 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "58c2c0f963904f178006a571158b74fe",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  2%|1         | 1/59 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "9f2a18f527c7431dab7167ba9dedc927",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  2%|1         | 1/59 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "cd10c4b78e4846f4be45c3225f895449",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  2%|1         | 1/59 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "67af84ca01e147859a4468d9784eb7e9",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  2%|1         | 1/59 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "312b62aee50641278e7c5e3469aefefd",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  2%|1         | 1/59 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "607a4c2ab2674c35ad2c3eeec8102846",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  2%|1         | 1/59 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "24519018d3ea4f3393734484dc090caa",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  2%|1         | 1/59 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "f8e95819999241319b25033ecac96131",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  2%|1         | 1/59 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "c6b71e70e8944bce85753663151ebff7",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  2%|1         | 1/59 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "08177120b61a4117839e1a106217a63a",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  2%|1         | 1/59 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "67f021029a8c40b68d583aa28702f5bd",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  2%|1         | 1/59 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "ad7db3f7eb784d97932c483c5b9f490b",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  2%|1         | 1/59 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "3f3eb1840b0942caa9c21106bcb0458d",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  2%|1         | 1/59 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "0437e056471143de9051cc2edcee4e5c",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  2%|1         | 1/59 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "8906565ef917471e9e0a39735960b3cb",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  2%|1         | 1/59 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "69d3e6f4fd0f4909ad7272bfc4407548",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  2%|1         | 1/59 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "effdceb1d9f04b4dbc01490a14cf9d7a",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  2%|1         | 1/59 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "8cd4fbc978a444d9874e356f8ef7faac",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  2%|1         | 1/59 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "2ac3d31c774d480e84d8e5ebcfeb876f",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  2%|1         | 1/59 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "7f5be65c224340c3bfd4fcfb4a2bebee",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  2%|1         | 1/59 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "f97a22b362134688bed2913760b60ad6",
        "version_major": 2,
        "version_minor": 0
       },
@@ -199,26 +763,26 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[2025-05-05 21:25:43,484 hyrax.pytorch_ignite:INFO] Total training time: 89.82[s]\n",
-      "[2025-05-05 21:25:43,484 hyrax.pytorch_ignite:INFO] Latest checkpoint saved as: /home/drew/code/hyrax/docs/pre_executed/results/20250505-212406-train-ID7T/checkpoint_epoch_10.pt\n",
-      "[2025-05-05 21:25:43,485 hyrax.pytorch_ignite:INFO] Best metric checkpoint saved as: /home/drew/code/hyrax/docs/pre_executed/results/20250505-212406-train-ID7T/checkpoint_10_loss=-115.1023.pt\n",
-      "2025/05/05 21:25:43 INFO mlflow.system_metrics.system_metrics_monitor: Stopping system metrics monitoring...\n",
-      "2025/05/05 21:25:43 INFO mlflow.system_metrics.system_metrics_monitor: Successfully terminated system metrics monitoring!\n",
-      "[2025-05-05 21:25:43,500 hyrax.train:INFO] Finished Training\n",
-      "[2025-05-05 21:25:43,756 hyrax.model_exporters:INFO] Exported model to ONNX format: /home/drew/code/hyrax/docs/pre_executed/results/20250505-212406-train-ID7T/example_model_opset_20.onnx\n",
-      "[2025-05-05 21:25:51,103 hyrax.models.model_registry:INFO] Using criterion: torch.nn.CrossEntropyLoss with default arguments.\n",
-      "[2025-05-05 21:25:51,104 hyrax.verbs.infer:INFO] data set has length 50000\n",
-      "2025-05-05 21:25:51,104 ignite.distributed.auto.auto_dataloader INFO: Use data loader kwargs for dataset '<hyrax.data_sets.hyr': \n",
+      "[2025-05-20 12:21:34,259 hyrax.pytorch_ignite:INFO] Total training time: 471.00[s]\n",
+      "[2025-05-20 12:21:34,260 hyrax.pytorch_ignite:INFO] Latest checkpoint saved as: /home/drew/code/hyrax/docs/pre_executed/results/20250520-121334-train-ETSe/checkpoint_epoch_50.pt\n",
+      "[2025-05-20 12:21:34,261 hyrax.pytorch_ignite:INFO] Best metric checkpoint saved as: /home/drew/code/hyrax/docs/pre_executed/results/20250520-121334-train-ETSe/checkpoint_50_loss=-88.8590.pt\n",
+      "2025/05/20 12:21:34 INFO mlflow.system_metrics.system_metrics_monitor: Stopping system metrics monitoring...\n",
+      "2025/05/20 12:21:34 INFO mlflow.system_metrics.system_metrics_monitor: Successfully terminated system metrics monitoring!\n",
+      "[2025-05-20 12:21:34,275 hyrax.train:INFO] Finished Training\n",
+      "[2025-05-20 12:21:34,563 hyrax.model_exporters:INFO] Exported model to ONNX format: /home/drew/code/hyrax/docs/pre_executed/results/20250520-121334-train-ETSe/example_model_opset_20.onnx\n",
+      "[2025-05-20 12:21:42,764 hyrax.models.model_registry:INFO] Using criterion: torch.nn.CrossEntropyLoss with default arguments.\n",
+      "[2025-05-20 12:21:42,765 hyrax.verbs.infer:INFO] data set has length 50000\n",
+      "2025-05-20 12:21:42,766 ignite.distributed.auto.auto_dataloader INFO: Use data loader kwargs for dataset '<hyrax.data_sets.hyr': \n",
       "\t{'sampler': None, 'batch_size': 512, 'shuffle': False, 'pin_memory': True}\n",
-      "[2025-05-05 21:25:51,126 hyrax.verbs.infer:INFO] Saving inference results at: /home/drew/code/hyrax/docs/pre_executed/results/20250505-212543-infer-XZTm\n",
-      "[2025-05-05 21:25:51,388 hyrax.pytorch_ignite:INFO] Evaluating model on device: cuda\n",
-      "[2025-05-05 21:25:51,390 hyrax.pytorch_ignite:INFO] Total epochs: 1\n"
+      "[2025-05-20 12:21:42,786 hyrax.verbs.infer:INFO] Saving inference results at: /home/drew/code/hyrax/docs/pre_executed/results/20250520-122134-infer-OpIj\n",
+      "[2025-05-20 12:21:42,998 hyrax.pytorch_ignite:INFO] Evaluating model on device: cuda\n",
+      "[2025-05-20 12:21:43,000 hyrax.pytorch_ignite:INFO] Total epochs: 1\n"
      ]
     },
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "a5de7ce0a99041698161ba68a9207460",
+       "model_id": "d2ac64c94ed742eb94bb6c504e3d283b",
        "version_major": 2,
        "version_minor": 0
       },
@@ -233,26 +797,26 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[2025-05-05 21:26:02,131 hyrax.pytorch_ignite:INFO] Total evaluation time: 10.74[s]\n",
-      "[2025-05-05 21:26:02,894 hyrax.verbs.infer:INFO] Inference Complete.\n",
-      "[2025-05-05 21:26:02,929 hyrax.config_utils:WARNING] Cannot find default_config.toml for torch.\n",
-      "[2025-05-05 21:26:02,930 hyrax.config_utils:WARNING] Cannot find default_config.toml for torch.\n",
-      "[2025-05-05 21:26:02,931 hyrax.config_utils:WARNING] Cannot find default_config.toml for umap.\n"
+      "[2025-05-20 12:21:54,057 hyrax.pytorch_ignite:INFO] Total evaluation time: 11.06[s]\n",
+      "[2025-05-20 12:21:54,131 hyrax.verbs.infer:INFO] Inference Complete.\n",
+      "[2025-05-20 12:21:54,383 hyrax.config_utils:WARNING] Cannot find default_config.toml for torch.\n",
+      "[2025-05-20 12:21:54,384 hyrax.config_utils:WARNING] Cannot find default_config.toml for torch.\n",
+      "[2025-05-20 12:21:57,851 hyrax.config_utils:WARNING] Cannot find default_config.toml for umap.\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "<hyrax.data_sets.inference_dataset.InferenceDataSet at 0x7f11bde49010>"
+       "<hyrax.data_sets.inference_dataset.InferenceDataSet at 0x7f513c509670>"
       ]
      },
-     "execution_count": 44,
+     "execution_count": 2,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "h.config[\"train\"][\"epochs\"] = 10\n",
+    "h.config[\"train\"][\"epochs\"] = 50\n",
     "h.train()\n",
     "h.infer()"
    ]
@@ -262,29 +826,41 @@
    "id": "0f2da27c",
    "metadata": {},
    "source": [
-    "Use the output of inference to populate a ChromaDB vector database."
+    "Now we'll use the output of inference to populate a ChromaDB vector database. By default `h.save_to_database()` will find the most recent output from `h.infer()` to use as the inputs when filling the database, but the user can specify a different dataset. Likewise, the default behavior is to create a new directory to store the vector database, but this can also be specified.\n",
+    "\n",
+    "`h.save_to_database([input_dir=\"/path/to/input\",] [output_dir=\"/path/to/output\"])`\n",
+    "\n",
+    "Note: If the goal is to add more data to an existing database, provide the existing database directory as the `output_dir` when calling `h.save_to_database`."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": 3,
    "id": "6b8e25f1",
    "metadata": {},
    "outputs": [
     {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Filling a chromadb database with the results of inference.\n"
+     ]
+    },
+    {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[2025-05-05 21:26:47,163 hyrax.config_utils:WARNING] Cannot find default_config.toml for torch.\n",
-      "[2025-05-05 21:26:47,164 hyrax.config_utils:WARNING] Cannot find default_config.toml for torch.\n",
-      "[2025-05-05 21:26:47,165 hyrax.config_utils:WARNING] Cannot find default_config.toml for umap.\n",
-      "[2025-05-05 21:26:54,821 hyrax.verbs.vdb_index:INFO] Number of inference result batches to index: 98.\n",
-      "100%|██████████| 98/98 [00:10<00:00,  9.05it/s]\n"
+      "[2025-05-20 12:22:06,574 hyrax.config_utils:WARNING] Cannot find default_config.toml for torch.\n",
+      "[2025-05-20 12:22:06,575 hyrax.config_utils:WARNING] Cannot find default_config.toml for torch.\n",
+      "[2025-05-20 12:22:06,576 hyrax.config_utils:WARNING] Cannot find default_config.toml for umap.\n",
+      "[2025-05-20 12:22:14,750 hyrax.verbs.save_to_database:INFO] Number of inference result batches to index: 98.\n",
+      "100%|██████████| 98/98 [00:11<00:00,  8.81it/s]\n"
      ]
     }
    ],
    "source": [
-    "h.index()"
+    "print(f\"Filling a {h.config['vector_db']['name']} database with the results of inference.\")\n",
+    "h.save_to_database()"
    ]
   },
   {
@@ -292,21 +868,22 @@
    "id": "fe58a5ef",
    "metadata": {},
    "source": [
-    "Some examples of simple database operations. Here we get the directory that contains the vector database that was just populated and create an instance of the ChromaDB object for querying."
+    "Now that the vector database has been populated, it can be used for similarity search and nearest neighbors. First we'll need to establish a connection using `h.database_connection()`.\n",
+    "\n",
+    "With the connection established, we have access to three types of queries:\n",
+    "* `get_by_id` to retrieve the vector associated with a particular id\n",
+    "* `search_by_id` to retrieve the _k_ nearest neighbors to a particular id\n",
+    "* `search_by_vector` to retrieve the _k_ nearest neighbors to a particular input vector"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "id": "9a7627c8",
+   "execution_count": 4,
+   "id": "6d22029f",
    "metadata": {},
    "outputs": [],
    "source": [
-    "from hyrax.vector_dbs import ChromaDB\n",
-    "from hyrax.config_utils import find_most_recent_results_dir\n",
-    "\n",
-    "context = {\"results_dir\": find_most_recent_results_dir(h.config, \"index\")}\n",
-    "cdb = ChromaDB({}, context)"
+    "conn = h.database_connection()"
    ]
   },
   {
@@ -314,12 +891,14 @@
    "id": "0a1934c7",
    "metadata": {},
    "source": [
-    "Next we'll retrieve the vectors associated with two ids. The result is a dictionary where the keys are id strings and values are the numpy array vectors stored in the vector database."
+    "### `get_by_id`\n",
+    "\n",
+    "With `get_by_id` we can retrieve the vectors associated with some ids. The result is a dictionary where the keys are id strings and values are the numpy array vectors stored in the vector database."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 24,
    "id": "9f61c605",
    "metadata": {},
    "outputs": [
@@ -327,55 +906,33 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Id: 97, Vector: [ 0.03944793  0.3558799   0.25223956 -0.0754521   1.21438968 -0.20974497\n",
-      "  0.1351877  -0.32994613 -0.31074765 -0.35594231 -0.34430811 -0.20604473\n",
-      "  0.45631796  0.43832898  0.39286935 -0.68292439 -0.43553033  0.2303443\n",
-      "  0.07766815  0.10676508  0.05971036 -0.58332515 -0.85855955  0.27715769\n",
-      "  0.29078636  0.35345447 -0.66003358 -0.21075204  0.6518687   0.41284499\n",
-      "  0.14182426  0.28613818 -0.52455962  0.50611925  0.04625352 -0.3224065\n",
-      "  0.3642571  -0.36285824 -0.10188343  0.20414513  0.24323951  0.61370313\n",
-      " -0.08387056 -0.32608244 -0.41909656  0.83472192  0.29513356 -0.05968503\n",
-      "  0.65934277 -0.46486792 -0.00231487 -0.07055005 -0.17652111  0.30367675\n",
-      "  0.28033113  0.41673368  0.70939934  0.50588834 -0.09763379 -0.34357762\n",
-      " -0.06451014  0.25463673 -0.59559703  0.27798894]\n",
-      "Id: 99, Vector: [ 0.73876572  0.19451125  0.14610657 -0.51498705  0.61082381  0.39704716\n",
-      " -0.43067837  0.31517011  0.65467519  0.8016476   0.32953    -0.07402328\n",
-      "  0.48097423 -0.41715565  0.17189725 -0.12793687 -0.31174842  0.21610478\n",
-      "  0.18904878  0.12781662  0.25548795 -0.10004312 -0.1588864   0.18900926\n",
-      " -0.60600233  0.44324812  0.11960325  0.04293833 -0.05438157 -0.49329892\n",
-      "  0.57582283  0.39957413  0.08884203  0.25487712  0.72081274 -0.6978538\n",
-      " -0.20381176 -0.16728716 -0.09492586  0.70705658 -0.02392591 -0.40256652\n",
-      " -0.00398434  0.47762519 -0.13295761 -0.07980289  0.65890872 -0.16351144\n",
-      "  0.23159459 -0.26683387  0.17476416 -0.09734846 -0.11687887  0.06231707\n",
-      "  0.24468309 -0.1957892   0.4440937   0.11096022 -0.56019002 -0.09255603\n",
-      "  0.09784195  0.54374331 -0.36552608  0.00855556]\n",
-      "Id: 334, Vector: [ 0.21758763  0.61957812  0.70391268 -0.71891177  0.03151681 -0.03021694\n",
-      " -0.78882849 -0.05880384 -0.17123401  0.10940058  0.23445277 -0.41498992\n",
-      "  0.20345522 -0.17673534  0.45089257 -0.8302533  -0.32601833  0.52293003\n",
-      "  0.12234025  0.11995897  0.48317307 -0.63917238 -0.40982932  0.01211371\n",
-      " -0.24531263  0.39203402 -0.19057278 -0.10403228 -0.21501856  0.59222835\n",
-      "  0.68357092  0.10693593  0.26825529  0.89528656  0.68839723  0.25249362\n",
-      "  0.61618882  0.24151264 -0.28890374 -0.34188798  0.2696152   0.10760415\n",
-      " -0.3607446   0.43477303 -0.55706829  0.07890901 -0.17707878  0.24020155\n",
-      "  0.81330979  0.00943825 -0.11097961  0.00190817 -0.13636126  0.37004232\n",
-      "  0.44999483  0.35046244  0.53614783  0.26852119 -0.1682405   0.57033759\n",
-      " -0.25760028  0.35980114 -0.15502594 -0.02204505]\n",
-      "Id: 19022, Vector: [ 0.17490365  0.48049939  0.43611622  0.07514876  0.9207859  -0.12114437\n",
-      " -0.48578677 -0.43594787  0.11580303  0.21337487  0.12295244 -0.27417156\n",
-      "  0.26114911  0.1373311  -0.07047495 -0.25382772 -0.37638015  0.82928431\n",
-      " -0.16666892  0.27457857  0.17267708 -0.28727862 -0.77045816  0.58270323\n",
-      "  0.50538534  0.29904756 -0.76027101 -0.25870228 -0.26126507  0.25753099\n",
-      "  0.00980249 -0.33886153 -0.47207943  0.80155778  0.34526649 -0.14036793\n",
-      " -0.12734018  0.64056575  0.21455288  0.27396193 -0.00817694 -0.08531304\n",
-      " -0.29876879 -0.01457919 -0.21274428 -0.21743254  0.17419121  0.15707381\n",
-      "  0.46332097 -0.41400301 -0.35714602  0.09599587 -0.40847179  0.09285823\n",
-      "  0.04295826  0.28861237  0.6971674  -0.02973679 -0.32608443  0.28712678\n",
-      " -0.22161517  0.06826291 -0.13286771  0.27101639]\n"
+      "Id: 334, Vector: [-3.24798942  1.98119485  1.55406356 -0.62645012  3.10358572 -3.61395788\n",
+      " -2.6421597  -0.61600274 -1.84572554  0.82733208  0.89585263 -0.05108402\n",
+      "  0.78944761 -1.05129087 -1.2733053  -0.88881552 -1.13432014  1.90325677\n",
+      " -2.20901775 -1.75057256  1.72877145  0.63546658  0.50094151 -1.30287147\n",
+      "  0.20819613  1.92933834 -0.10779276  2.74875712 -1.38990939  0.99484938\n",
+      " -3.42075944  2.14404345 -3.83847785  5.28903532 -0.82823217  1.65449035\n",
+      " -0.04479901 -0.74067652 -1.49031544  3.332618   -0.42576975  0.82981318\n",
+      " -4.09225798 -1.0847671  -0.29326448 -2.29713273 -0.0332582  -0.17452615\n",
+      "  0.31300914 -0.21796861 -2.86028075  2.05296707 -0.82099587  0.09970309\n",
+      "  1.45865738 -2.23555088 -0.17257968  2.91896725 -1.94137704 -0.20339584\n",
+      " -2.15755415  1.02150869 -0.65463024  2.33411288]\n",
+      "Id: 19022, Vector: [-2.33262563  0.04649137  3.31983447  0.50175482  1.54706371 -2.84869981\n",
+      " -0.27642718 -0.30221859 -1.88166511  1.20784402  0.14550534 -0.6565448\n",
+      "  1.47187555 -0.3599979  -0.53884566 -0.10859923  0.27937558  1.82549071\n",
+      " -0.60621667 -2.43768144  1.11523855  0.64238709 -0.73361105 -1.06656742\n",
+      " -0.18609504 -0.37470672 -0.17663226  2.28438187 -1.90835869  2.27438331\n",
+      " -1.47124481  2.12520504 -3.83304524  3.5974195  -1.34257436  0.05598652\n",
+      "  0.73499131  0.14249866 -1.02003539  3.26024556  0.73118341  0.62491828\n",
+      " -3.26831579 -1.6454109  -0.65517992 -1.52420259  0.52505571  0.08770087\n",
+      "  0.39371127 -0.10824432 -3.22489595  3.86399245 -1.10378337 -0.7202642\n",
+      "  1.86410856 -1.28097677 -0.20346631  1.94834697 -1.50692284 -0.0404964\n",
+      " -1.73626339  0.24650386  0.85735005  2.3722589 ]\n"
      ]
     }
    ],
    "source": [
-    "results = cdb.get_by_id(ids=[\"97\", \"99\", \"334\", \"19022\"])\n",
+    "results = conn.get_by_id(ids=[\"334\", \"19022\"])\n",
     "\n",
     "for k, v in results.items():\n",
     "    print(f\"Id: {k}, Vector: {v}\")"
@@ -386,28 +943,30 @@
    "id": "14cff8dc",
    "metadata": {},
    "source": [
-    "Here we'll search for the 5 nearest neighbors of the vector with id = '334'. Note that the closest of the 5 neighbors is the vector itself, since it's in the database."
+    "### `search_by_id`\n",
+    "\n",
+    "Now we'll search for nearest neighbors. First we search for the _k_ nearest neighbors of using an id from the database. Note that the closest of the 5 neighbors is the vector itself, since it's in the database. The returned dictionary contains the ids of the nearest neighbors in order of increasing distance."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 25,
    "id": "b7d4b69e",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{0: ['3133', '3608', '30942', '37903', '30307']}"
+       "{'19022': ['19022', '29955', '30105', '43441', '431']}"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 25,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "cdb.search_by_id(\"3133\", k=5)"
+    "conn.search_by_id(\"19022\", k=5)"
    ]
   },
   {
@@ -415,22 +974,46 @@
    "id": "8079aa88",
    "metadata": {},
    "source": [
-    "We can repeat the search, using the vector that we found when running `get_by_id`. The results from this search should match those of `search_by_id`."
+    "### `search_by_vector`\n",
+    "\n",
+    "We can repeat the search this time using the vector that we found when running `get_by_id`. The results from this search should match the previous results from `search_by_id`. Again, the returned dictionary contains the ids of the nearest neighbors in order of increasing distance.\n",
+    "\n",
+    "Note that the input vector to `search_by_vector` is a list of vectors. Also the input vectors don't need to be vectors extracted from the database. For example - if a new piece of data was run through `infer`, the resulting vector could be passed as input to `search_by_vector` to find similar data. This is why the keys of the returned dictionary are integers, they are the indexes of the input vectors."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 26,
    "id": "81088de0",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{0: ['19022', '29955', '30105', '43441', '431']}"
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "neighbors = cdb.search_by_vector([results[\"99\"]], k=2)"
+    "neighbors = conn.search_by_vector([results[\"19022\"]], k=5)\n",
+    "neighbors"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3a32ea79",
+   "metadata": {},
+   "source": [
+    "We have now successfully queried our vector database. Let's take a look at the nearest neighbors that were found for the example image. First we'll get an interactive copy of the original dataset, and write a couple of helpful plotting functions so that we can plot the original images."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 27,
    "id": "32946b37",
    "metadata": {},
    "outputs": [
@@ -438,7 +1021,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[2025-05-06 20:38:13,897 hyrax.prepare:INFO] Finished Prepare\n"
+      "[2025-05-20 12:29:02,797 hyrax.prepare:INFO] Finished Prepare\n"
      ]
     }
    ],
@@ -447,8 +1030,16 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "44c22fce",
+   "metadata": {},
+   "source": [
+    "The following is some boilerplate code for displaying either a single image or a collection of images from `dataset`."
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 28,
    "id": "2d245a5f",
    "metadata": {},
    "outputs": [],
@@ -468,68 +1059,9 @@
     "    if title:\n",
     "        plt.title(title)\n",
     "    plt.axis(\"off\")\n",
-    "    plt.show()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 22,
-   "id": "bd6f001f",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYUAAAGbCAYAAAAr/4yjAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjEsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvc2/+5QAAAAlwSFlzAAAPYQAAD2EBqD+naQAAInpJREFUeJzt3WmQnXXZ5/HfffY+vXenlxAg0IYkHZYA8oBoWB8lWKAVCoZheGYAWcoCrUIGEPNCYbQEEVAKUJAHFBxqyvKBiBQuY9BgKUaCYNgDWQWydHrvPt1n63PueeHwH5lEc10BxMLvp4oXdF25uM99lt+5k9w/ojiOYwEAICnxXh8AAOAfB6EAAAgIBQBAQCgAAAJCAQAQEAoAgIBQAAAEhAIAICAUAAABoYB33ZYtWxRFkW6++eZ3bOfjjz+uKIr0+OOPv2M7/54uuOACHXDAAe/1YQC7IBSwW/fdd5+iKNIf/vCH9/pQ3hWvvPKKrrjiCn34wx9WLpdTFEXasmXL29r59zxnhUJBn/vc57Tvvvsqm82qv79fd955525nV65cqSVLliifz6u9vV1nnXXW236seP8iFPBPafXq1brttts0OTmp/v7+9/pwXGq1mpYuXao777xTZ599tm699VYtWLBAl112ma6//vq3zD766KM69dRTVS6X9bWvfU1XXnmlfv3rX2vJkiUaHBx8jx4B/pGl3usDAN4Ln/zkJzU2Nqbm5mbdfPPNWrt27Xt9SGYrVqzQ7373O91777268MILJUmXXnqpzjrrLH3lK1/RxRdfrO7ubknSNddco76+Pj3xxBPKZDKSpE984hM68sgj9bWvfU233HLLe/Y48I+JKwXstUqloi996Uv64Ac/qNbWVjU2Nuq4447TqlWr/uqv+eY3v6m5c+eqoaFBJ5xwgl544YVdZtatW6ezzjpLHR0dyuVyOuqoo/TII4/s8Ximp6e1bt06DQ0N7XG2o6NDzc3Ne5x7Jzz88MM65JBDlMvldMghh+hHP/rRbue2b9+udevWqVqt/s19v/nNbyRJ55xzzlt+fs4556hUKunHP/6xJGlkZEQvvfSSzjjjjBAIkrR48WL19/frBz/4wdt5WHifIhSw1yYmJnTPPffoxBNP1I033qjrrrtOg4ODWrp06W6/eX//+9/Xbbfdps985jNavny5XnjhBZ188skaGBgIMy+++KI+9KEP6eWXX9YXvvAF3XLLLWpsbNSyZcv+6ofpm9asWaP+/n7dcccd7/RD3Wu/+MUvdOaZZyqKIt1www1atmyZPvWpT+32zx2WL1+u/v5+bd269W/uLJfLSiaTb/mgl6R8Pi9Jevrpp8OcJDU0NOyyI5/Pa9u2bdqxY8dePS68f/HbR9hr7e3t2rJly1s+nC655BItXLhQt99+u+699963zG/YsEHr16/XnDlzJEmnnnqqjjnmGN144436xje+IUm6/PLLtf/+++upp55SNpuVJF122WVasmSJrrnmGp1xxhl/p0f3zrjmmmvU09Oj3/72t2ptbZUknXDCCTrllFM0d+7cvdq5YMEC1Wo1/f73v9eSJUvCz9+8gngzVHp6etTW1qYnnnjiLb9+eHhYL730Upjt7e3dq+PA+xNXCthrf/lttV6va2RkRDMzMzrqqKP0zDPP7DK/bNmyEAiSdPTRR+uYY47RT3/6U0l//u2OX/3qVzr77LM1OTmpoaEhDQ0NaXh4WEuXLtX69ev/5rfoE088UXEc67rrrntnH+he2r59u9auXavzzz8/BIIkfexjH9OiRYt2mb/vvvsUx/Ee/6rqueeeq9bWVl144YVauXKltmzZorvvvlvf/va3JUnFYlGSlEgk9OlPf1q//OUvtXz5cq1fv15PP/20zj77bFUqlbfMAm8iFPC23H///TrssMOUy+XU2dmprq4u/eQnP9H4+PguswcddNAuP5s/f37465EbNmxQHMf64he/qK6urrf8c+2110qSdu7c+a4+nnfSn/70J0m7f9wLFizY6729vb165JFHVC6Xdcopp+jAAw/U1Vdfrdtvv12S1NTUFGa//OUv66KLLtLXv/51zZ8/X0cddZRSqZQuuuiiXWYBid8+wtvwwAMP6IILLtCyZct09dVXq7u7W8lkUjfccIM2btzo3lev1yVJV111lZYuXbrbmXnz5r2tY36/OP7447Vp0yY9//zzmpqa0uLFi7Vt2zZJfw7aN2UyGd1zzz366le/qldffVU9PT2aP3++zj33XCUSCc4ndkEoYK89+OCD6uvr04oVKxRFUfj5m9/q/3/r16/f5Wevvvpq+O2Svr4+SVI6ndZHP/rRd/6A/87e/DOD3T3uV1555W3vTyaTOvzww8O/P/bYY5K023PX09Ojnp4eSX++z+Hxxx/XMcccw5UCdsFvH2GvJZNJSVIcx+FnTz75pFavXr3b+YcffvgtfyawZs0aPfnkk/r4xz8uSeru7taJJ56o73znO9q+ffsuv35PN1t5/krq38Ps2bN1+OGH6/7773/Lb6etXLky/EHvX7L+ldTdGRwc1I033qjDDjtsj4F68803a/v27bryyivd/x28/3GlgL/pu9/9rn7+85/v8vPLL79cp59+ulasWKEzzjhDp512mjZv3qy77rpLixYtUqFQ2OXXzJs3T0uWLNGll16qcrmsW2+9VZ2dnfr85z8fZr71rW9pyZIlOvTQQ3XJJZeor69PAwMDWr16td544w09++yzf/VY16xZo5NOOknXXnvtHv+weXx8PPwe/Jt/O+eOO+5QW1ub2tra9NnPfjbMXnDBBbr//vu1efNmd1/RDTfcoNNOO01LlizRhRdeqJGREd1+++06+OCDdzlHy5cvN/93TjjhBB177LGaN2+eduzYobvvvluFQkGPPvqoEon/913vgQce0EMPPaTjjz9eTU1Neuyxx/TDH/5QF198sc4880zXY8E/iRjYje9973uxpL/6z+uvvx7X6/X4+uuvj+fOnRtns9n4iCOOiB999NH4/PPPj+fOnRt2bd68OZYU33TTTfEtt9wS77fffnE2m42PO+64+Nlnn93lv71x48b4vPPOi3t7e+N0Oh3PmTMnPv300+MHH3wwzKxatSqWFK9atWqXn1177bV7fHxvHtPu/vnLY4/jOD7zzDPjhoaGeHR01HTOnnrqqbf8/KGHHor7+/vjbDYbL1q0KF6xYsUu5yiO4/j888+PJcWbN2/e4/FfccUVcV9fX5zNZuOurq743HPPjTdu3LjL3JNPPhkff/zxcXt7e5zL5eLFixfHd911V1yv1/f438A/pyiO/+LaH8Auenp6dN555+mmm256rw8FeNcRCsDf8OKLL+rYY4/Vpk2bNGvWrPf6cIB3HaEAAAj420cAgIBQAAAEhAIAICAUAACB+ea14086xLW4MD5inp2plF27k2l7luXz0Z6H/kJcd9zPl/Dd+1cp2x9n2nlbYa1acc2nU/b/wUwk3znMZLLm2fZZPa7dbS2zzbPPPfcb127FvnO4aKH9PfGhxR9x7X762TXm2R1bn3ftzufS5tl9mrtcuxtn9ZlnD/uIfVaSJspjrvmXNz9pnu3t8f0Pl3o6W8yz2XzNtbutyf7+eW7tjGv356/52R5nuFIAAASEAgAgIBQAAAGhAAAICAUAQEAoAAACQgEAEBAKAICAUAAABIQCACAgFAAAgblhJ4p8/UTppH02kcm5dqeyjizz1fYoiu0HXprynZO66ubZtKM/SJKilO//lRSlPJ0pGdfukYlx8+zg6Khrd7G41jwbOc63JDU2+F6HA6PD5tmVq3/p2l2P7H0545WSa3dD3v44J0q+3W0tTfbjyM5z7d5vtq+faGx8m3m2o9P3OJtb7J8T0+WCa3dh2v5+y+XtPVZWXCkAAAJCAQAQEAoAgIBQAAAEhAIAICAUAAABoQAACAgFAEBAKAAAAkIBABCYay6qM74ahXxLo3m26GuLUL1mvyW9NuO7Dbxcsh9MU5P9ln5JiqsT5tla3VfRUI98+Z5NOfo/kr7b9NMz9hqFymTRtTubc1RuRJ4qDymOKq75rQOvmWfTafNbTZJUnrbXXGR8b01NZOyPs5ywH4ckVbY8b56drmx17c5l213z++y3r3m2NPmia/fApP21lcz4unYm4ynz7M4RXz2HBVcKAICAUAAABIQCACAgFAAAAaEAAAgIBQBAQCgAAAJCAQAQEAoAgIBQAAAEhAIAIDAXsuRyvvwYG582z0axo89GUmODvVsnn7fPSlJh2t5TEse+fqJixV5Sk2/ynRPVfD0/xWl751C15HucqVzVPBtFzt2ppHk29n7nqflKhBrS9l6tatXXfZSo2R9nPfb130xN2fu9GhqaXbuL06Pm2YFB33EXpu1dU5LU0vGv5tlcfrZr90Rph3m2VPS9rmqyd1MNjTuL4wy4UgAABIQCACAgFAAAAaEAAAgIBQBAQCgAAAJCAQAQEAoAgIBQAAAEhAIAIDDfe1+YsNciSFLVcQd7W6uviqJUtFdo1GZ89Q/j4/ZbzCcmJly7OzvtlQHNDa7VGht31lwU7LfepzO+iobpKfuxeKtC4tj+PaZcrLl216u+OoIoaT/2bNp3LFHOfiwzvtVSwl7lkk/aZyWpWLHPD45OuXZns77PiYmxYfPsqLMuYueQfb6lxffd2/ORVZzyPT8WXCkAAAJCAQAQEAoAgIBQAAAEhAIAICAUAAABoQAACAgFAEBAKAAAAkIBABAQCgCAwFxqk2lIuhbnGtLm2cL4uGt31VH2Uqn4envK5YJ5tqPT/hglqaXFPrtjq/04JKlSr7rmszn785n2PUylcvZfUJr2dbeUSvbHmcs6n3vZe68kKa7bS2pqvreP0pH9+1qt6juHCUeXVbHBt3usYD+H1ZqvtKm9w/dC3D7wunm2Uvd1u5Uc5W6loq+zqVazd2oVy97iqz3jSgEAEBAKAICAUAAABIQCACAgFAAAAaEAAAgIBQBAQCgAAAJCAQAQEAoAgMB8v/v0pP3Wa0lKJO23jad8bQRKpjPm2dhxy7gkHbSozTzb3Og78Ikhe0VDrd1XL1As+m53T6TsvQsV56307Z323R1dvuqCyXH7eSkXfc99Z2+jaz4b2Y99fNJXoVGV/ZwnM75zWHTUxEzXff0c1Zq9/qFW9J2TiVHf67BcsdeQtHd0uHbXYvvsdOyrrMmm7J9vtfqka7cFVwoAgIBQAAAEhAIAICAUAAABoQAACAgFAEBAKAAAAkIBABAQCgCAgFAAAASEAgAgMJf3tOZ9+ZHM2nuBChO+DpR0yl48ksnZe0QkqV6xd+tUI3uXkSTFGXsXz6wW12ptfc3XlTRdsB9LLfY9zlTO/ty3t/h6e2pF++PMNvi6qfLe10rdfg7rBd9rvL0rZ56d9lXraHLc3k80PDju2t2ct5/DtGNWkmbqjsIhSdWSfX583NchVC7ZT3oub38uJSndZn+N7zOny7XbgisFAEBAKAAAAkIBABAQCgCAgFAAAASEAgAgIBQAAAGhAAAICAUAQEAoAAACcw9Aue6rUZjcYb8NvL3D1+lQr02bZysJZ9VBvmyeLZR9t93XKvaqg1zGVwHQ0uKbb2tKmmeHR+11DpI0Nuyo0Cj76h9Ssp/zpmbfOSlN2597Sao4jr21PevanUnZX7fZVtdqDQ/Y38sNjteJJBXK9vdm1lGHIkll7/tt2l7Pkq/5XivpnP0cTjtfV7Fq5tliccq124IrBQBAQCgAAAJCAQAQEAoAgIBQAAAEhAIAICAUAAABoQAACAgFAEBAKAAAAkIBABCYy0cmC76OjVrN3gszVfR1g0yM2eezaXv/iSSlkmnzbDLh64PyJHClYu8/kaRU2jffkLH3yExXfN8d4ti+e6bs61WqpezPT3Gk5NqdTfq6eNLJBvNsLbZ3AklS0vE6rBR9z08isr9ux8Z93VTtnfaOp2LZ974vV3zdR51tOfuxTM24dk+X7fN131tT46P2x7lPb7tvuQFXCgCAgFAAAASEAgAgIBQAAAGhAAAICAUAQEAoAAACQgEAEBAKAICAUAAABIQCACAwl7005+w9L5I0MFk0z04XJ1y74zhpn635ikemJuw52beoybW7NG6fHS34emHiuq9DqDRjn29os59vSWpscvT2jPuOe3TIfl7qSV9XTj3y9d/Ess83tvu+f9UT9s6h1q68a3df1j4/Nurrj5qpOs5hzff8NLf6zmFru6ObrO7rvXptm73LqqOj0bW7tTljnq2U7Z+zVlwpAAACQgEAEBAKAICAUAAABIQCACAgFAAAAaEAAAgIBQBAQCgAAAJCAQAQmO/tbsznXIsTaXs1QqLuu9095ziUrl7fcc/qsd/uPlPzVVFMFOyVG5Up12rNVH11Hp1z7LUlbR2+YymX7ccyMe07hzOxvRYjLvu+88w+yF4vIEnVkv1xJiPf85NMOeYTvnqOVMY+39Tsq3/YOWCv52jM+nZnco7aCkljBfvjbGnyPff7NNorbryVNa2OWplczldBY8GVAgAgIBQAAAGhAAAICAUAQEAoAAACQgEAEBAKAICAUAAABIQCACAgFAAAAaEAAAjM5SOvbHzDtzlKm0dzDb5s6t7H3tvT2WnvypGkhOw9TDMVX3dLY5O9u6Uhaz9/kvSnLb5uncjxfaAw6evWGR22z89Ufb1Xiuy7s0151+qZiu9xJlOO123N18E1Omrvy8mkpl270/a3vaKar1sndnRw1SPfc5/wVR+pXrY/n1NZ32fQgb3292divOTaXXO8J2oJuo8AAO8iQgEAEBAKAICAUAAABIQCACAgFAAAAaEAAAgIBQBAQCgAAAJCAQAQmO93r9d9tQvVStU829mVde3uW9honh3dbq8LkKSREft8U7trtVra7PUCo4O+6oLOOb7nJ99sv5V+dNDXL1At26sOjumb79p9UFenefaHL6xx7VbKVxmw8SX7c9S1T8a1O3ZUQMzM+L7blRxVFLWKrz4llbPXyuzzgSbX7tKEr7KmuK1onm2s2mclabRkr66YcdSKSFJl2v7ZmW1wdn8YcKUAAAgIBQBAQCgAAAJCAQAQEAoAgIBQAAAEhAIAICAUAAABoQAACAgFAEBAKAAAAnMpx37tra7FG7YOmGenCr5+ohee32merRZ9fSkNDfY+lpFNvn6i9ln2bp1q2d5/Ikn1yNcftWOrfX++0dcJVJqeMc8e2evrPjrlQ/9inh0vV1y7X9j8mmv+Xxf1m2fXvrHRtTtqtL8nqtO+537Ovvb+qM0b7O9jSerN2z8nejO+vq5C0veeaGjNm2eHhsZcu9MNDebZmarv862lyd6T1RH5OrUsuFIAAASEAgAgIBQAAAGhAAAICAUAQEAoAAACQgEAEBAKAICAUAAABIQCACAw11x0tre4Fg8Xx82zowOxa3dct9cuNHf6ai6mClPm2VSDL1OLk/bjLtoPQ5JUqvl+wdSYfba7p9m1u1qyVwBsKE66dud//4x59pT97TUUknRQepZrvn9un3n2kn9f59o9Mlgwzx595OGu3Qcc0G2eLTkraMaG7VUUgwONrt3l3JhrvlqxH3sl3e7a3T3bfg7jwnbXbjk+DlO5Nt9uA64UAAABoQAACAgFAEBAKAAAAkIBABAQCgCAgFAAAASEAgAgIBQAAAGhAAAICAUAQGDuPpqcmXAtbmqxdyUVCr7+m6lxe6dJLptx7W7vsvcT7dxZ8e3usM9Xy74+qMER37HUS/ZOqIlhX/9NIsqZZw897r+6dhd2bHXMbnTtniiMuuaHXrcfy1XnnOHa/fgfnzXPNs450LW7t6PLPFtcaO8wk6Str71knh15w9cJVGzyvSeijP29XJ30vX9eeW2HeXai6Htd9bS1mmfnz5vr2m3BlQIAICAUAAABoQAACAgFAEBAKAAAAkIBABAQCgCAgFAAAASEAgAgIBQAAAGhAAAIzN1HGzePuBZXazXzbL7R10/UPSdtni0VZ1y7Jwr2TqC0+ez92eY37LtnNfvy+uDuRtf8lGaZZ6tVXy9MNps3zy4+4oOu3bXiYvNs/fk/uHb/8if2PhtJ2rb1RfPsOef+m2v35EjBPPvQsy+7dp/0qcPtw84XecXR2bVvVHLtTr+41jXfnLV/TqQi+6wkjUX28zKes3cZSdJMxt4dVh0ddO224EoBABAQCgCAgFAAAASEAgAgIBQAAAGhAAAICAUAQEAoAAACQgEAEBAKAIAgiuPYdF/6vr1drsXptL3SIZOLXLurkb12oTblq2jo7LPfYp6qNLt2nzqZNM+ePbjNtfuR7gNc8z9rbjHPRrWya3fF3nCiD5/0UdfufzvpZPPszKYNrt2r1v7ONb9951bz7JJFh7p2D42PmmfrSfvrSpJ25uzPfXl4wLW7ed4B5tkFM/bPCEn6ZL7bNZ+W/YUYNzS4dselqnm2/sZO1+7itu3m2dc2POPafcjaPb8nuFIAAASEAgAgIBQAAAGhAAAICAUAQEAoAAACQgEAEBAKAICAUAAABIQCACAgFAAAQco62NLmKLSR1NZi7wXaOjjk2l2atHcljRd8vUr/0tFhnr123sGu3QfP2s88m9hp776RpM0bn3fN/0fV3mcU1XzPfSK2n/Mnfv4T1+4jeu2vq2jHa67dhyzqdc1/8uz/Yp6dlK+faLbsz8/dd9zm2t09r9882zpvf9fu2bG9Q+iwfMa1O17Y55qv9C82zybm+97Lem6tebS+8heu1emdr5tnF1ZmXLstuFIAAASEAgAgIBQAAAGhAAAICAUAQEAoAAACQgEAEBAKAICAUAAABIQCACCI4jiOLYMnHOyrACiW7dUI4+NTrt3pBntlwGmR/bZ7Sboq026ebe2wz0rSTL1unk1t3uLaraK9FkGSvtuaNc+uaG5x7R6N7M99JeWrfzhpP3tVyKzIt/sjs7pd83O69zHPVocHXbubilXz7KY1z7p2dzqaX1pz9tesJDWNF8yz6dhXn5IrV1zzUa/9Myty1lzUm/Lm2URh3LU7HnNU3IyXXLvTT6/e4wxXCgCAgFAAAASEAgAgIBQAAAGhAAAICAUAQEAoAAACQgEAEBAKAICAUAAABIQCACAwdx9duuwg1+KmDntfThSlXLt7NgyYZy95zdfdkvyA/XGm5i5y7Y5W77l35E3xay/7dsveZSRJqs+YRwc7Wl2rh5s7zbOFjKOIR9KB2SbzbEfbLNfuyNGpJUlRxv66jfP245akZIt9PtllP9+SpHyzeTTO51yr66mMebY24+syqid8r5VUh/35TyZ8z73S9sdZ9x224lWr7MM/W+nanVq3do8zXCkAAAJCAQAQEAoAgIBQAAAEhAIAICAUAAABoQAACAgFAEBAKAAAAkIBABCY79Pf13krfTptv228Vjc1bQQnb5gyz2aafVUHidYe+/BzT7t2R4Nb7bOHfNi3+4jFrnntN8c8Oqet3bV6TtZeAaBS2bW7PmSvONHwoGt3rWKv/pCkRIO9iiKq+yodaoVp82y8aZtrd5yxfxeMI985icv2+bhc9O121lxUWux1Hsmcr8pF7fb52r6+z6DkvD777MX/zbXbgisFAEBAKAAAAkIBABAQCgCAgFAAAASEAgAgIBQAAAGhAAAICAUAQEAoAAACQgEAEJi7jzry9p4XScqm0ubZ/MC4a/cHCvYemaiww7W79saj5tnpXkdPkqTEgvn24YUHuXZrlr3nRZISA5vNs/U/PuPanRybNM/WSiXX7g1xwTzb4ujhkaSOou9YspW6ebaeNb/VJElRtWYfrvoeZ5TJmmfrchyHfMedSPrOSew8FkX2+ZrvqVcU2bvdcjlHF5ikN2r253PK+bX+4Kuu3OMMVwoAgIBQAAAEhAIAICAUAAABoQAACAgFAEBAKAAAAkIBABAQCgCAgFAAAATm+8yrZd994JWy/RbzhS8PuHbnYvst5jMzVdfuGdlvMc+N+eo58kNj5tl4zVOu3XHd9zirsf35qcaxa3fk+K4RJSPX7gOS9vqUdMJXo5CMfXURcWyvuUjI/pr17o4cs5Kkuv259x21pNj+fCbqvteV9O69Dr3fj6uOyo1vJHyv8f/lOJQJ5yncZJjhSgEAEBAKAICAUAAABIQCACAgFAAAAaEAAAgIBQBAQCgAAAJCAQAQEAoAgIBQAAAE5nKYto5ZrsUz4/ZukNlbfB1ClekJ82zs7O1JOsZLpUHX7t+l7b09U3PaXbujiq/7aPakvctqXsHXexXJ0fUyY3+dSFLaOe/h3exptIld0z7O5iPncXt5j8bO/fxE9l+RcT7S/5mx92rd3JJz7V44f555dv/cO/+64koBABAQCgCAgFAAAASEAgAgIBQAAAGhAAAICAUAQEAoAAACQgEAEBAKAICAUAAABOYCj1zO19+RWv2iebZtbMy1u+zoKXH18EiqRPb5/5HPunb/cb9u8+zcRf2u3V29B7jmh159wTw77zdPuXb/9/KMeTbpfH7qjnlvb4+3RaYWvXuvw4Tr4H2P1HMk3m+Nno4n//PjO4ep2N7DNO48mh+k7d1HfbN7XLv/8+n/yTzb2Oj7DLLgSgEAEBAKAICAUAAABIQCACAgFAAAAaEAAAgIBQBAQCgAAAJCAQAQEAoAgMB8r3Zl2l5dIEmHbpiwH0Q249odFcuO6Zpr988zDebZ/93R7tq9eFaTeTajSdfuzib7cUtSqbPZPPvofl2u3UdvHjDPHl/31Qt4ns1M7NttL0X4s6Rjv//bl3237xUuxZ62CG8XhYO3ViTpnH99/w7z7GvFqmv3VseLZXGX/b0mSa9sWWee7Wxvce224EoBABAQCgCAgFAAAASEAgAgIBQAAAGhAAAICAUAQEAoAAACQgEAEBAKAICAUAAABObuo2Te3iMiSU8d3W+ejdb5+jty618xz7bUfI0paxP2JplU2rVauZy942n/RntPkiRVhjb6jiW2dyu1tLa6dv86N2yePbnga+5JORqKvLU95jfDXvEdjWfafdzvYp/Ru7hakXN7Q8nekbYt9n0/TmSz5tnOvH1WkupTm8yzlVLetduCKwUAQEAoAAACQgEAEBAKAICAUAAABIQCACAgFAAAAaEAAAgIBQBAQCgAAALzHfKZjL1eQJIG9m02z/7HVl/VwTPdjebZmfGSa/erNfuxRHVfpmaaO82zvd09rt1Rfdo1/6cp+633lXLRtXsothcvjM72VWiM9B9ink3PzLh2p+LINZ+o2WsXkjXf+0eR57Xle/+obp+PE75z4im6qM/4jjvh/A6bn7S/JypvbHDtjhrt9Tkzdd9z39c22zxbr1Vduy24UgAABIQCACAgFAAAAaEAAAgIBQBAQCgAAAJCAQAQEAoAgIBQAAAEhAIAICAUAACBuaSmsbHDtTibs/fO/LrBl02ra/bdhYSvdyQle9dL88SEa3e6od08O/vgE127p4aHXPM7X19lni2UfR01f5ix9019r2TvkJGk1we3mmeTztqeTMJ3LJnIPl93dgglk/bdUfTu9RNFzj6oyPH+iZK+971ntyRVWjLm2VdSvt2x42NlsmbvApOkSr7JPJvL2metuFIAAASEAgAgIBQAAAGhAAAICAUAQEAoAAACQgEAEBAKAICAUAAABIQCACAw33+9z75zXIvjtP0W848UC67dC2b3mGenSkXX7nrNfv/6lh3Drt3PP/+ceXbhgiNdu5safbe77xgYNc+Oj4y4dpcb7JUB301UXLsTr282z06WfLurVV8liucblb1Y4v/OO36Bt+XCcyzeAg3POXE2fyjja4tQW1OzeXZnreraXR21V9wMDE/6dkf24+6be4RrtwVXCgCAgFAAAASEAgAgIBQAAAGhAAAICAUAQEAoAAACQgEAEBAKAICAUAAABIQCACCI4tjTsgIAeD/jSgEAEBAKAICAUAAABIQCACAgFAAAAaEAAAgIBQBAQCgAAAJCAQAQ/B+nkPW9YpMmjAAAAABJRU5ErkJggg==",
-      "text/plain": [
-       "<Figure size 640x480 with 1 Axes>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "d = dataset[99]\n",
-    "show_image(d)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 44,
-   "id": "8ac4f559",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "hello\n"
-     ]
-    },
-    {
-     "ename": "AttributeError",
-     "evalue": "'Axes' object has no attribute 'flatten'",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
-      "\u001b[31mAttributeError\u001b[39m                            Traceback (most recent call last)",
-      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[44]\u001b[39m\u001b[32m, line 43\u001b[39m\n\u001b[32m     40\u001b[39m \u001b[38;5;28;01mfor\u001b[39;00m n \u001b[38;5;129;01min\u001b[39;00m nearest_neighbors[\u001b[32m1\u001b[39m:]:\n\u001b[32m     41\u001b[39m     data_list.append(dataset[\u001b[38;5;28mint\u001b[39m(n)])\n\u001b[32m---> \u001b[39m\u001b[32m43\u001b[39m \u001b[43mshow_image_grid\u001b[49m\u001b[43m(\u001b[49m\u001b[43mdata_list\u001b[49m\u001b[43m)\u001b[49m\n",
-      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[44]\u001b[39m\u001b[32m, line 17\u001b[39m, in \u001b[36mshow_image_grid\u001b[39m\u001b[34m(data_list)\u001b[39m\n\u001b[32m     15\u001b[39m     cols = \u001b[38;5;28mlen\u001b[39m(data_list)\n\u001b[32m     16\u001b[39m fig, axes = plt.subplots(rows, cols, figsize=(cols * \u001b[32m3\u001b[39m, rows * \u001b[32m3\u001b[39m))\n\u001b[32m---> \u001b[39m\u001b[32m17\u001b[39m axes = \u001b[43maxes\u001b[49m\u001b[43m.\u001b[49m\u001b[43mflatten\u001b[49m()  \u001b[38;5;66;03m# Flatten the axes for easy iteration\u001b[39;00m\n\u001b[32m     19\u001b[39m \u001b[38;5;28;01mfor\u001b[39;00m ax, data \u001b[38;5;129;01min\u001b[39;00m \u001b[38;5;28mzip\u001b[39m(axes, data_list):\n\u001b[32m     20\u001b[39m     image = data[\u001b[33m'\u001b[39m\u001b[33mimage\u001b[39m\u001b[33m'\u001b[39m]\n",
-      "\u001b[31mAttributeError\u001b[39m: 'Axes' object has no attribute 'flatten'"
-     ]
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAScAAAEYCAYAAAAedjA5AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjEsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvc2/+5QAAAAlwSFlzAAAPYQAAD2EBqD+naQAAF2ZJREFUeJzt3H9M03cex/EXVFs0s5UdR/lxdQR3zm0q3EB61RnjpRuJhh1/XMapAY7445yccTR3E0TpnDfqeZ4hmTgip3N/zIPdomYZBG/rJIuTCzmgiTtBw9DBLdcKt7PlcGuBfu4PYzcEHN9Kywd4PZL+wXefT79vcH3m21IaIYQQICKSTORUD0BENBbGiYikxDgRkZQYJyKSEuNERFJinIhISowTEUmJcSIiKTFORCQlxomIpKQ4Tp988gmysrKQkJCAiIgInD9//nv3NDY24plnnoFGo8Hjjz+O06dPBzEqEc0miuM0MDCAlJQUVFZWTmj9jRs3sGHDBqxbtw4OhwMvv/wytm7digsXLigelohmj4iH+cPfiIgInDt3DtnZ2eOu2bNnD+rq6vDZZ58Fjv3yl7/E7du30dDQEOypiWiGmxPqEzQ1NcFsNo84lpmZiZdffnncPV6vF16vN/C13+/HV199hR/84AeIiIgI1ahEFAQhBPr7+5GQkIDIyMl7GTvkcXI6ndDr9SOO6fV6eDwefP3115g3b96oPTabDQcOHAj1aEQ0iXp6evCjH/1o0u4v5HEKRklJCSwWS+Brt9uNRYsWoaenB1qtdgonI6L7eTweGAwGLFiwYFLvN+RxiouLg8vlGnHM5XJBq9WOedUEABqNBhqNZtRxrVbLOBFJarJfcgn5+5xMJhPsdvuIYx9++CFMJlOoT01E05jiOP3vf/+Dw+GAw+EAcPetAg6HA93d3QDuPiXLy8sLrN+xYwe6urrwyiuvoKOjA8ePH8e7776LoqKiyfkOiGhmEgpdvHhRABh1y8/PF0IIkZ+fL9auXTtqT2pqqlCr1SI5OVm89dZbis7pdrsFAOF2u5WOS0QhFqrH50O9zylcPB4PdDod3G43X3MikkyoHp/82zoikhLjRERSYpyISEqMExFJiXEiIikxTkQkJcaJiKTEOBGRlBgnIpIS40REUmKciEhKjBMRSYlxIiIpMU5EJCXGiYikxDgRkZQYJyKSEuNERFJinIhISowTEUmJcSIiKTFORCQlxomIpMQ4EZGUGCcikhLjRERSYpyISEqMExFJiXEiIikxTkQkJcaJiKTEOBGRlBgnIpIS40REUmKciEhKQcWpsrISSUlJiIqKgtFoRHNz8wPXV1RU4IknnsC8efNgMBhQVFSEb775JqiBiWh2UByn2tpaWCwWWK1WtLa2IiUlBZmZmbh169aY68+cOYPi4mJYrVa0t7fj5MmTqK2txd69ex96eCKauRTH6ejRo9i2bRsKCgrw1FNPoaqqCvPnz8epU6fGXH/58mWsXr0amzZtQlJSEp5//nls3Ljxe6+2iGh2UxQnn8+HlpYWmM3mb+8gMhJmsxlNTU1j7lm1ahVaWloCMerq6kJ9fT3Wr18/7nm8Xi88Hs+IGxHNLnOULO7r68Pw8DD0ev2I43q9Hh0dHWPu2bRpE/r6+vDss89CCIGhoSHs2LHjgU/rbDYbDhw4oGQ0IpphQv7busbGRpSXl+P48eNobW3F2bNnUVdXh4MHD467p6SkBG63O3Dr6ekJ9ZhEJBlFV04xMTFQqVRwuVwjjrtcLsTFxY25Z//+/cjNzcXWrVsBAMuXL8fAwAC2b9+O0tJSREaO7qNGo4FGo1EyGhHNMIqunNRqNdLS0mC32wPH/H4/7HY7TCbTmHvu3LkzKkAqlQoAIIRQOi8RzRKKrpwAwGKxID8/H+np6cjIyEBFRQUGBgZQUFAAAMjLy0NiYiJsNhsAICsrC0ePHsVPfvITGI1GdHZ2Yv/+/cjKygpEiojoforjlJOTg97eXpSVlcHpdCI1NRUNDQ2BF8m7u7tHXCnt27cPERER2LdvH7788kv88Ic/RFZWFl5//fXJ+y6IaMaJENPguZXH44FOp4Pb7YZWq53qcYjoO0L1+OTf1hGRlBgnIpIS40REUmKciEhKjBMRSYlxIiIpMU5EJCXGiYikxDgRkZQYJyKSEuNERFJinIhISowTEUmJcSIiKTFORCQlxomIpMQ4EZGUGCcikhLjRERSYpyISEqMExFJiXEiIikxTkQkJcaJiKTEOBGRlBgnIpIS40REUmKciEhKjBMRSYlxIiIpMU5EJCXGiYikxDgRkZQYJyKSEuNERFIKKk6VlZVISkpCVFQUjEYjmpubH7j+9u3bKCwsRHx8PDQaDZYsWYL6+vqgBiai2WGO0g21tbWwWCyoqqqC0WhERUUFMjMzce3aNcTGxo5a7/P58NxzzyE2NhbvvfceEhMT8cUXX2DhwoWTMT8RzVARQgihZIPRaMTKlStx7NgxAIDf74fBYMCuXbtQXFw8an1VVRX++Mc/oqOjA3Pnzg1qSI/HA51OB7fbDa1WG9R9EFFohOrxqehpnc/nQ0tLC8xm87d3EBkJs9mMpqamMfe8//77MJlMKCwshF6vx7Jly1BeXo7h4eGHm5yIZjRFT+v6+vowPDwMvV4/4rher0dHR8eYe7q6uvDxxx9j8+bNqK+vR2dnJ3bu3InBwUFYrdYx93i9Xni93sDXHo9HyZhENAOE/Ld1fr8fsbGxOHHiBNLS0pCTk4PS0lJUVVWNu8dms0Gn0wVuBoMh1GMSkWQUxSkmJgYqlQoul2vEcZfLhbi4uDH3xMfHY8mSJVCpVIFjTz75JJxOJ3w+35h7SkpK4Ha7A7eenh4lYxLRDKAoTmq1GmlpabDb7YFjfr8fdrsdJpNpzD2rV69GZ2cn/H5/4Nj169cRHx8PtVo95h6NRgOtVjviRkSzi+KndRaLBdXV1Xj77bfR3t6Ol156CQMDAygoKAAA5OXloaSkJLD+pZdewldffYXdu3fj+vXrqKurQ3l5OQoLCyfvuyCiGUfx+5xycnLQ29uLsrIyOJ1OpKamoqGhIfAieXd3NyIjv22ewWDAhQsXUFRUhBUrViAxMRG7d+/Gnj17Ju+7IKIZR/H7nKYC3+dEJC8p3udERBQujBMRSYlxIiIpMU5EJCXGiYikxDgRkZQYJyKSEuNERFJinIhISowTEUmJcSIiKTFORCQlxomIpMQ4EZGUGCcikhLjRERSYpyISEqMExFJiXEiIikxTkQkJcaJiKTEOBGRlBgnIpIS40REUmKciEhKjBMRSYlxIiIpMU5EJCXGiYikxDgRkZQYJyKSEuNERFJinIhISowTEUmJcSIiKTFORCSloOJUWVmJpKQkREVFwWg0orm5eUL7ampqEBERgezs7GBOS0SziOI41dbWwmKxwGq1orW1FSkpKcjMzMStW7ceuO/mzZv47W9/izVr1gQ9LBHNHorjdPToUWzbtg0FBQV46qmnUFVVhfnz5+PUqVPj7hkeHsbmzZtx4MABJCcnP9TARDQ7KIqTz+dDS0sLzGbzt3cQGQmz2YympqZx97322muIjY3Fli1bJnQer9cLj8cz4kZEs4uiOPX19WF4eBh6vX7Ecb1eD6fTOeaeS5cu4eTJk6iurp7weWw2G3Q6XeBmMBiUjElEM0BIf1vX39+P3NxcVFdXIyYmZsL7SkpK4Ha7A7eenp4QTklEMpqjZHFMTAxUKhVcLteI4y6XC3FxcaPWf/7557h58yaysrICx/x+/90Tz5mDa9euYfHixaP2aTQaaDQaJaMR0Qyj6MpJrVYjLS0Ndrs9cMzv98Nut8NkMo1av3TpUly5cgUOhyNwe+GFF7Bu3To4HA4+XSOicSm6cgIAi8WC/Px8pKenIyMjAxUVFRgYGEBBQQEAIC8vD4mJibDZbIiKisKyZctG7F+4cCEAjDpORPRdiuOUk5OD3t5elJWVwel0IjU1FQ0NDYEXybu7uxEZyTeeE9HDiRBCiKke4vt4PB7odDq43W5otdqpHoeIviNUj09e4hCRlBgnIpIS40REUmKciEhKjBMRSYlxIiIpMU5EJCXGiYikxDgRkZQYJyKSEuNERFJinIhISowTEUmJcSIiKTFORCQlxomIpMQ4EZGUGCcikhLjRERSYpyISEqMExFJiXEiIikxTkQkJcaJiKTEOBGRlBgnIpIS40REUmKciEhKjBMRSYlxIiIpMU5EJCXGiYikxDgRkZQYJyKSEuNERFIKKk6VlZVISkpCVFQUjEYjmpubx11bXV2NNWvWIDo6GtHR0TCbzQ9cT0QEBBGn2tpaWCwWWK1WtLa2IiUlBZmZmbh169aY6xsbG7Fx40ZcvHgRTU1NMBgMeP755/Hll18+9PBENHNFCCGEkg1GoxErV67EsWPHAAB+vx8GgwG7du1CcXHx9+4fHh5GdHQ0jh07hry8vAmd0+PxQKfTwe12Q6vVKhmXiEIsVI9PRVdOPp8PLS0tMJvN395BZCTMZjOampomdB937tzB4OAgHn300XHXeL1eeDyeETciml0Uxamvrw/Dw8PQ6/Ujjuv1ejidzgndx549e5CQkDAicPez2WzQ6XSBm8FgUDImEc0AYf1t3aFDh1BTU4Nz584hKipq3HUlJSVwu92BW09PTxinJCIZzFGyOCYmBiqVCi6Xa8Rxl8uFuLi4B+49cuQIDh06hI8++ggrVqx44FqNRgONRqNkNCKaYRRdOanVaqSlpcFutweO+f1+2O12mEymcfcdPnwYBw8eRENDA9LT04OflohmDUVXTgBgsViQn5+P9PR0ZGRkoKKiAgMDAygoKAAA5OXlITExETabDQDwhz/8AWVlZThz5gySkpICr0098sgjeOSRRybxWyGimURxnHJyctDb24uysjI4nU6kpqaioaEh8CJ5d3c3IiO/vSB788034fP58Itf/GLE/VitVrz66qsPNz0RzViK3+c0Ffg+JyJ5SfE+JyKicGGciEhKjBMRSYlxIiIpMU5EJCXGiYikxDgRkZQYJyKSEuNERFJinIhISowTEUmJcSIiKTFORCQlxomIpMQ4EZGUGCcikhLjRERSYpyISEqMExFJiXEiIikxTkQkJcaJiKTEOBGRlBgnIpIS40REUmKciEhKjBMRSYlxIiIpMU5EJCXGiYikxDgRkZQYJyKSEuNERFJinIhISowTEUkpqDhVVlYiKSkJUVFRMBqNaG5ufuD6v/71r1i6dCmioqKwfPly1NfXBzUsEc0eiuNUW1sLi8UCq9WK1tZWpKSkIDMzE7du3Rpz/eXLl7Fx40Zs2bIFbW1tyM7ORnZ2Nj777LOHHp6IZq4IIYRQssFoNGLlypU4duwYAMDv98NgMGDXrl0oLi4etT4nJwcDAwP44IMPAsd++tOfIjU1FVVVVRM6p8fjgU6ng9vthlarVTIuEYVYqB6fc5Qs9vl8aGlpQUlJSeBYZGQkzGYzmpqaxtzT1NQEi8Uy4lhmZibOnz8/7nm8Xi+8Xm/ga7fbDeDuD4GI5HLvcanwOud7KYpTX18fhoeHodfrRxzX6/Xo6OgYc4/T6RxzvdPpHPc8NpsNBw4cGHXcYDAoGZeIwug///kPdDrdpN2fojiFS0lJyYirrdu3b+Oxxx5Dd3f3pH7zoebxeGAwGNDT0zPtno5O19mn69zA9J3d7XZj0aJFePTRRyf1fhXFKSYmBiqVCi6Xa8Rxl8uFuLi4MffExcUpWg8AGo0GGo1m1HGdTjet/tHu0Wq103JuYPrOPl3nBqbv7JGRk/vOJEX3plarkZaWBrvdHjjm9/tht9thMpnG3GMymUasB4APP/xw3PVEREAQT+ssFgvy8/ORnp6OjIwMVFRUYGBgAAUFBQCAvLw8JCYmwmazAQB2796NtWvX4k9/+hM2bNiAmpoa/OMf/8CJEycm9zshohlFcZxycnLQ29uLsrIyOJ1OpKamoqGhIfCid3d394jLu1WrVuHMmTPYt28f9u7dix//+Mc4f/48li1bNuFzajQaWK3WMZ/qyWy6zg1M39mn69zA9J09VHMrfp8TEVE48G/riEhKjBMRSYlxIiIpMU5EJCVp4jRdP4ZFydzV1dVYs2YNoqOjER0dDbPZ/L3fZygp/ZnfU1NTg4iICGRnZ4d2wHEonfv27dsoLCxEfHw8NBoNlixZMi3+fwGAiooKPPHEE5g3bx4MBgOKiorwzTffhGnauz755BNkZWUhISEBERERD/y72HsaGxvxzDPPQKPR4PHHH8fp06eVn1hIoKamRqjVanHq1Cnxz3/+U2zbtk0sXLhQuFyuMdd/+umnQqVSicOHD4urV6+Kffv2iblz54orV65IPfemTZtEZWWlaGtrE+3t7eJXv/qV0Ol04l//+ldY5xZC+ez33LhxQyQmJoo1a9aIn//85+EZ9juUzu31ekV6erpYv369uHTpkrhx44ZobGwUDocjzJMrn/2dd94RGo1GvPPOO+LGjRviwoULIj4+XhQVFYV17vr6elFaWirOnj0rAIhz5849cH1XV5eYP3++sFgs4urVq+KNN94QKpVKNDQ0KDqvFHHKyMgQhYWFga+Hh4dFQkKCsNlsY65/8cUXxYYNG0YcMxqN4te//nVI57yf0rnvNzQ0JBYsWCDefvvtUI04rmBmHxoaEqtWrRJ//vOfRX5+/pTESencb775pkhOThY+ny9cI45L6eyFhYXiZz/72YhjFotFrF69OqRzPshE4vTKK6+Ip59+esSxnJwckZmZqehcU/607t7HsJjN5sCxiXwMy3fXA3c/hmW89aEQzNz3u3PnDgYHByf9Dya/T7Czv/baa4iNjcWWLVvCMeYowcz9/vvvw2QyobCwEHq9HsuWLUN5eTmGh4fDNTaA4GZftWoVWlpaAk/9urq6UF9fj/Xr14dl5mBN1uNzyj+VIFwfwzLZgpn7fnv27EFCQsKof8hQC2b2S5cu4eTJk3A4HGGYcGzBzN3V1YWPP/4YmzdvRn19PTo7O7Fz504MDg7CarWGY2wAwc2+adMm9PX14dlnn4UQAkNDQ9ixYwf27t0bjpGDNt7j0+Px4Ouvv8a8efMmdD9TfuU0Wx06dAg1NTU4d+4coqKipnqcB+rv70dubi6qq6sRExMz1eMo4vf7ERsbixMnTiAtLQ05OTkoLS2d8KewTqXGxkaUl5fj+PHjaG1txdmzZ1FXV4eDBw9O9WhhMeVXTuH6GJbJFszc9xw5cgSHDh3CRx99hBUrVoRyzDEpnf3zzz/HzZs3kZWVFTjm9/sBAHPmzMG1a9ewePHi0A6N4H7m8fHxmDt3LlQqVeDYk08+CafTCZ/PB7VaHdKZ7wlm9v379yM3Nxdbt24FACxfvhwDAwPYvn07SktLJ/0jSibLeI9PrVY74asmQIIrp+n6MSzBzA0Ahw8fxsGDB9HQ0ID09PRwjDqK0tmXLl2KK1euwOFwBG4vvPAC1q1bB4fDEbZPKA3mZ7569Wp0dnYGYgoA169fR3x8fNjCBAQ3+507d0YF6F5khcR/Ejtpj09lr9WHRk1NjdBoNOL06dPi6tWrYvv27WLhwoXC6XQKIYTIzc0VxcXFgfWffvqpmDNnjjhy5Ihob28XVqt1yt5KoGTuQ4cOCbVaLd577z3x73//O3Dr7+8P69zBzH6/qfptndK5u7u7xYIFC8RvfvMbce3aNfHBBx+I2NhY8fvf/1762a1Wq1iwYIH4y1/+Irq6usTf/vY3sXjxYvHiiy+Gde7+/n7R1tYm2traBABx9OhR0dbWJr744gshhBDFxcUiNzc3sP7eWwl+97vfifb2dlFZWTl930oghBBvvPGGWLRokVCr1SIjI0P8/e9/D/y3tWvXivz8/BHr3333XbFkyRKhVqvF008/Lerq6sI88V1K5n7ssccEgFE3q9Ua/sGF8p/5d01VnIRQPvfly5eF0WgUGo1GJCcni9dff10MDQ2Feeq7lMw+ODgoXn31VbF48WIRFRUlDAaD2Llzp/jvf/8b1pkvXrw45v+392bNz88Xa9euHbUnNTVVqNVqkZycLN566y3F5+VHphCRlKb8NSciorEwTkQkJcaJiKTEOBGRlBgnIpIS40REUmKciEhKjBMRSYlxIiIpMU5EJCXGiYikxDgRkZT+D7aMrA8QYoBpAAAAAElFTkSuQmCC",
-      "text/plain": [
-       "<Figure size 300x300 with 1 Axes>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
+    "    plt.show()\n",
+    "\n",
+    "\n",
     "def show_image_grid(data_list):\n",
     "    \"\"\"\n",
     "    Display a grid of images.\n",
@@ -564,404 +1096,67 @@
     "        ax.axis(\"off\")\n",
     "\n",
     "    plt.tight_layout()\n",
-    "    plt.show()\n",
-    "\n",
-    "\n",
-    "# Example usage\n",
-    "data_list = []\n",
-    "nearest_neighbors = neighbors[0]\n",
-    "for n in nearest_neighbors[1:]:\n",
-    "    data_list.append(dataset[int(n)])\n",
-    "\n",
-    "show_image_grid(data_list)"
+    "    plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "482e3355",
+   "metadata": {},
+   "source": [
+    "First we'll display the image that we used for searching."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
-   "id": "50c1bf0c",
+   "execution_count": 29,
+   "id": "bd6f001f",
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[{'object_id': 49594, 'image': tensor([[[-0.7882, -0.6235, -0.3725,  ..., -0.4353, -0.4902, -0.4824],\n",
-      "         [-0.6941, -0.7647, -0.6471,  ..., -0.4510, -0.6314, -0.5373],\n",
-      "         [-0.6078, -0.5059, -0.4039,  ..., -0.4980, -0.6471, -0.4667],\n",
-      "         ...,\n",
-      "         [-0.5765, -0.2863,  0.0745,  ..., -0.8824, -0.7882, -0.8118],\n",
-      "         [-0.4667,  0.0510,  0.2314,  ..., -0.7804, -0.8118, -0.4510],\n",
-      "         [-0.5059,  0.3255,  0.3804,  ..., -0.7490, -0.4824, -0.2078]],\n",
-      "\n",
-      "        [[-0.7882, -0.6157, -0.3569,  ..., -0.4431, -0.4588, -0.4431],\n",
-      "         [-0.6941, -0.7647, -0.6235,  ..., -0.4824, -0.6235, -0.4902],\n",
-      "         [-0.6000, -0.4980, -0.4039,  ..., -0.5137, -0.6471, -0.4196],\n",
-      "         ...,\n",
-      "         [-0.6078, -0.3882, -0.2000,  ..., -0.9059, -0.8588, -0.8667],\n",
-      "         [-0.5137, -0.0118,  0.0353,  ..., -0.8196, -0.8353, -0.5608],\n",
-      "         [-0.5529,  0.2706,  0.2706,  ..., -0.8039, -0.6000, -0.3725]],\n",
-      "\n",
-      "        [[-0.8824, -0.7882, -0.6235,  ..., -0.8196, -0.8196, -0.7961],\n",
-      "         [-0.8745, -0.9059, -0.7961,  ..., -0.8510, -0.8824, -0.8745],\n",
-      "         [-0.8745, -0.7020, -0.6706,  ..., -0.8275, -0.8510, -0.8588],\n",
-      "         ...,\n",
-      "         [-0.6784, -0.5373, -0.4275,  ..., -0.9451, -0.8980, -0.9294],\n",
-      "         [-0.5765, -0.0745, -0.1059,  ..., -0.8824, -0.8824, -0.6471],\n",
-      "         [-0.6000,  0.2784,  0.2157,  ..., -0.8353, -0.6941, -0.5294]]]), 'label': 1}, {'object_id': 37791, 'image': tensor([[[-0.4824, -0.4667, -0.4745,  ..., -0.3569, -0.3412, -0.4902],\n",
-      "         [-0.2549, -0.2157, -0.2549,  ..., -0.2000, -0.0510, -0.0431],\n",
-      "         [-0.0667,  0.2471, -0.1529,  ..., -0.3961, -0.2941, -0.2471],\n",
-      "         ...,\n",
-      "         [ 0.0196,  0.0353,  0.0196,  ...,  0.0039,  0.0275,  0.0118],\n",
-      "         [ 0.0118,  0.0353,  0.0039,  ..., -0.0118,  0.0431,  0.0275],\n",
-      "         [ 0.0588,  0.0667,  0.0667,  ...,  0.0275,  0.0431,  0.0510]],\n",
-      "\n",
-      "        [[-0.4980, -0.4980, -0.4980,  ..., -0.4980, -0.4980, -0.5765],\n",
-      "         [-0.3176, -0.2863, -0.3333,  ..., -0.2471, -0.1686, -0.1765],\n",
-      "         [-0.1294,  0.1922, -0.2549,  ..., -0.5373, -0.4431, -0.4510],\n",
-      "         ...,\n",
-      "         [-0.3412, -0.3333, -0.3490,  ..., -0.3412, -0.3333, -0.3490],\n",
-      "         [-0.3490, -0.3412, -0.3569,  ..., -0.3725, -0.3333, -0.3333],\n",
-      "         [-0.3020, -0.3098, -0.3020,  ..., -0.3098, -0.2784, -0.2235]],\n",
-      "\n",
-      "        [[-0.5765, -0.5686, -0.5608,  ..., -0.6078, -0.5765, -0.6235],\n",
-      "         [-0.4039, -0.3804, -0.4275,  ..., -0.3569, -0.2941, -0.2941],\n",
-      "         [-0.2078,  0.0824, -0.3882,  ..., -0.6157, -0.5529, -0.5451],\n",
-      "         ...,\n",
-      "         [-0.6627, -0.6471, -0.6627,  ..., -0.6784, -0.6627, -0.6627],\n",
-      "         [-0.6784, -0.6706, -0.6784,  ..., -0.6863, -0.6706, -0.6627],\n",
-      "         [-0.6549, -0.6706, -0.6706,  ..., -0.6235, -0.6078, -0.5529]]]), 'label': 7}, {'object_id': 33511, 'image': tensor([[[ 0.1373,  0.0275, -0.0196,  ...,  0.0588, -0.2000, -0.6078],\n",
-      "         [ 0.0824, -0.0118, -0.0588,  ..., -0.0039, -0.3020, -0.8745],\n",
-      "         [ 0.0667, -0.0039, -0.0431,  ..., -0.0039, -0.2235, -0.7804],\n",
-      "         ...,\n",
-      "         [ 0.2471,  0.2392,  0.2706,  ...,  0.0980,  0.1451, -0.0667],\n",
-      "         [ 0.2235,  0.1765,  0.1529,  ...,  0.1529,  0.1373, -0.2078],\n",
-      "         [ 0.2392,  0.1922,  0.1686,  ...,  0.2000,  0.1451, -0.1451]],\n",
-      "\n",
-      "        [[-0.1137, -0.2549, -0.2863,  ..., -0.1608, -0.3176, -0.6000],\n",
-      "         [-0.3255, -0.4510, -0.4902,  ..., -0.3176, -0.4824, -0.8667],\n",
-      "         [-0.3490, -0.4353, -0.4824,  ..., -0.3098, -0.4353, -0.7804],\n",
-      "         ...,\n",
-      "         [-0.1608, -0.1922, -0.1765,  ..., -0.2549, -0.1529, -0.2706],\n",
-      "         [-0.2000, -0.2863, -0.3176,  ..., -0.2000, -0.2000, -0.4353],\n",
-      "         [-0.0824, -0.1765, -0.2000,  ..., -0.0667, -0.1137, -0.3176]],\n",
-      "\n",
-      "        [[-0.4588, -0.5843, -0.6078,  ..., -0.4510, -0.5137, -0.6784],\n",
-      "         [-0.8118, -0.9059, -0.9529,  ..., -0.7412, -0.8039, -1.0000],\n",
-      "         [-0.8039, -0.8667, -0.9137,  ..., -0.7333, -0.7961, -0.9922],\n",
-      "         ...,\n",
-      "         [-0.6863, -0.7569, -0.7255,  ..., -0.7569, -0.6314, -0.6549],\n",
-      "         [-0.7569, -0.8510, -0.8588,  ..., -0.7098, -0.6863, -0.8196],\n",
-      "         [-0.4902, -0.5765, -0.5922,  ..., -0.4510, -0.4980, -0.5922]]]), 'label': 3}, {'object_id': 8049, 'image': tensor([[[-0.2078, -0.2392, -0.2078,  ..., -0.3961, -0.4118, -0.4980],\n",
-      "         [-0.1843, -0.2627, -0.2784,  ..., -0.4745, -0.4745, -0.4667],\n",
-      "         [-0.2157, -0.3176, -0.3020,  ..., -0.5765, -0.4902, -0.4745],\n",
-      "         ...,\n",
-      "         [-0.4431, -0.3882, -0.2941,  ...,  0.0039, -0.0588, -0.0431],\n",
-      "         [-0.6078, -0.5686, -0.5529,  ..., -0.3490, -0.3961, -0.4353],\n",
-      "         [-0.7647, -0.7804, -0.7569,  ..., -0.6314, -0.6784, -0.7098]],\n",
-      "\n",
-      "        [[-0.1137, -0.1294, -0.1059,  ..., -0.3255, -0.3804, -0.4824],\n",
-      "         [-0.1059, -0.1608, -0.1765,  ..., -0.4118, -0.4510, -0.4745],\n",
-      "         [-0.1294, -0.2235, -0.2078,  ..., -0.5137, -0.4667, -0.4824],\n",
-      "         ...,\n",
-      "         [-0.5451, -0.5059, -0.4275,  ..., -0.2941, -0.3412, -0.3176],\n",
-      "         [-0.6627, -0.6471, -0.6471,  ..., -0.5608, -0.6000, -0.6157],\n",
-      "         [-0.7961, -0.8196, -0.8275,  ..., -0.7725, -0.8118, -0.8275]],\n",
-      "\n",
-      "        [[-0.5922, -0.7020, -0.6941,  ..., -0.7569, -0.7255, -0.8196],\n",
-      "         [-0.5451, -0.6941, -0.7490,  ..., -0.7725, -0.7333, -0.6941],\n",
-      "         [-0.5843, -0.6941, -0.7176,  ..., -0.8902, -0.7725, -0.6784],\n",
-      "         ...,\n",
-      "         [-0.8118, -0.8275, -0.7882,  ..., -0.8588, -0.8667, -0.7961],\n",
-      "         [-0.8275, -0.8275, -0.8431,  ..., -0.9059, -0.8980, -0.8745],\n",
-      "         [-0.8980, -0.9137, -0.9059,  ..., -0.9216, -0.9294, -0.9216]]]), 'label': 4}, {'object_id': 47650, 'image': tensor([[[-0.8588, -0.8196, -0.7961,  ..., -0.4275, -0.3882, -0.4039],\n",
-      "         [-0.8588, -0.8353, -0.8510,  ..., -0.4745, -0.4510, -0.4588],\n",
-      "         [-0.8510, -0.8431, -0.8824,  ..., -0.4824, -0.4667, -0.5137],\n",
-      "         ...,\n",
-      "         [-0.3255, -0.3804, -0.4745,  ..., -0.1059, -0.1686, -0.2235],\n",
-      "         [-0.4353, -0.1922, -0.3176,  ..., -0.1529, -0.2627, -0.3176],\n",
-      "         [-0.5922, -0.2235, -0.2706,  ..., -0.2157, -0.3255, -0.2941]],\n",
-      "\n",
-      "        [[-0.5529, -0.4353, -0.4039,  ...,  0.0353,  0.0353,  0.0667],\n",
-      "         [-0.5608, -0.4118, -0.3961,  ...,  0.0824,  0.0667,  0.0902],\n",
-      "         [-0.5608, -0.4196, -0.4118,  ...,  0.1294,  0.1059,  0.0902],\n",
-      "         ...,\n",
-      "         [-0.2471, -0.2627, -0.3647,  ..., -0.4118, -0.4745, -0.5137],\n",
-      "         [-0.3569, -0.1059, -0.3176,  ..., -0.4275, -0.5373, -0.5529],\n",
-      "         [-0.6627, -0.2157, -0.3255,  ..., -0.1922, -0.2706, -0.2000]],\n",
-      "\n",
-      "        [[-0.9059, -0.8902, -0.8745,  ..., -0.5608, -0.5294, -0.5294],\n",
-      "         [-0.9922, -0.9686, -0.9686,  ..., -0.7647, -0.7412, -0.7020],\n",
-      "         [-0.9765, -0.9686, -0.9765,  ..., -0.8118, -0.7882, -0.7647],\n",
-      "         ...,\n",
-      "         [-0.7333, -0.7647, -0.7569,  ..., -0.7020, -0.7176, -0.7176],\n",
-      "         [-0.6863, -0.6392, -0.7020,  ..., -0.7647, -0.8039, -0.7804],\n",
-      "         [-0.8667, -0.7647, -0.8039,  ..., -0.7176, -0.7569, -0.6314]]]), 'label': 6}, {'object_id': 36488, 'image': tensor([[[-0.0902, -0.4039, -0.4902,  ..., -0.4275, -0.3882, -0.4667],\n",
-      "         [-0.2471, -0.3490, -0.3255,  ..., -0.4118, -0.4275, -0.4824],\n",
-      "         [-0.4039, -0.4588, -0.4275,  ..., -0.4196, -0.4667, -0.5373],\n",
-      "         ...,\n",
-      "         [ 0.5373,  0.5529,  0.5373,  ..., -0.0902,  0.0510,  0.2627],\n",
-      "         [ 0.3176,  0.2784,  0.2784,  ..., -0.2471, -0.1529,  0.0118],\n",
-      "         [ 0.2314,  0.0667,  0.0039,  ..., -0.0902, -0.0745, -0.1137]],\n",
-      "\n",
-      "        [[-0.3255, -0.5843, -0.6235,  ..., -0.4745, -0.4353, -0.5216],\n",
-      "         [-0.4353, -0.4745, -0.4353,  ..., -0.4588, -0.4745, -0.5294],\n",
-      "         [-0.5451, -0.5451, -0.5216,  ..., -0.4745, -0.5216, -0.5922],\n",
-      "         ...,\n",
-      "         [-0.0275,  0.0196,  0.0196,  ..., -0.6235, -0.4667, -0.2549],\n",
-      "         [-0.2314, -0.2471, -0.2392,  ..., -0.7804, -0.6784, -0.5137],\n",
-      "         [-0.3176, -0.4588, -0.5216,  ..., -0.6314, -0.6000, -0.6471]],\n",
-      "\n",
-      "        [[-0.4824, -0.6314, -0.6392,  ..., -0.5765, -0.5373, -0.6157],\n",
-      "         [-0.5686, -0.5451, -0.4745,  ..., -0.5765, -0.5922, -0.6392],\n",
-      "         [-0.6706, -0.6549, -0.5843,  ..., -0.5373, -0.5843, -0.6627],\n",
-      "         ...,\n",
-      "         [-0.3020, -0.3020, -0.2863,  ..., -0.7490, -0.6157, -0.4431],\n",
-      "         [-0.5451, -0.5765, -0.5059,  ..., -0.8824, -0.7961, -0.6549],\n",
-      "         [-0.6392, -0.7725, -0.7569,  ..., -0.7176, -0.6863, -0.7255]]]), 'label': 4}, {'object_id': 34293, 'image': tensor([[[-0.6235, -0.5843, -0.5294,  ..., -0.3725, -0.3098, -0.2471],\n",
-      "         [-0.6157, -0.5843, -0.5294,  ..., -0.3333, -0.2863, -0.2392],\n",
-      "         [-0.6000, -0.5765, -0.5294,  ..., -0.2863, -0.2471, -0.2235],\n",
-      "         ...,\n",
-      "         [-0.5686, -0.5608, -0.1765,  ..., -0.0588, -0.1059, -0.2078],\n",
-      "         [-0.5529, -0.4667, -0.0353,  ..., -0.0667, -0.1137, -0.2078],\n",
-      "         [-0.4588,  0.0118,  0.2078,  ..., -0.0745, -0.1137, -0.1922]],\n",
-      "\n",
-      "        [[-0.5608, -0.5529, -0.5137,  ..., -0.4275, -0.4039, -0.3804],\n",
-      "         [-0.5529, -0.5529, -0.5137,  ..., -0.4275, -0.4118, -0.3961],\n",
-      "         [-0.5373, -0.5373, -0.5059,  ..., -0.4039, -0.4039, -0.3961],\n",
-      "         ...,\n",
-      "         [-0.5843, -0.6157, -0.2863,  ..., -0.3176, -0.3255, -0.4039],\n",
-      "         [-0.5765, -0.5451, -0.1765,  ..., -0.3255, -0.3412, -0.4039],\n",
-      "         [-0.4980, -0.1686, -0.0510,  ..., -0.3176, -0.3412, -0.3961]],\n",
-      "\n",
-      "        [[-0.7020, -0.7020, -0.6784,  ..., -0.6863, -0.6941, -0.7020],\n",
-      "         [-0.6941, -0.7020, -0.6706,  ..., -0.7020, -0.7098, -0.7255],\n",
-      "         [-0.6784, -0.6863, -0.6706,  ..., -0.7098, -0.7255, -0.7412],\n",
-      "         ...,\n",
-      "         [-0.7176, -0.7255, -0.6549,  ..., -0.7804, -0.7647, -0.7412],\n",
-      "         [-0.7098, -0.6941, -0.5922,  ..., -0.7490, -0.7412, -0.7412],\n",
-      "         [-0.7020, -0.5765, -0.6314,  ..., -0.7725, -0.7569, -0.7647]]]), 'label': 2}, {'object_id': 2339, 'image': tensor([[[-0.0902, -0.0667, -0.0431,  ..., -0.5059, -0.4118, -0.3412],\n",
-      "         [-0.0588, -0.0510, -0.0196,  ..., -0.6863, -0.8196, -0.8510],\n",
-      "         [-0.1137, -0.0745, -0.0118,  ..., -0.7882, -0.8588, -0.8510],\n",
-      "         ...,\n",
-      "         [ 0.9137,  0.9059,  0.9294,  ..., -0.0431,  0.3098,  0.3176],\n",
-      "         [ 0.9529,  0.9294,  0.9529,  ..., -0.2235,  0.2235,  0.2549],\n",
-      "         [ 0.9529,  0.9373,  0.9608,  ..., -0.3176,  0.1451,  0.2078]],\n",
-      "\n",
-      "        [[-0.5765, -0.5608, -0.5451,  ..., -0.7020, -0.6627, -0.6235],\n",
-      "         [-0.5843, -0.5765, -0.5529,  ..., -0.7961, -0.8902, -0.8980],\n",
-      "         [-0.5922, -0.5529, -0.5137,  ..., -0.8196, -0.8588, -0.8510],\n",
-      "         ...,\n",
-      "         [-0.6706, -0.6549, -0.6235,  ..., -0.8196, -0.8980, -0.9922],\n",
-      "         [-0.6392, -0.6157, -0.5765,  ..., -0.8588, -0.9294, -0.9765],\n",
-      "         [-0.7490, -0.7176, -0.6392,  ..., -0.7961, -0.9451, -0.9765]],\n",
-      "\n",
-      "        [[-0.9843, -0.9922, -0.9843,  ..., -0.9059, -0.9137, -0.9137],\n",
-      "         [-0.9922, -0.9922, -1.0000,  ..., -0.8745, -0.9294, -0.9137],\n",
-      "         [-0.9765, -0.9686, -0.9608,  ..., -0.8510, -0.8824, -0.8667],\n",
-      "         ...,\n",
-      "         [-0.6941, -0.6784, -0.6549,  ..., -0.8431, -0.8980, -1.0000],\n",
-      "         [-0.6706, -0.6471, -0.6314,  ..., -0.8980, -0.9529, -1.0000],\n",
-      "         [-0.6941, -0.6784, -0.6627,  ..., -0.8353, -0.9529, -0.9922]]]), 'label': 1}, {'object_id': 15042, 'image': tensor([[[-0.8431, -0.8039, -0.8275,  ...,  0.0745,  0.1608,  0.2549],\n",
-      "         [-0.8039, -0.8431, -0.8667,  ...,  0.0824,  0.1373,  0.2000],\n",
-      "         [-0.8039, -0.8353, -0.8588,  ...,  0.0196,  0.0118,  0.0431],\n",
-      "         ...,\n",
-      "         [-0.6235, -0.5608, -0.3490,  ...,  0.1765,  0.3098,  0.3804],\n",
-      "         [-0.6157, -0.6627, -0.6157,  ..., -0.0039,  0.3412,  0.5216],\n",
-      "         [-0.4980, -0.5922, -0.6941,  ..., -0.1216,  0.1686,  0.4353]],\n",
-      "\n",
-      "        [[-0.7255, -0.7176, -0.6706,  ...,  0.3882,  0.4745,  0.5216],\n",
-      "         [-0.7255, -0.7882, -0.7490,  ...,  0.4039,  0.4510,  0.4745],\n",
-      "         [-0.7333, -0.7961, -0.7490,  ...,  0.3412,  0.3255,  0.3255],\n",
-      "         ...,\n",
-      "         [-0.4588, -0.6000, -0.7176,  ..., -0.3333, -0.2549, -0.0431],\n",
-      "         [-0.3647, -0.5451, -0.7098,  ..., -0.1529,  0.1529,  0.4196],\n",
-      "         [-0.1843, -0.3333, -0.5373,  ..., -0.0510,  0.2078,  0.4980]],\n",
-      "\n",
-      "        [[-0.9294, -0.8980, -0.9216,  ..., -0.1608, -0.1608, -0.0353],\n",
-      "         [-0.8824, -0.9216, -0.9529,  ..., -0.1765, -0.1922, -0.1059],\n",
-      "         [-0.8824, -0.9059, -0.9373,  ..., -0.2549, -0.3176, -0.2706],\n",
-      "         ...,\n",
-      "         [-0.8510, -0.8902, -0.9686,  ..., -0.6000, -0.5451, -0.4118],\n",
-      "         [-0.8745, -0.9373, -1.0000,  ..., -0.5686, -0.2706, -0.0510],\n",
-      "         [-0.7961, -0.8431, -0.9294,  ..., -0.5608, -0.3098, -0.0196]]]), 'label': 1}, {'object_id': 4946, 'image': tensor([[[-0.4196, -0.3961, -0.2392,  ..., -0.2078, -0.1922, -0.1765],\n",
-      "         [-0.5686, -0.5529, -0.5059,  ..., -0.1216, -0.1765, -0.2157],\n",
-      "         [-0.5373, -0.5608, -0.5216,  ..., -0.0824, -0.1608, -0.2549],\n",
-      "         ...,\n",
-      "         [-0.5137, -0.5373, -0.4980,  ..., -0.1059, -0.1686, -0.1765],\n",
-      "         [-0.6000, -0.5529, -0.3647,  ..., -0.1059, -0.1373, -0.0980],\n",
-      "         [-0.5765, -0.5373, -0.4196,  ..., -0.1216, -0.2078, -0.0902]],\n",
-      "\n",
-      "        [[-0.6078, -0.5608, -0.4353,  ..., -0.5529, -0.5529, -0.5216],\n",
-      "         [-0.7647, -0.7412, -0.7098,  ..., -0.4824, -0.5373, -0.5608],\n",
-      "         [-0.7490, -0.7569, -0.7412,  ..., -0.4510, -0.5137, -0.5765],\n",
-      "         ...,\n",
-      "         [-0.7098, -0.7098, -0.7020,  ..., -0.4667, -0.5059, -0.5294],\n",
-      "         [-0.7647, -0.7255, -0.5765,  ..., -0.4902, -0.4745, -0.4275],\n",
-      "         [-0.7255, -0.7020, -0.6392,  ..., -0.5216, -0.5529, -0.4039]],\n",
-      "\n",
-      "        [[-0.8431, -0.8275, -0.7255,  ..., -0.9608, -0.9451, -0.9294],\n",
-      "         [-0.9686, -0.9686, -0.9608,  ..., -0.9529, -0.9529, -0.9529],\n",
-      "         [-0.9529, -0.9608, -0.9686,  ..., -0.9373, -0.9451, -0.9529],\n",
-      "         ...,\n",
-      "         [-0.9451, -0.9451, -0.9373,  ..., -0.8510, -0.8824, -0.9137],\n",
-      "         [-0.9922, -0.9529, -0.8510,  ..., -0.8824, -0.8824, -0.8902],\n",
-      "         [-0.9608, -0.9529, -0.9137,  ..., -0.9137, -0.9529, -0.8902]]]), 'label': 6}, {'object_id': 33524, 'image': tensor([[[-0.3961, -0.3804, -0.3569,  ..., -0.4118, -0.4510, -0.5137],\n",
-      "         [-0.3647, -0.3647, -0.3490,  ..., -0.3804, -0.4118, -0.4431],\n",
-      "         [-0.3961, -0.3725, -0.3569,  ..., -0.3804, -0.3882, -0.4353],\n",
-      "         ...,\n",
-      "         [ 0.1451,  0.1451,  0.1686,  ...,  0.0824,  0.0588,  0.0196],\n",
-      "         [ 0.1373,  0.1608,  0.1922,  ...,  0.0745,  0.0431, -0.0039],\n",
-      "         [ 0.0902,  0.1294,  0.1608,  ...,  0.0431, -0.0118, -0.0588]],\n",
-      "\n",
-      "        [[-0.5529, -0.5451, -0.5294,  ..., -0.5529, -0.5765, -0.6235],\n",
-      "         [-0.5216, -0.5137, -0.4902,  ..., -0.5373, -0.5529, -0.5686],\n",
-      "         [-0.5529, -0.5059, -0.4745,  ..., -0.5529, -0.5451, -0.5765],\n",
-      "         ...,\n",
-      "         [-0.3098, -0.3176, -0.3176,  ..., -0.3725, -0.3804, -0.4039],\n",
-      "         [-0.3176, -0.3020, -0.2941,  ..., -0.3725, -0.3882, -0.4196],\n",
-      "         [-0.3412, -0.3098, -0.3020,  ..., -0.3882, -0.4196, -0.4588]],\n",
-      "\n",
-      "        [[-0.7647, -0.7412, -0.7176,  ..., -0.7333, -0.7412, -0.7725],\n",
-      "         [-0.7333, -0.7255, -0.7098,  ..., -0.7176, -0.7176, -0.7098],\n",
-      "         [-0.7569, -0.7333, -0.7255,  ..., -0.7255, -0.7020, -0.7176],\n",
-      "         ...,\n",
-      "         [-0.7020, -0.7176, -0.7333,  ..., -0.7020, -0.7020, -0.7020],\n",
-      "         [-0.6941, -0.6941, -0.7020,  ..., -0.7020, -0.7020, -0.7098],\n",
-      "         [-0.7020, -0.6863, -0.6941,  ..., -0.7020, -0.7255, -0.7333]]]), 'label': 7}, {'object_id': 37635, 'image': tensor([[[-0.2314, -0.2549, -0.3882,  ...,  0.0510,  0.0745,  0.0667],\n",
-      "         [-0.1373, -0.1765, -0.3804,  ...,  0.0902,  0.1137,  0.1216],\n",
-      "         [-0.1686, -0.2078, -0.3725,  ...,  0.1137,  0.1216,  0.1294],\n",
-      "         ...,\n",
-      "         [ 0.0824,  0.1294,  0.0980,  ...,  0.0353,  0.0980,  0.0588],\n",
-      "         [ 0.1059,  0.1059,  0.0353,  ...,  0.0431,  0.0588,  0.0118],\n",
-      "         [ 0.0824,  0.0745,  0.0431,  ...,  0.0353,  0.0118,  0.0353]],\n",
-      "\n",
-      "        [[-0.3098, -0.4275, -0.5843,  ..., -0.1059, -0.0824, -0.0824],\n",
-      "         [-0.2157, -0.3490, -0.5765,  ..., -0.0667, -0.0510, -0.0431],\n",
-      "         [-0.2627, -0.3882, -0.5922,  ..., -0.0353, -0.0275, -0.0353],\n",
-      "         ...,\n",
-      "         [-0.2784, -0.2471, -0.2863,  ..., -0.3255, -0.2863, -0.3098],\n",
-      "         [-0.2784, -0.2627, -0.3098,  ..., -0.3333, -0.3176, -0.3490],\n",
-      "         [-0.3020, -0.3098, -0.3176,  ..., -0.3255, -0.3412, -0.2863]],\n",
-      "\n",
-      "        [[-0.3255, -0.4431, -0.5843,  ..., -0.2706, -0.2627, -0.2627],\n",
-      "         [-0.2392, -0.3804, -0.5765,  ..., -0.2471, -0.2314, -0.2314],\n",
-      "         [-0.2706, -0.3961, -0.5765,  ..., -0.2235, -0.2235, -0.2235],\n",
-      "         ...,\n",
-      "         [-0.4902, -0.4745, -0.5059,  ..., -0.5608, -0.5373, -0.5608],\n",
-      "         [-0.4902, -0.5059, -0.5216,  ..., -0.5765, -0.5686, -0.5843],\n",
-      "         [-0.5137, -0.5373, -0.5216,  ..., -0.5608, -0.5686, -0.5137]]]), 'label': 7}, {'object_id': 2712, 'image': tensor([[[-0.5373, -0.5373, -0.5294,  ..., -0.5608, -0.5608, -0.5686],\n",
-      "         [-0.5451, -0.5529, -0.5451,  ..., -0.5608, -0.5765, -0.5843],\n",
-      "         [-0.5373, -0.5373, -0.5216,  ..., -0.5608, -0.5686, -0.5843],\n",
-      "         ...,\n",
-      "         [ 0.2941,  0.2941,  0.3255,  ..., -0.2471, -0.2314, -0.2235],\n",
-      "         [ 0.3333,  0.2941,  0.3255,  ..., -0.1451, -0.1373, -0.1059],\n",
-      "         [ 0.3412,  0.3255,  0.3255,  ..., -0.0039,  0.0196,  0.0745]],\n",
-      "\n",
-      "        [[-0.5922, -0.6000, -0.5843,  ..., -0.6000, -0.6000, -0.6078],\n",
-      "         [-0.6000, -0.6078, -0.6000,  ..., -0.6000, -0.6157, -0.6235],\n",
-      "         [-0.5922, -0.5922, -0.5765,  ..., -0.6000, -0.6078, -0.6235],\n",
-      "         ...,\n",
-      "         [ 0.0980,  0.0980,  0.1373,  ..., -0.2941, -0.2706, -0.2627],\n",
-      "         [ 0.0902,  0.0510,  0.0824,  ..., -0.2706, -0.2549, -0.2235],\n",
-      "         [ 0.0824,  0.0667,  0.0667,  ..., -0.1922, -0.1686, -0.1137]],\n",
-      "\n",
-      "        [[-0.6392, -0.6392, -0.6314,  ..., -0.6549, -0.6471, -0.6549],\n",
-      "         [-0.6627, -0.6627, -0.6549,  ..., -0.6471, -0.6627, -0.6706],\n",
-      "         [-0.6627, -0.6627, -0.6471,  ..., -0.6471, -0.6549, -0.6706],\n",
-      "         ...,\n",
-      "         [-0.4510, -0.4588, -0.4353,  ..., -0.7098, -0.7176, -0.7412],\n",
-      "         [-0.4667, -0.4902, -0.4667,  ..., -0.6863, -0.6863, -0.6784],\n",
-      "         [-0.4824, -0.4824, -0.4745,  ..., -0.6471, -0.6314, -0.5843]]]), 'label': 4}, {'object_id': 49391, 'image': tensor([[[-0.3961, -0.3569, -0.3255,  ..., -0.4667, -0.5765, -0.6392],\n",
-      "         [-0.4588, -0.4353, -0.4353,  ..., -0.5137, -0.6000, -0.6392],\n",
-      "         [-0.6235, -0.6314, -0.6471,  ..., -0.4902, -0.6078, -0.6392],\n",
-      "         ...,\n",
-      "         [-0.1765, -0.1686, -0.2000,  ..., -0.2000, -0.2000, -0.2000],\n",
-      "         [-0.1451, -0.1294, -0.1451,  ..., -0.2549, -0.2157, -0.2157],\n",
-      "         [-0.1451, -0.1216, -0.1294,  ..., -0.1686, -0.1216, -0.0745]],\n",
-      "\n",
-      "        [[-0.4824, -0.4588, -0.4353,  ..., -0.5294, -0.6784, -0.7490],\n",
-      "         [-0.5294, -0.5137, -0.5137,  ..., -0.5765, -0.6941, -0.7490],\n",
-      "         [-0.6784, -0.6941, -0.7020,  ..., -0.6000, -0.7098, -0.7569],\n",
-      "         ...,\n",
-      "         [-0.4667, -0.4667, -0.4902,  ..., -0.4902, -0.4824, -0.4824],\n",
-      "         [-0.4275, -0.4275, -0.4431,  ..., -0.5294, -0.4980, -0.4902],\n",
-      "         [-0.4353, -0.4431, -0.4510,  ..., -0.4353, -0.3725, -0.3176]],\n",
-      "\n",
-      "        [[-0.5765, -0.5765, -0.5608,  ..., -0.5922, -0.7020, -0.7569],\n",
-      "         [-0.6078, -0.6157, -0.6078,  ..., -0.5843, -0.7098, -0.7647],\n",
-      "         [-0.7020, -0.7333, -0.7412,  ..., -0.6627, -0.7333, -0.7804],\n",
-      "         ...,\n",
-      "         [-0.6784, -0.6941, -0.7020,  ..., -0.7098, -0.7098, -0.7020],\n",
-      "         [-0.6706, -0.6941, -0.6941,  ..., -0.7412, -0.7176, -0.7098],\n",
-      "         [-0.6863, -0.7020, -0.6941,  ..., -0.6471, -0.6157, -0.5765]]]), 'label': 7}, {'object_id': 46942, 'image': tensor([[[-0.6706, -0.5059, -0.4196,  ..., -0.5216, -0.5686, -0.5373],\n",
-      "         [-0.6157, -0.5843, -0.5294,  ..., -0.3961, -0.5608, -0.4431],\n",
-      "         [-0.5608, -0.6235, -0.7020,  ..., -0.2157, -0.3255, -0.5608],\n",
-      "         ...,\n",
-      "         [-0.2157, -0.0431, -0.0353,  ...,  0.0431,  0.0980, -0.2314],\n",
-      "         [-0.1922, -0.1294, -0.0039,  ..., -0.2392, -0.2314, -0.3882],\n",
-      "         [-0.2627, -0.2471, -0.0824,  ..., -0.1843, -0.2471, -0.3176]],\n",
-      "\n",
-      "        [[-0.6863, -0.5922, -0.5373,  ..., -0.5216, -0.5686, -0.5451],\n",
-      "         [-0.6314, -0.6314, -0.6000,  ..., -0.4039, -0.5608, -0.4431],\n",
-      "         [-0.5529, -0.6392, -0.7255,  ..., -0.1373, -0.3020, -0.5843],\n",
-      "         ...,\n",
-      "         [-0.1843, -0.0118,  0.0118,  ..., -0.0431,  0.0980, -0.1686],\n",
-      "         [-0.1608, -0.0431,  0.0588,  ..., -0.2627, -0.2157, -0.3412],\n",
-      "         [-0.2000, -0.1529, -0.0039,  ..., -0.1686, -0.2314, -0.2941]],\n",
-      "\n",
-      "        [[-0.8118, -0.7961, -0.7647,  ..., -0.5294, -0.5765, -0.5608],\n",
-      "         [-0.7412, -0.7725, -0.7569,  ..., -0.3804, -0.5373, -0.4196],\n",
-      "         [-0.7098, -0.7412, -0.7647,  ..., -0.0745, -0.2157, -0.5451],\n",
-      "         ...,\n",
-      "         [-0.7490, -0.7020, -0.7255,  ..., -0.6784, -0.6235, -0.7255],\n",
-      "         [-0.7490, -0.7490, -0.7176,  ..., -0.7412, -0.6627, -0.7176],\n",
-      "         [-0.7412, -0.7804, -0.7255,  ..., -0.7333, -0.7255, -0.7098]]]), 'label': 7}, {'object_id': 34299, 'image': tensor([[[-0.1686, -0.1922, -0.1294,  ..., -0.4510, -0.3882, -0.3569],\n",
-      "         [-0.1686, -0.1922, -0.1137,  ..., -0.3176, -0.3255, -0.3412],\n",
-      "         [-0.1216, -0.0980, -0.0667,  ..., -0.1765, -0.2471, -0.3176],\n",
-      "         ...,\n",
-      "         [-0.4275, -0.3176, -0.1686,  ...,  0.0745,  0.0588,  0.0353],\n",
-      "         [-0.3333, -0.3725, -0.3255,  ...,  0.0431,  0.0039, -0.0196],\n",
-      "         [-0.3020, -0.3804, -0.4275,  ..., -0.0745, -0.1216, -0.1451]],\n",
-      "\n",
-      "        [[-0.4980, -0.5137, -0.4431,  ..., -0.8275, -0.7569, -0.5843],\n",
-      "         [-0.5216, -0.5294, -0.4431,  ..., -0.7020, -0.7020, -0.5451],\n",
-      "         [-0.4667, -0.4353, -0.4118,  ..., -0.5608, -0.6078, -0.5216],\n",
-      "         ...,\n",
-      "         [-0.5451, -0.4353, -0.3020,  ..., -0.2627, -0.2863, -0.3333],\n",
-      "         [-0.4588, -0.4824, -0.4275,  ..., -0.3176, -0.3490, -0.3804],\n",
-      "         [-0.4353, -0.5059, -0.5373,  ..., -0.4353, -0.4667, -0.4824]],\n",
-      "\n",
-      "        [[-0.8510, -0.8667, -0.8353,  ..., -0.9686, -0.9686, -0.8196],\n",
-      "         [-0.8824, -0.8980, -0.8431,  ..., -0.9294, -0.9529, -0.7961],\n",
-      "         [-0.8275, -0.8118, -0.8118,  ..., -0.8980, -0.9294, -0.7804],\n",
-      "         ...,\n",
-      "         [-0.7255, -0.6314, -0.5373,  ..., -0.7569, -0.7725, -0.7882],\n",
-      "         [-0.6784, -0.6863, -0.6471,  ..., -0.7882, -0.8039, -0.8118],\n",
-      "         [-0.6235, -0.7020, -0.7255,  ..., -0.8431, -0.8667, -0.8824]]]), 'label': 5}]\n"
-     ]
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYUAAAGbCAYAAAAr/4yjAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjEsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvc2/+5QAAAAlwSFlzAAAPYQAAD2EBqD+naQAAJOxJREFUeJzt3Xm0lXXd9/HPtYez99lnBg4cBjmKyK2YgEpYTwhkLTTrNiyHlrXUFIe0lms12Yx12+BQUWqYaWar1uMq0zKzespAzMdEcyQwUTgKnAOcgTMPe7qeP7j9PdJB+X4Tbqf3ay1Xq+OX77n2tYfP3udwfYziOI4FAICkxKt9AACA1w5CAQAQEAoAgIBQAAAEhAIAICAUAAABoQAACAgFAEBAKAAAAkIBe9XS0qIoinT11Vfvs52rVq1SFEVatWrVPtv5P2nRokVatGjRq30YwD5HKLxB/eQnP1EURXr44Ydf7UPZLy677DJFUTTqn2w2+4p3dnR07MMj3bMVK1bo1FNP1dSpUxVFkc4+++yXnP3Tn/6k+fPnK5fLqaGhQaeccopaWlr2OHvnnXfqqKOOUjab1dSpU7Vs2TIVi8XdZu655x6dc845mjFjhnK5nKZNm6alS5eqra1tt7nBwUFdd911Wrx4sSZOnKiamhodeeSRWrFihUql0is9BXiNSr3aBwC8EitWrFB1dXX4/8lk8lU8GrsrrrhCfX19mjdv3qgX4xe766679P73v19HHXWUvvWtb6m3t1ff+973NH/+fD366KNqbGwMs7///e+1ZMkSLVq0SNdcc42efPJJXX755dqxY4dWrFgR5i699FJ1dXXp1FNP1SGHHKKNGzfq2muv1V133aXHHntMTU1NkqSNGzfqE5/4hN71rnfpk5/8pGpra/XHP/5RF110kf72t7/plltu2X8nCK+eGG9IN998cywpfuihh17xrk2bNsWS4quuumofHNkuK1eujCXFK1eu/Lf+/LJly2JJcXt7+z47Js/OhQsXxgsXLvy3v1dLS0tcLpfjOI7jqqqq+Kyzztrj3MyZM+Pp06fHIyMj4WuPPfZYnEgk4k9+8pOjZmfPnh0XCoXwtS9+8YtxFEXx+vXrw9fuvffeuFQq7fZn77333lhS/MUvfjF8rb29PV67du2oY/roRz8aS4o3bNhgv8F43eDHR29i+XxeX/nKV3T00Uerrq5OVVVVOvbYY7Vy5cqX/DPf/e531dzcrMrKSi1cuFBr164dNfPUU0/plFNO0ZgxY5TNZjV37lzdeeedez2ewcFBPfXUU64f38RxrN7eXsX7sez3hhtu0MEHH6zKykrNmzdP99133x7nnn/+eT311FOmnc3NzYqi6GVnurq6tG7dOp188smqqKgIX589e7YOO+ww3XrrreFr69at07p163T++ecrlfr/PwC46KKLFMexbrvttvC1BQsWKJHY/am/YMECjRkzRuvXrw9fGzdunA4//PBRx3XyySdL0m6zeOMgFN7Eent7deONN2rRokW64oordNlll6m9vV3HH3+8HnvssVHzP/3pT/X9739fF198sT7/+c9r7dq1Ou6447R9+/Yw849//ENve9vbtH79en3uc5/Tt7/9bVVVVWnJkiW64447XvZ41qxZo8MOO0zXXnut+TZMmzZNdXV1qqmp0Uc+8pHdjmVfuOmmm3TBBReoqalJV155pd7xjnfopJNO0ubNm0fNnnnmmTrssMP22fceGRmRJFVWVo76d7lcTq2trdq2bZsk6dFHH5UkzZ07d7e5SZMmacqUKeHfv5T+/n719/dr3Lhxez2uF76nZRavP/xO4U2soaFBLS0tu70LPe+883TooYfqmmuu0U033bTb/DPPPKMNGzZo8uTJkqQTTjhBxxxzjK644gp95zvfkSRdcsklmjp1qh566CFlMhlJu96tzp8/X5deeml4l7kvjv3jH/+43v72tyuTyei+++7TddddpzVr1ujhhx9WbW3tK/4ehUJBX/jCFzRnzhytXLkynKeZM2fq/PPP1wEHHPCKv8fLmTBhgurr63X//ffv9vXOzk6tW7dOkrR161Y1NTWF30tMnDhx1J6JEyeqtbX1Zb/X8uXLlc/ndfrpp7/sXD6f1/Lly3XQQQfprW99q+fm4HWCTwpvYslkMrzQlctldXV1qVgsau7cuXrkkUdGzS9ZsiQEgiTNmzdPxxxzjO6++25Ju37c8Ze//EWnnXaa+vr61NHRoY6ODnV2dur444/Xhg0btHXr1pc8nkWLFimOY1122WV7PfZLLrlE11xzjc444wx98IMf1PLly3XLLbdow4YN+sEPfuA8E3v28MMPa8eOHbrwwgt3C86zzz5bdXV1o+ZXrVq1T3+MlUgkdMEFF+iee+7R5z//eW3YsEF///vfddpppymfz0uShoaGdvvfF4L4xbLZbPj3e7J69Wp99atf1WmnnabjjjvuZY/p4x//uNatW6drr712tx9T4Y2DUHiTu+WWWzRr1ixls1mNHTtWjY2N+t3vfqeenp5Rs4cccsior82YMSP89chnnnlGcRzry1/+shobG3f7Z9myZZKkHTt27LfbcsYZZ6ipqUl//vOf98m+5557TtLo251OpzVt2rR98j325mtf+5rOPfdcXXnllZoxY4bmzp2rVCqlc889V5LC37x64UdML/zI6cWGh4f3+CMoadfvf04++WS95S1v0Y033viyx3LVVVfpRz/6kf7rv/5LJ5544iu5WXgNI+rfxH72s5/p7LPP1pIlS/SZz3xG48ePVzKZ1De/+U09++yz7n3lclmS9OlPf1rHH3/8HmemT5/+io55bw444AB1dXXt1+/xP6miokI33nijvv71r+vpp5/WhAkTNGPGDJ1xxhlKJBLhfL7wY6O2trZRP9Zqa2vTvHnzRu3evHmzFi9erLq6Ot19992qqal5yeP4yU9+oksvvVQXXnihvvSlL+3DW4jXGkLhTey2227TtGnTdPvtt+/2N2FeeFf/rzZs2DDqa08//bQOPPBASQrvntPptN797nfv+wPeiziO1dLSoiOPPHKf7Gtubpa063a/+McqhUJBmzZt0uzZs/fJ97GYMGGCJkyYIEkqlUpatWqVjjnmmPBJYc6cOZJ2/cjrxQHQ2tqqLVu26Pzzz99tX2dnpxYvXqyRkRHdc889e/xdxAt+85vfaOnSpfrABz6g6667bh/fMrzW8OOjN7EXLvR68c/BH3zwQT3wwAN7nP/1r3+92+8E1qxZowcffFDvec97JEnjx4/XokWL9MMf/nCPF2S1t7e/7PF4/krqnnatWLFC7e3tOuGEE/b65y3mzp2rxsZGXX/99eFn+NKud83d3d2j5j1/JfWVuPrqq9XW1qZPfepT4WuHH364Dj30UN1www27XW28YsUKRVGkU045JXxtYGBAJ554orZu3aq77757jz8WfMHq1av1oQ99SAsWLNDPf/7zUX+VFW88fFJ4g/vxj3+sP/zhD6O+fskll+h973ufbr/9dp188sl673vfq02bNun666/XzJkz1d/fP+rPTJ8+XfPnz9fHPvYxjYyMaPny5Ro7dqw++9nPhpnrrrtO8+fP1xFHHKHzzjtP06ZN0/bt2/XAAw9oy5Ytevzxx1/yWNesWaN3vvOdWrZs2V5/2dzc3KzTTz9dRxxxhLLZrP7617/q1ltv1Zw5c3TBBRfsNrto0SLde++97l8Cp9NpXX755brgggt03HHH6fTTT9emTZt088037/F3Cmeeeab5+/z2t78N56JQKOiJJ57Q5ZdfLkk66aSTNGvWLEm7fsT3q1/9SgsWLFB1dbX+/Oc/6xe/+IWWLl2qD37wg7vtvOqqq3TSSSdp8eLF+tCHPqS1a9fq2muv1dKlS3f7q7If/vCHtWbNGp1zzjlav379btcbVFdXa8mSJZJ2/U7lpJNOCqHyy1/+crfvN2vWrHCceAN5ta6aw/71whXNL/XP5s2b43K5HH/jG9+Im5ub40wmEx955JHxXXfdFZ911llxc3Nz2PXiK5q//e1vxwcccECcyWTiY489Nn788cdHfe9nn302PvPMM+OmpqY4nU7HkydPjt/3vvfFt912W5jZ0xXNL3xt2bJle719S5cujWfOnBnX1NTE6XQ6nj59enzppZfGvb29o2aPPvrouKmpaa87X+qK5h/84AfxQQcdFGcymXju3Lnx6tWr93hF88KFC2PrU+qss856yfvm5ptvDnMPPvhgvGDBgrihoSHOZrPx7Nmz4+uvvz5cDf2v7rjjjnjOnDlxJpOJp0yZEn/pS1+K8/n8bjPNzc0v+b1ffL+/cH+81D+W+wmvP1Ec78dLQYFXWV9fn8aMGaPly5fr4osvfrUPB3jN4weEeENbvXq1Jk+erPPOO+/VPhTgdYFPCgCAgE8KAICAUAAABIQCACAgFAAAgfnitUObnP/tW8fvr5Nxce9DL1a2j6b3Y5NjInYciKSU42rQiuzotsuXM2aKr1Oo6eCXvor1X9XWjG4EfTkN1XsuX9uTXMb3n8+sclRi11bXu3b39ne75qNE2jy7s/3lq6v/1cb168yzO57z9VTld9r/I0aFYsG1W0n7OfE8jyWp7Hy+FYr216Bi2bfbMx+XfX+XJ3K8TsTll/8PNf2rBzv2fn/ySQEAEBAKAICAUAAABIQCACAgFAAAAaEAAAgIBQBAQCgAAAJCAQAQEAoAgIBQAAAE5mIg93+Lx9Fn5KwdUTJh7/solkuu3Z6UTCZ8vT2JpH17KpNz7a5ubHLNV9U1mGeTct73pRHzaDqy9yRJUm2uyjw7dtw41+5srsI1PzJs7wUa7vfdn7Hsj/Eo7egbkhQ5HrdpZ3VY2fEMKjs7zxLOx2Ei6TiHzhehrOOpX3IchySVHa+1vlc3Gz4pAAACQgEAEBAKAICAUAAABIQCACAgFAAAAaEAAAgIBQBAQCgAAAJCAQAQ2C9ij30XVKcixyXmKd9l4HHRfkl65KjEkKSE47i9Uml7jUK2tt61u6Gx0TWfTjj6CwoDrt2R42FVV1Pj2p3J2M9huTDk2l2b81VuFNJZ8+zOdl8VRU1drXm2p8N+HJJUTtnvn2LBWRPjePpEad970pLjeS9JkaMuorLCd//IUblRKPvqPPIFZ63MPsYnBQBAQCgAAAJCAQAQEAoAgIBQAAAEhAIAICAUAAABoQAACAgFAEBAKAAAAkIBABCYS1CcFUKeahDJ0VHiFTm7jDztKt6epFQmZ56trB/n2l1bU++aHzve3pXU2rLetbsmV2eenXzgIa7dw8UR82wU+zpn0omkaz5y1OXUVPs6nsY32u//Qn+fa/eW7u3m2aS3h8fxNrNQ9PUqJZ1vYSsc3UolR1+XJBVHCubZuOx88dx/9WsmfFIAAASEAgAgIBQAAAGhAAAICAUAQEAoAAACQgEAEBAKAICAUAAABIQCACDwXdvtYr88PvZ0S7j5LtNPOqoOEinf6Ysc86lMxrW7XPadxMGBHvuxRL5zWJmz13kUS76qg7TjfUxlZbVr90hhyDc/PGg/lqyvQqOutsE8O9Cw07W7ONVXLeJRKNvvz8Gdna7d5YK94kSShhz3T3nIVxUSO95OR76HuKvlYn80YvBJAQAQEAoAgIBQAAAEhAIAICAUAAABoQAACAgFAEBAKAAAAkIBABAQCgCAgFAAAAT2Mp7Y138TOVo5Imc0efqJUmlf54zvOHzNI+msvRMom6ty7R4eGXbNjwx0m2drnb091dVZ82w+b+9gkqTIUfFUku8cRqkK13wylzbPVlX5erIam2fad4+f7No9o1w0z6YrK1278yX760RUtB+HJPV0trvmW9Y9YZ59+qH7XbvzI72Oad9rZ8rxuhKXfbst+KQAAAgIBQBAQCgAAAJCAQAQEAoAgIBQAAAEhAIAICAUAAABoQAACAgFAEBgv/beeTl15LhUO5X0VQCk0/Z6gcjXRCHPJeneeo5Eyn7cqYqMa3e20l4tIUnDPYPm2UzaVxeRqaw2zxaLjt4KSam0fXemqsG1u75xgmveUwGRdD4OM1n7/X/QobNcu5921D9E8t0/StifFLVjx/l2OxsdJh48wzzb0NTs2n3/nf/bPFvs2+na7RI77x8DPikAAAJCAQAQEAoAgIBQAAAEhAIAICAUAAABoQAACAgFAEBAKAAAAkIBABAQCgCAwFw6lEolXYvTCXufUSrl6z6KHIVGsYqu3YmEvWAlKXuXkSQN9PeZZ/Mjw67dg/29rvlSMW8fTta5dhccfUbJpO8cNk5qMs+m0hWu3TW1ta75ZNr+nKis8HVTVVTaz8uYMRNduytz9t3btmx27R4asndqpZ2FUMmU7/4cP2mqeTY+2les1N3Rap595J67XbsL+YJ92F/utld8UgAABIQCACAgFAAAAaEAAAgIBQBAQCgAAAJCAQAQEAoAgIBQAAAEhAIAIDD3S3hqKyQpkbRXAPiv1HbUKCR8uZet8NR5+HZnqqrNs1W5KtfukaF+13yqbL+UPpGwn29JyhdK5tkx9eNcuxXbd6eTvuqCbMZXuZHN2e/PpHzHUijYa0iGB+31KZIUlxzH4nz+DDtqLvp7u1275XwNSmUz5tlsva/i5B3/+X7zbMvT/3Ttbn1mvXk2Efnqh0w79/lGAMDrFqEAAAgIBQBAQCgAAAJCAQAQEAoAgIBQAAAEhAIAICAUAAABoQAACAgFAEBgLhNJpHy9I3HZ3lETx75emLSjVymbqXDtTjl6mPIl+22UpGyu0n4cKV+nSbnoO5ZC3t6tk66wd8hIUq6mzjHr65w5aNpU82xnxw7XbsVF13gm63hsleznW5K2b9lmnt22dYtrd3XNGPNsUr7H1eRJU8yz23fYb6MkKeF7TuSHBsyzpUF7Z5MklWP76+G7T/2wa/evVyw3z/b27XTttuCTAgAgIBQAAAGhAAAICAUAQEAoAAACQgEAEBAKAICAUAAABIQCACAgFAAAAaEAAAjsBR7OfqLI0SGUTvt6lXIVafNsIuk4EEkq2vtvvJ1AFZmseTaZ9J2Twb5u13xUts+WYl/nTK6qxjx78LRprt2pjP2+Hxwecu2uLRdc84Vhe7fO8EC/c/eIebanu8u1e2jI3vNTW51z7e7r6TXP9nRtd+3Ol3zdVKWCfb6/p8+1O+V4Lh982Ftcu2fOO9Y8+8D/ud2124JPCgCAgFAAAASEAgAgIBQAAAGhAAAICAUAQEAoAAACQgEAEBAKAICAUAAABOYuhTguuRZnHXUEVTn7JeOSFDmOJSo5+hwkydGKkfedEuVL9qqQyqyvQqO76Kshqcraz3kmab8vJSmZtp/EXK29EkOS2ttazLO1Y8a5do8M2WsrJKk6a6+AKJd9D5Z8v712oaNtq2t305Tp5tme7b4qioKjimKou823O1Xtms9W2B/j9eMnu3Z3du8wz+5o3+bafeDs2ebZJx+8z7Xbgk8KAICAUAAABIQCACAgFAAAAaEAAAgIBQBAQCgAAAJCAQAQEAoAgIBQAAAEhAIAIDB3H+Vyla7FFRXm1ZKzF0Zy9Pz4KoGUcO0uuHYP9vaYZzu2+fpSFNs7ZySpVLK/HygWRly76+rsfUaOqqn/3l1nH44qXLs7uzp8B5Owd0Ktf+oJ1+r77l1tnp08qdG1e/qh9s6mge5+1+4oa3+d6B70Pe/XPHK/a/7AyePNszPnvNW1u5QfNs9mq3ydTQfOsHdTHTD9YNduCz4pAAACQgEAEBAKAICAUAAABIQCACAgFAAAAaEAAAgIBQBAQCgAAAJCAQAQmLso0mn7Jf2SpNh+CXvk7aJw1GLEcdm1OpW213NUZ6pcu9N19svdBwZ6XbuLeV8VRcFxO4eHB1y7B3u7zbPdOztdu5OR5/703fdR5Khm2fUHzKN33fk71+rBvP3YK3O+x2FxxF7PUlU31rW7t7vLPNvX7XuM3/fgk75jmTHJPHvgIYe5dicdFScdbW2u3cWk/XFVLPke4xZ8UgAABIQCACAgFAAAAaEAAAgIBQBAQCgAAAJCAQAQEAoAgIBQAAAEhAIAICAUAACBueylXC66FieT9tk49nUfRY75igpfZ1MqZe+/SdWOce2ubLDPF4v2fidJGhrod80PDPSZZ3sdXUaS1L6j1Tybra137c5ls/bdOXvXlCTVNfiOpadzh3k2l/a9/9r03Bbz7JSGnGv3YE+7ebZm3DjX7v6enebZUt7ewSRJDZW+53JVtf28TD3wINfujc8+a55t3dzi2l0u2c/LUI+vO8yCTwoAgIBQAAAEhAIAICAUAAABoQAACAgFAEBAKAAAAkIBABAQCgCAgFAAAATmTgdHa4UkKVEom2cj2WclKZ22V1Gk086ai4T9ltaOmeDaXVFlr10YGh5y7a6tstc/SFLrTnvVQffODtfu9rY28+zYSVNcuzOZKvNsKuU7J4XhYdd8b3eXeXbRwmNdu/sGfm+ebWyode3etm2zeXZLu/2+lKSBXvvjtn6srybmkovOcc0XRuzVLwn5amXqxjWZZ4effNS1u/Xp9ebZgZ32qhUrPikAAAJCAQAQEAoAgIBQAAAEhAIAICAUAAABoQAACAgFAEBAKAAAAkIBABAQCgCAwFwiVC4VfYsT9rypSPmalVIp++5YsWt3XM6bZ/u2b3LtLuzsNM9OOmCqa3exwpfvlQn7eWlv2+ba3dpQY56dNOVQ1+7eTnufTeP48a7d9XX1rvnq6jrzbGms7/mz+J0LzbOHzprr2p0v2Xt+Njy70bW7b9Dek3XgtGbX7rhccM1377A/l7dv2eLanay29zZ1dfj6iTo3/9M8m4rtt9GKTwoAgIBQAAAEhAIAICAUAAABoQAACAgFAEBAKAAAAkIBABAQCgCAgFAAAASEAgAgMHcfpZO+fqIKRz9RKunLpsgxXi6XXbsTjpuZLQ64dlfE9u6WfOuIa3cq8t3Ouoz5rlcil3Pt3tnZap7d+M+HXbvL6VrzbDJyrVZdrX33roOxdwg999QTrtWpTMY8W/I8ISQNOHrM7vzjH1y7n3nG3pX0v97+DtfuebP/wzX/7MYW8+yEpibX7nT/sHm2lPf1rw1395pnMxX257EVnxQAAAGhAAAICAUAQEAoAAACQgEAEBAKAICAUAAABIQCACAgFAAAAaEAAAjM10h7qyhSSfvl13HZXv8gSYrs/QWZlK+eI5Z9dynyXWKedRxKVBpy7S7GvkvpI0flRnVNjWt3dW3WPNvRtdO1e/qsQ8yzjU3jXbuzlb46j20bnzHP5gf6XLvHTz/cPFtTV+/ave4he7XI/ff/X9fudIW9nmPVvStdu4+ePcM1P3FCvXl2cMD3ONy+Y5t5dssm++NEkvqG7ZU1iYTveW/auc83AgBetwgFAEBAKAAAAkIBABAQCgCAgFAAAASEAgAgIBQAAAGhAAAICAUAQEAoAAACc3lPIuXLj1K5aJ5NJnz9RKmE41gS9i6jXeP2+XK55NpdjO3HXS76dudH8q75OHb0R2XsfTaS1HTAf5hnE6kK1+5MRdo8Wyj5emFGhn19U1s2rjfPDjuPJZ2z9zAlM/auKUmqrR9jnh07ZrJr9z/W/t08O226vcdqF1/XWDpr7+zqbm1z7S463k93d/e4dhdkfz20tyTZ8UkBABAQCgCAgFAAAASEAgAgIBQAAAGhAAAICAUAQEAoAAACQgEAEBAKAIDAfN147LyeOuGoroicVRSRo4rCLbbXEaSTvnqOyLE7P1Jw7U46z0mxZL9DB/sHXbtLJXtFRyrpq/MY7LVXBgwN+WorOvO+cz5SsM9XVNtrKySpd2e7ebans9G1e+LkKebZI2bNdu1ubW01zy565/Gu3WPHNrnmt/V3mWfrG+pduzdv3WGeHRwYcO1OOcorHE9jMz4pAAACQgEAEBAKAICAUAAABIQCACAgFAAAAaEAAAgIBQBAQCgAAAJCAQAQEAoAgMDcfZRI7r9+oqSz+0iydwh5O5uihD0nvbUjxXzePJvYn/1Okjx3ZyaTdu3ODw07Zn29SmXH+5i2bdtduyc1TXDN1zba53t6e127d3Z0mGeHhp5w7S6nsubZQ6Yf7Npde/rp9t3TJrt2b2l5yjU/1GPvjyoMjbh2D/f1mWdTKrp211TaH+NxydfXZcEnBQBAQCgAAAJCAQAQEAoAgIBQAAAEhAIAICAUAAABoQAACAgFAEBAKAAAAnPNRblkr5aQpChl71EolX27U45ajMhZoZFw1FyUCr5LzBOOY0nEvuNORs58T9rPeW1NtWt1KmU/lqG8r16gULJXaHR3d7t2j21ocM2nq+vMs1XO509+2H5etraud+1+5NFHzLPb2vtdu4speyVK29Pmlx9J0sT6nGu++cCDXPMeI8P281JX47ud0aD9vk+mMq7dFnxSAAAEhAIAICAUAAABoQAACAgFAEBAKAAAAkIBABAQCgCAgFAAAASEAgAgIBQAAIG5lCNW2bU4dnT3eDqBJMkzHZd9x10ql+zHEfv6bJKODI4cHUySVI7txy3JdW86b6YSaXv/TUXSdzvrxk+yD6d8XTmtW1td8/XVlebZnvbtrt2DRfv9masZ59p9yFuONM+mn/cdd6lo7+2ZVJt17U7n+1zzVVW15tnunh7X7lIhb55NRc7Xt2TSMbvv39fzSQEAEBAKAICAUAAABIQCACAgFAAAAaEAAAgIBQBAQCgAAAJCAQAQEAoAgMBcc5FwXk4dOS7t9iZT7OhdcF5h7qrQcHMcjKdu49+RytorICoy9joHSRrJ26sO6sc0unZPmjzNPJurrXftbvnnE6755zf+0zw70OurUcjmqs2zI8MF1+4xNWPMs5PmznbtHhroNc/2duxw7R4Y8Z3DYsH+OBwaGHTtTibsVS7Foq9qp8JRc7E/8EkBABAQCgCAgFAAAASEAgAgIBQAAAGhAAAICAUAQEAoAAACQgEAEBAKAICAUAAABObuo1TCmR+OfqJy7GscSjjG0ylnZ5Nj1ttQUio7Opscs7sOxnc7U9kq82yhVHTtjhydM85bqVLBfizlgq8TaMSxW5J2drabZ8dNmOTaXRjJm2cHuuzHIUlRbO/iGR4Zcu1Olu3nvKd9m2t3fqTfNb+15VnzbCx7l5Ek5fP225mUr/so6XitLZZ9uy34pAAACAgFAEBAKAAAAkIBABAQCgCAgFAAAASEAgAgIBQAAAGhAAAICAUAQEAoAAACc/eRp7dHkiJHq00U+bqPPL1K3txLObqSvIkaFe09JXHk6zRJpMx35X/vtx99tqrWtTtXV2eeLZZ8932xYO8E2uzovpGkVLrSNa/Yfs7HN011rd66ZbN5Nu94XElSMl1hnh3TYL8vJenpfzxqnq2syrl2y9GrJEk9vb3mWe99395h721KOkvSPK8rccnbHrZvvz8A4A2OUAAABIQCACAgFAAAAaEAAAgIBQBAQCgAAAJCAQAQEAoAgIBQAAAE5uv0I1e1hCTZ6wu8lQ4eCWeDRsJRuREXS77djsvdE5Hv2viy43xLUspRdZCqyPh2J9Lm2Xx+2LW7p7vLPFtw1j+Ma5romm9xnMOhEd/tbBhnP5aBgX7X7lzWXunQ02mvc5CkdNr+WGkYM9a1u2t7m2t+xFGJsvW5VtfubNrxftpZEeR6qS3v+9dOPikAAAJCAQAQEAoAgIBQAAAEhAIAICAUAAABoQAACAgFAEBAKAAAAkIBABAQCgCAwNx9lJCvYyN2jEeRL5vKcdE8m0z4envyQyPm2Ui+TpNM1t6V4+1sKsW+c5iqrDbPplO+czg4MGCeddbCKD9iv3/Sjm4iSerr7XHN56pqzbNbn9/k2l3f0GSeHR62nxNJatv6vHm2odb+OJGk6px9fkfrFtfuzu07XPPFpPnlTcP5gmt37OiySnpKzyQVC/bXt0Ri37+v55MCACAgFAAAAaEAAAgIBQBAQCgAAAJCAQAQEAoAgIBQAAAEhAIAICAUAACB+TrwYtFXc1GRtl9iHscl1+7I0Y2Qd1YAFEv2Y6lI+rooyo7dyZT9/ElSwbFbkgYG7edlaNh+Sb8kJR3npVzyPa46O9rNsxXptGt3oeA7h0lH/cfO7g7X7r7+Z82zpaK9FkGSdu6wn8OONt/jsLrGXnPR3dPt2j3kfKyM5PPm2UTs61spDtqrXCI5X98i+/MntR/e1/NJAQAQEAoAgIBQAAAEhAIAICAUAAABoQAACAgFAEBAKAAAAkIBABAQCgCAgFAAAATmYhNPH4ckJRP2vCk5O2dSyaRr3iPt6ByK5OtL8XQflZO+vC7HvvtnsK/HPNvX3eXaXT+20TxbLtn7aSSpp3uneTabq3Ttlq9aR+msff+Bh7zFtbtlwzrzbLnsu+8TmZx51nO+Jamzu9M8mx/xPe/bu/td8z399n6vYn7QtXuC/RQqXeG7f+QYj+g+AgDsT4QCACAgFAAAAaEAAAgIBQBAQCgAAAJCAQAQEAoAgIBQAAAEhAIAIDB3OpRjX6VDoVAwz6adtRWexo2kc3cyss8XC8Ou3ZHrWHydC7lsxjU/WC46pn11BL299lqMbDrt2p2IPPUpntsoVVXXu+Zr6uzzg0NDrt2ptL1CI52udu2urqk1z2ac909X+w7zbF+/vWpFktq2t7vmR/L2CpXqCt/rRLlsPy9RwncOPQpF33PTgk8KAICAUAAABIQCACAgFAAAAaEAAAgIBQBAQCgAAAJCAQAQEAoAgIBQAAAEhAIAIIji2FlqBAB4w+KTAgAgIBQAAAGhAAAICAUAQEAoAAACQgEAEBAKAICAUAAABIQCACD4f8wlw9QC5L8zAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     }
    ],
    "source": [
-    "a = [dataset[int(i)] for i in nearest_neighbors[1:]]\n",
-    "print(a)"
+    "show_image(dataset[19022])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "64aa055b",
+   "metadata": {},
+   "source": [
+    "Next we'll display the 4 nearest neighbors. We'll exclude the absolute nearest neighbor, because in our case, that is the original search image. It seems that the model is doing something vaguely reasonable since 3 of 4 nearest neighbors appear to be similar types of dogs as the original search image. Though, clearly, there is room for model improvement."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "865cb668",
+   "execution_count": 30,
+   "id": "8ac4f559",
    "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "d4a84d4b",
-   "metadata": {},
-   "outputs": [],
-   "source": []
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABJIAAAEwCAYAAADsAVtdAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjEsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvc2/+5QAAAAlwSFlzAAAPYQAAD2EBqD+naQAAaetJREFUeJzt/Xm4XWVh9/9/9l57PvN8TuaEJBjGiIyW2SoowoMV63D5dcSxT4t+q1CtYlunWqnSRyvUp06t+tOKUP1ZH3EWEAURREZDQkLm5MzTPmeP6/sHTR5DwudeTCbo+3VdXJfms/Za97rXPa37nGSn4jiOBQAAAAAAAASkD3YBAAAAAAAA8PTARhIAAAAAAAASYSMJAAAAAAAAibCRBAAAAAAAgETYSAIAAAAAAEAibCQBAAAAAAAgETaSAAAAAAAAkAgbSQAAAAAAAEiEjSQAAAAAAAAkwkbSk2jTpk1KpVK64oornrRz/vjHP1YqldKPf/zjJ+2cv0tnnnmmzjzzzINdDOAPHuPT/hifgEMD49P+XvOa12jZsmUHuxgAHgPGsv2x1vr99Qe/kfT5z39eqVRKt91228EuylPib/7mb5RKpfb7r1AoPOFzjoyMPIkl3d+WLVv0t3/7tzrxxBPV1dWl3t5enXnmmfr+979/wOO/973v6dRTT1WpVFJXV5cuuugibdq0ab/jZmZm9La3vU2LFi1SPp/XmjVrdNVVV+133J62caD/du7cuc+xy5YtO+Bxb37zm5+UusAfJsanx3/Op3p8mpub0+tf/3odddRR6ujoUGtrq4499lj90z/9k2q12n7HT0xM6I1vfKP6+vrU0tKis846S7fffvt+x331q1/VK1/5Sq1atUqpVMouviqVii677DItWLBAxWJRJ510kr73ve/td9yZZ555wHo+99xzn1Ad4A/b7/v4dO211+qlL32pVqxYoVKppMMPP1x/+Zd/qYmJicd9zoNVZxs2bFChUDjgtW+44QZdcMEFWrx4sQqFggYHB3Xuuefqpz/9qT3nxMSE+vv7lUqldM0119hjP/jBDyqVSumoo47aL/vud7+7dyyNoojNM/zO/b6PZU/ntdYj3XTTTXvL/8hrX3fddTrnnHO0YMEC5fN5LVq0SBdddJHuvvvu/c7zWNZaeHSZg10A/G5cddVVam1t3fv/oyg6iKVJ5hvf+IY+8pGP6MILL9SrX/1q1et1/du//Zue+9zn6rOf/axe+9rX7j32W9/6lv7H//gfOu644/T3f//3mpqa0j/90z/p1FNP1R133KG+vj5JUqPR0DnnnKPbbrtNf/Znf6ZVq1bp+uuv11vf+laNj4/r3e9+937l+Lu/+zstX758nz/r7Ozc77i1a9fqL//yL/f5s9WrVz8JNQH8fns6jk9zc3O655579IIXvEDLli1TOp3WzTffrLe//e265ZZb9OUvf3nvsc1mU+edd57uvPNOvfOd71Rvb68+9alP6cwzz9Qvf/lLrVq1au+xV111lX75y1/qhBNO0OjoqC3Da17zGl1zzTV629veplWrVunzn/+8XvCCF+hHP/qRTj311H2OXbRokT784Q/v82cLFix4EmoC+P30xje+UQsWLNArX/lKLVmyRHfddZc++clP6tvf/rZuv/12FYvFg13ExN7+9rcrk8moUqnsl61bt07pdFpvfvObNTg4qPHxcX3xi1/U6aefrv/6r/961A3nyy+/XOVyOXjtrVu36kMf+pBaWloOmH/5y1/WV7/6VR133HGMScBT6Om41vptzWZTf/7nf66WlhbNzs7ul991113q6urSJZdcot7eXu3cuVOf/exndeKJJ+pnP/uZjj322L3HPpa1Fh4dG0l/IC666CL19vYe7GI8JmeddZY2b968T7nf/OY3a+3atbr88sv32Ui67LLLtGLFCv30pz9VLpeTJJ1//vl7N5b+8R//UdLDP2G8+eab9ZnPfEave93rJElvectbdNFFF+n973+/Lr74YvX39+9Tjuc///k6/vjjg+VduHChXvnKVz7h+wb+0Dwdx6fu7m79/Oc/3+fP3vzmN6ujo0Of/OQn9bGPfUyDg4OSpGuuuUY333yzvva1r+miiy6SJP3pn/6pVq9erfe97337bDr9+7//uxYuXKh0On3An97vceutt+orX/mKPvrRj+od73iHJOlVr3qVjjrqKF166aW6+eab9zm+o6OD8Ql4DK655pr9fkr9rGc9S69+9av1pS99SRdffPHBKdhjdP311+v666/XpZdeqg984AP75RdffPF+9/LWt75VK1as0JVXXnnAjaS7775bV111lS6//HJdfvnl9vrveMc7dPLJJ6vRaBzwtxc+9KEP6X//7/+tbDarF77whQf87QEAT9zTca312z796U9ry5Ytuvjii/VP//RP++UHGosuvvhiLVq0SFdddZWuvvrqvX+edK0F7w/+r7YlUa1Wdfnll+tZz3qWOjo61NLSotNOO00/+tGPHvUzH//4x7V06VIVi0WdccYZB5wY77//fl100UXq7u5WoVDQ8ccfr29+85vB8pTLZd1///2P6dcJ4zjW1NSU4jhO/JnH6tOf/rQOO+wwFYtFnXjiibrxxhsPeNzmzZt1//33B8935JFH7jfg5fN5veAFL9DWrVs1PT0tSRobG9O9996rF73oRXs3kSTp2GOP1Zo1a/SVr3xl75/tKdPLXvayfc77spe9TPPz8/rGN75xwLJMT0+r0WgEy1ytVg+4Sw48VRifknmyx6dHs+evZfz2X3+55pprNDAwoD/5kz/Z+2d9fX360z/9U33jG9/Y57cEFi9erHQ6PDVfc801iqJIb3zjG/f+WaFQ0Otf/3r97Gc/05YtW/b7TL1e18zMzOO4K+DxeTqPTwf6qw4vetGLJEn33Xdf8POPxX/+53/qqKOOUqFQ0FFHHaXrrrvugMft2LFD999//wH/+uyB1Go1XXLJJbrkkkt02GGHJS5PqVRSX1/fo/41vksuuUQvetGLdNppp9nz3HDDDbrmmmt05ZVXPuoxCxYsUDabTVw24GB4Oo9lezyd11pjY2N6z3veo7/7u7874N8KeTT9/f0qlUr7jWVJ11rwqMEEpqam9K//+q8688wz9ZGPfER/8zd/o+HhYZ1zzjn61a9+td/x//Zv/6b/9b/+l/7sz/5M73rXu3T33Xfr7LPP1q5du/Yec8899+jkk0/Wfffdp7/6q7/SP/7jP6qlpUUXXnjhoy4g9rj11lu1Zs0affKTn0x8DytWrFBHR4fa2tr0yle+cp+yPBk+85nP6E1vepMGBwf1D//wD/qjP/ojXXDBBQd8mXnVq16lNWvWPO5r7dy5U6VSSaVSSZL2voQd6NfMS6WStm/fvvffNKpUKoqiaJ8Npz3HSdIvf/nL/c5x1llnqb29XaVSSRdccIEeeOCBA5brhz/8oUqlklpbW7Vs2bID7pYDTzbGp7CncnyqVqsaGRnRli1bdN111+mKK67Q0qVLtXLlyr3H3HHHHTruuOP2W7SceOKJKpfLWrdu3WO+pzvuuEOrV69We3v7fueUtN+zX7dunVpaWtTW1qbBwUG9973vTfwyCjxevw/j02/bs5Z4Mn+q/93vflcvfvGLlUql9OEPf1gXXnihXvva1x7w32t517vepTVr1mjbtm2Jzn3llVdqfHxc73nPe4LHTk1NaWRkRPfff7/e/e536+6779ZznvOc/Y772te+pptvvln/8A//YM/XaDT053/+57r44ot19NFHJyovcKj6fRjLns5rrfe+970aHBzUm970puCxExMTGh4e1l133aWLL75YU1NTBxzL8MTxV9sS6Orq0qZNm/bZfHjDG96gZzzjGfrEJz6hz3zmM/scv379ej3wwANauHChJOncc8/VSSedpI985CP62Mc+Junhn+YsWbJEv/jFL5TP5yU9/KvEp556qi677LK9P/V6Msr+P//n/9Qpp5yifD6vG2+8Uf/8z/+sW2+9Vbfddtt+LyGPR61W07vf/W6tXbtWP/rRj/bW0xFHHKE3vvGNWrx48RO+xh7r16/Xtddeq5e85CV7/27vwMCAOjs79/uHIUdHR3XvvfdKkrZt26bBwUEdfvjhajQa+vnPf77PvyGyZ8f8txdnpVJJr3nNa/ZuJP3yl7/Uxz72MT372c/W7bffvs99HXPMMTr11FN1+OGHa3R0VJ///Of1tre9Tdu3b9dHPvKRJ+3+gUdifPKe6vHp2muv1ctf/vK9///444/XZz/7WWUy/3d63bFjh04//fT9Pjs0NCRJ2r59+2N+0dqxY8fezz/aOfc47LDDdNZZZ+noo4/W7OysrrnmGn3gAx/QunXr9NWvfvUxXRd4LJ7O49OBfOQjH1EURXv/iuqT4bLLLtPAwIBuuukmdXR0SJLOOOMMPe95z9PSpUsf93l37typ97///briiisSjaV/+qd/quuvv16SlMvl9KY3vUnvfe979zlmbm5O73jHO/T2t79dy5YtO+AXmuxx9dVX66GHHnrUL0gBnk6ezmPZ032t9etf/1r/8i//om9/+9uJ/l2nk08+Wb/5zW8kSa2trXrPe96j17/+9Y/7+jDiP3Cf+9znYknxL37xi0THNxqNeHR0NB4eHo7PO++8eO3atXuzjRs3xpLil7/85ft97qSTTooPP/zwOI7jeHR0NE6lUvH73//+eHh4eJ///vZv/zaWFG/dujWO4zj+0Y9+FEuKf/SjHz3xm/1vX/rSl2JJ8Yc//OHH9fn3ve99saR4eHg4juM4vvnmm2NJ8dVXX73PcdVqNe7o6IjPOOOMJ1rkOI7jeHZ2Nl67dm3c1dUVb9u2bZ/ssssuiyXFf/VXfxWvW7cuvu222+Kzzz47zmazsaT4xhtvjOM4jnfs2BF3dHTEq1atir/73e/GGzdujP/lX/4lbm9vjyXFz3nOc2wZbrzxxjiVSsVvetOb7HHNZjM+55xz4kwmE2/ZsuWJ3Tj+YDE+PXa/6/Fp586d8fe+9734a1/7WvzmN785PuWUU+Kf/exn+xyTTqfjt7zlLft99gc/+EEsKb7uuusOeO4jjzzyUcu3YsWK+PnPf/5+f75hw4ZYUvzxj3/clvsNb3hDLGm/sgJJ/aGNT3vGpksvvfRxn+ORdbZ9+/a9a5dHOuKII+KlS5c+7mu96lWvio899ti40Wgc8NqPdMcdd8Tf/e5348985jPx6aefHr/2ta+Np6en9znm8ssvj4eGhvb++Z46/trXvrbPcSMjI3F3d3d8xRVX7P2zM844Iz7yyCNtmc8777wndM/A4/GHNpbF8dNrrXXGGWfEL3zhCx/12o908803x9/5znfiT33qU/EJJ5wQ/+Vf/mVcrVYf9fxurQWPv9qW0Be+8AUdc8wxKhQK6unpUV9fn/7rv/5Lk5OT+x3729/As8fq1av3/uRm/fr1iuNY733ve9XX17fPf+973/skSbt3737K7uUVr3iFBgcHn7SfEj300EOS9r/vbDarFStWPCnXaDQaetnLXqZ7771X11xzzX7f7PF3f/d3ev3rX69/+Id/0OrVq3X88ccrk8ns3YHe8y0Fg4OD+uY3v6lKpaLnPe95Wr58ud75znfqE5/4xD7HPZpTTz1VJ510UrDuUqmU3v72t6ter+vHP/7x47xrIBnGp0f3VI9PAwMD+uM//mNddNFFuuqqq/TCF75Qz33uc/f+FRjp4b92e6BvS5qfn9+bP1ZP9Jx7vmGS3xbAU+33YXy68cYb9frXv17nnHOOPvjBDz5p53208UmSDj/88Md93p///Of693//d3384x9P/O+ArF27Vs997nP1ute9Tt/73vd066236jWvec3efNOmTfroRz+qD37wg8G10nve8x51d3frz//8zx/3PQCHmt+HsWyPp8ta66tf/apuvvnmvV+alMQpp5yic845R295y1t0/fXX64tf/KLe9a53Pe4y4NHxV9sS+OIXv6jXvOY1uvDCC/XOd75T/f39iqJIH/7wh7Vhw4bHfL5msynp4W+yOOeccw54zG//+xpPhcWLF2tsbOwpvcaT6Q1veIO+9a1v6Utf+pLOPvvs/fJcLqd//dd/1Qc/+EGtW7dOAwMDWr16tV7xilconU7vU5+nn366HnzwQd11112anZ3Vscceu/evgaxevTpYlsWLF+/9lcnQcZKeVvWMpx/Gp0PLRRddpL/+67/WN77xjb1/l39oaEg7duzY79g9f/Z4vvJ6aGjogP9OStJzMj7hd+H3YXy68847dcEFF+ioo47SNddcs89fWz1UXXrppTrttNO0fPnyvS+ue/5R3h07dmjz5s1asmTJo34+l8vpggsu0N///d9rbm5OxWJRl19+uRYuXKgzzzxz7zn3bJgPDw9r06ZNWrJkiTZs2KBPf/rTuvLKK/f5K7bz8/Oq1WratGmT2tvb1d3d/dTcPPAU+H0Yyx7p6bDWeuc736mXvOQlyuVye8edPf9w9pYtW1StVu16p6urS2effba+9KUv6YorrvgdlPgPy6E/Gx4CrrnmGq1YsULXXnutUqnU3j/fs2P8SAf6x5jXrVu399t89uzMZrNZ/fEf//GTX+CAOI61adMmPfOZz3xSzrfn7/A/8MAD+2zy1Go1bdy4Uccee+wTOv873/lOfe5zn9OVV165z79FciADAwMaGBiQ9PBvMf34xz/WSSedtN9Pz6Io0tq1a/f+/z078kmex4MPPqi+vr5Ex0lKdCzweDE+eU/1+PRIc3NzkrTPTyjXrl2rG2+8Uc1mc5/fDrjllltUKpUSbWA/0p5/h2Bqamqff9/glltu2Zs7jE/4XXi6j08bNmzQueeeq/7+fn37298O/ibOY/Xb49MjJfmB1aPZvHmzHnroIS1fvny/7IILLlBHR8ejfiPbHnNzc4rjWNPT0yoWi9q8ebPWr19/wN8ueOtb3ypJGh8f17Zt29RsNvUXf/EX+ou/+Iv9jl2+fLkuueQS+01uwKHm6T6WPdLTZa21ZcsWffnLX9aXv/zl/bLjjjtOxx577AH/sfPfNjc3d8DfGsMTx19tS2DPP+wV/9bXJd5yyy362c9+dsDj//M//3OfnxTfeuutuuWWW/T85z9f0sNfRXjmmWfqX/7lXw74U+rh4WFbnsfylY8HOtdVV12l4eFhnXvuucHPJ3H88cerr69PV199tarV6t4///znP3/Ahcpj+crHj370o7riiiv07ne/W5dccsljKtcVV1yhHTt27P0rHI9meHhYH/nIR3TMMcfsM5gfqO6+/e1v65e//OU+dTc2NqZGo7HPcbVaTX//93+vXC6ns8466zGVG3gsGJ+8p2p8GhkZOeBX6P7rv/7r3uvucdFFF2nXrl269tpr9/n81772NZ1//vl7/5HNx+Kiiy5So9HQpz/96b1/VqlU9LnPfU4nnXTS3t84mpqa2u+vwMVxrA984AOS9Kg/CQWeDE/n8Wnnzp163vOep3Q6reuvv/4p2XQdGhrS2rVr9YUvfGGfF53vfe97e78s5Lft2LFD999/f/AbFz/96U/ruuuu2+e/PX/N7IorrtCXvvSlvcce6K/PTExM6Otf/7oWL16s/v5+SdIHPvCB/c75/ve/X9LDvwF13XXXqaWlRUcdddR+x1133XU68sgjtWTJEl133XX8w7d42nk6j2VP57XWgcaSl770pZIe/ma8j3/843uPPdBYtmnTJv3gBz/YZ02GJw+/kfTfPvvZz+o73/nOfn9+ySWX6IUvfKGuvfZavehFL9J5552njRs36uqrr9YRRxyhmZmZ/T6zcuVKnXrqqXrLW96iSqWiK6+8Uj09Pbr00kv3HvPP//zPOvXUU3X00UfrDW94g1asWKFdu3bpZz/7mbZu3ao777zzUct666236qyzztL73vc+/c3f/I29r6VLl+qlL32pjj76aBUKBd100036yle+orVr1+73FYpnnnmmfvKTnxzw5cjJZrP6wAc+oDe96U06++yz9dKXvlQbN27U5z73uQP+5OpVr3pVoutcd911uvTSS7Vq1SqtWbNGX/ziF/fJn/vc5+797aMvfvGL+vrXv67TTz9dra2t+v73v6//+I//0MUXX6wXv/jF+3zujDPO0CmnnKKVK1dq586d+vSnP62ZmRl961vf2ue3BZ797Gfrmc98po4//nh1dHTo9ttv12c/+1ktXrxY7373u/ce981vflMf+MAHdNFFF2n58uUaGxvTl7/8Zd1999360Ic+pMHBwcdUn8AjMT4deuPTF7/4RV199dW68MILtWLFCk1PT+v666/X9773PZ1//vn7/ETuoosu0sknn6zXvva1uvfee9Xb26tPfepTajQa+tu//dt9znvDDTfohhtukPTw4m92dnbvps/pp5++99vfTjrpJL3kJS/Ru971Lu3evVsrV67UF77wBW3atGmfb4+5/fbb9fKXv1wvf/nLtXLlSs3Nzem6667TT3/6U73xjW/Ucccd95jqE3ik39fx6dxzz9WDDz6oSy+9VDfddJNuuummvdnAwICe+9zn7v3/r3nNa/SFL3xBGzdu3PsbB0l9+MMf1nnnnadTTz1Vr3vd6zQ2NqZPfOITOvLII/ero3e9612JrvO85z1vvz/b8zJ3xhln7PNS9fznP1+LFi3SSSedpP7+fm3evFmf+9zntH379n2+1fG3v+l2j87OTknSCSecoAsvvFCS1Nvbu/d//7Y9v4H0yOzXv/61vvnNb0p6+N+NmZyc3DvmHXvssTr//PMf9T6BJ9Pv61j2dF5rHWgs2fMbSM9//vPV29u798+PPvpoPec5z9HatWvV1dWlBx54QJ/5zGf2/nD/tyVdayHgd/tvex969vxL/Y/235YtW+Jmsxl/6EMfipcuXRrn8/n4mc98Zvytb30rfvWrX73Pt0vs+Zf6P/rRj8b/+I//GC9evDjO5/PxaaedFt955537XXvDhg3xq171qnhwcDDOZrPxwoUL4xe+8IXxNddcs/eYA/1L/Xv+7H3ve1/w/i6++OL4iCOOiNva2uJsNhuvXLkyvuyyy+Kpqan9jn3Ws54VDw4OBs/5aP9a/qc+9al4+fLlcT6fj48//vj4hhtuiM8444z9/iX8M844I07S9PZc59H+++06ueWWW+LTTz897urqiguFQnzsscfGV199ddxsNvc779vf/vZ4xYoVcT6fj/v6+uJXvOIV8YYNG/Y77q//+q/jtWvXxh0dHXE2m42XLFkSv+Utb4l37ty5z3G33XZbfP7558cLFy6Mc7lc3NraGp966qnxf/zHfwTvEXAYn/6vQ218+sUvfhG/5CUviZcsWRLn8/m4paUlPu644+KPfexjca1W2+/4sbGx+PWvf33c09MTl0ql+IwzzjjgN8S4ce+RdTo3Nxe/4x3viAcHB+N8Ph+fcMIJ8Xe+8519jnnwwQfjl7zkJfGyZcviQqEQl0ql+FnPetajjo9AUr/v45O7t0eOGy9+8YvjYrEYj4+PJ6qzR/b9r3/96/GaNWvifD4fH3HEEfG11167Xx3FcRy/+tWvjiXFGzduDJY/6bU/+clPxqeeemrc29sbZzKZuK+vLz7//PPjG264IXjOR/vWtgN5tG9tc+3o1a9+deL7Ax6v3/ex7Om81nos137f+94XH3/88XFXV1ecyWTiBQsWxC972cviX//61496jiRrLTy6VBw/xi1H/F6anp5Wd3e3rrzySv3Zn/3ZwS4OAOzF+ATgUDYwMKBXvepV+uhHP3qwiwIAjwtrLTxW/BtJkPTwr/gtXLhQb3jDGw52UQBgH4xPAA5V99xzj+bm5nTZZZcd7KIAwOPGWguPFb+RBAAAAAAAgET4jSQAAAAAAAAkwkYSAAAAAAAAEmEjCQAAAAAAAImwkQQAAAAAAIBE2EgCAAAAAABAIpmkB77pTafZfKbWsHkj1RW8Rq41Z/PWQtbmY1s3+wvMV4NlGBjotfnW3bttfuSqIZt3trXYvBaoR0lqNPwx9XrTnyD2+4eZbMHm4zMVf35J9/1mk817e3psXujutnkpE/6ywWZl2uazs/4+tm7davPutjabL+nwuSTtvufnNi+l8jZfsPZEm/cvXRIsw9YH/X3e8+Mbbf4fD4Tbw1Pt6MMGbJ5K+TYfpVPBa6Sf4L57KniJQL+VVK/7vh+6Rmve9+2gBFUQBeo6FThJHAfmkqbPoyiyuSRlosDUF/gy02qgDKHPJxFqko2GP6AZeFZxM1zGRuzbZPBLXwP3sH10MliGZq1u82LGP+8Nu2eC1/hdOGWNH4tD81EceqCS4rR/Hk35dptJ+brMhh6opEyg/2Wzfh2Xzfq+2dbq59WOrvBas9Te6vNSyeatgTIUi36cTed8HUhS3PTtvjY/b/Py1LjN52bGgmWozPm+U67WbB4FxtlUya/56+nwejg16dd52S7/LONuvyavjswGy9AaKGcs3y+v/vIvg9d4qh3+rNAayrfZWi28fqnM+DYdB17R0pEvQz7vn6UkVcplmzcC/SodeP9qLfrrr1ji330kqaPgT7Jz57DNGw3f3lKBcT7XEl5DzczM2bxS8+fYNevruVZPsib37SG0PskE1g6hEiT50vtUYFEeysPnD68L0oFrpCN/jge3bfGfD5YAAAAAAAAAEBtJAAAAAAAASIiNJAAAAAAAACTCRhIAAAAAAAASYSMJAAAAAAAAibCRBAAAAAAAgEQC34H8f434b0xUR8l/5erSgfBXoW/13yaomXn/9bgrl/TavFEJf1VflPVfR5ob8183uG2b/0rVlsP8V5E2Al8tKUnNpv8qv2K+2+ZR5L9aMpR3dvp7kKSutiGbB7+xMPAVwtX5iWAZopJ/Vl1t/qtrc1n/daaNOf/5Qku7zSUp0xL4KtDJURuPPrTR5u39/itdJWn3dv9VorW5wHeyHgKiwNdXhr6GOErwDZypwPAR+KZ0pdKBMga+klWSMhnfput13yabTV/IfD5v83SoEiQFv1U+UE+hr2TNBx5WJufHcElqaemweTMwDFfrvk9UZsNfOR/6KvZ0oE02Gr49heaSwMclSVHwZ02+kNMVP2c36uGvjG4JtIds5ol9fe7vSuhrfqPApNhI8DXBceCQdBx4noGvM04FxlFJygbm7mzWFzKX9Z8vFANfAV7w+cNl8MeE8tAYFQXG6UxgnfnfZ/FxYKxPZwLzTTo834TqoZAODPaBZxEN+feCUmv4WVZ3+TI0G36sXrTEr5dbVg8GyzAeWENtXL8zeI6DbS7QnjKB8aea4N0ltPAPtbfQV53Xa/4eJKlSDfSbwH3mAvP26gX+PXTtqnB76u/ybXJuqX9vqATelXfs9O21LUG/m5n2edTh7/On6/1Xym/YPhUsQzEwjqaj0H0E1h+B4S0dmnB/B+LQi4ekZmAd90R/o4jfSAIAAAAAAEAibCQBAAAAAAAgETaSAAAAAAAAkAgbSQAAAAAAAEiEjSQAAAAAAAAkwkYSAAAAAAAAEmEjCQAAAAAAAIlkkh5Yq/tDc1EukIevsaAjFTiiZNPefNPm0+VqsAz1hj/HYYt7bV6pVmxeq/m82WzYXJIy2W6bd/ettHmp1G7zeq1u8yS7j4V8wR/gq1lxM7Z5JevbgiTNV6ZtPlkZtnlHW4f/fG3S5oVSoA4ktQ+ssPnohL9Gc9Lfw7YNG4NlGN024q+RSTxMHDSpVGjs8O0p9GlJitJ+EEtlnti+fJJPRyl/H5GyNq/X/PgSBfp+vuDH+YfLEJDynT/K+jN09fXY/PDDnxEqgVY+Y43NJ2dmbL5zxxab3/erO4NlmJv245PSgXpq+BZTq/tWHSk81zSaT6xNV2f8PWTicM+LAn278TT5eVgmMI5GWV9XqUa4rmry/TcOzLuhkTBKJ3he2cB9Rv4c2Zwfw3K5wFoz6z8vSamUbzOh+SQbuEYh78uYSlDGONA965EfJ0PtLR34vCRl0v4ccdbPR+XAMm06M2fzZuxzSUrnfZsv1H2jLwXK2DNUDJYhW1pg83vWbQue42BLB/qEokCfCbw7SeGxIVUNjPVNf43Q+kaSCkX/wOtzZf/5wBqoNe/79qKFgzaXpKOfdYzNd6y/1+a1sr+HXNH3W01P+FxSseLrutiV92UIjIGNQBElqR77g1oCc0Wh6N/RZib9Gi0VeK/4XUiyZxB64Y7jp/7dBQAAAAAAAGAjCQAAAAAAAMmwkQQAAAAAAIBE2EgCAAAAAABAImwkAQAAAAAAIBE2kgAAAAAAAJAIG0kAAAAAAABIhI0kAAAAAAAAJJJJemAhH9m8karZfKrSDF6jLe/zZmDfa2yyYfNazZdRkmqVii9DHNs8nUrZfHJm1n9evp4laWCg2+YtpS6bd3V1+gukfD2PT4z5z0sqpv05mk3/LObnfT11dPt7lKRo2jfv4eEdNi83qjZv1P31W0slf4Ck/LJFNt+15SGb1yu7bT62eX2wDOXpaZuXunuC5zjYsjnfb0L9KtzrpCjyfTsdGJ9CI2Dc9OOXJPkSSFHgiGw+688fuEAUJakpf6f1QD0V29tsfvQzj7P5iaecaHNJ6h/ot/nYxITN+/r9+NOWoO9vf2izzbdu3mjz0FyVzvhn3YzDzzLUJKt1PwhWaj7PhBqcpHRgLpmrh9cWh4LA0kGpQF2EcklKxYGfDaZ9XaUC40c6sDaQwuNkKM9m/TVyOT+vZwO5JGWy/pgoempzpRP0Pfm+E7pGJjBWR1k/PkiS6n4NlMr5jzd6fRk3z/r1y/yov74kZQPjYEG+4/WMDtu8I3APktTW2Wfz9o6W4DkOukC/qwcmgzgKjw2Nmn8WqcA1QvNRLhd4iZTUDEwX9cB7Yq0ZGMhzBRsfd8pp/vOSlPGFbCn6jtfaXrR5OuvXJ7sf2mBzSWrJ+eed7+y0+fy8X9+kovCzDLXJ08483ebnnHOOzT9x5ZU23/bQFptLUjYwzob2FBRqbwnmkigwbwfnqwB+IwkAAAAAAACJsJEEAAAAAACARNhIAgAAAAAAQCJsJAEAAAAAACARNpIAAAAAAACQCBtJAAAAAAAASISNJAAAAAAAACSSSXrg7OSMzRvz8zbPxoXgNWpZv69VrlVsXqnU/Pmr/vOSVJ6r2ryhrM0L2Zz/fMPX0/IlK20uSZ1dQzZPN3w9FCJ/D9mWNptXqg2bS5KavgzT0yM2zxV8e2lt82V8uAhNm7cUOmxenvJtYWLW5+MzZZtL0qJ+X4b+pStsvvlXvh6707PBMnS3+nqKOluC5zjY8rnAUOZvUan4SShEyl8k3QhcJJ0KXiIb6Ltx5D/faPi+mwr8aGE+MLZIUjbjx8Cuvk6brzpitc1XPmOVzfsHemwuSdlAe+nv77V5a7Fk894u/3lJ2jq0wObprH+Ymzes959v1m3eTDD9x03fZqfn/HxWr/oxspQLNFhJCrRZ1QOd+xARx76ccRwahMLjQypwSCrQwTOBny1msuE2E6X9Mw0MYcqG2kRonA1XU7CM2Yy/z2zW30Q68vWYzoR/htts+DI0AtfIRKF7yAfLENX9eN/I+jV1rc1fY3bUr5Emt0/ZXJKOPuJwmxcCzWnnrlGbL10Wnk9KRT/n9XW1B89xsFWrfr5oBIbZbDrQsRUewdKBI+JAHvq8JJXL/l222Qysh3O+TfcMLrZ5byCXpLtu/anNG4FuMbTIrz+6WoZtvjMwxkpSobPL5sMzfuwYm/BjR77g11iSVJ+fs/niJUtsfv7559v85p/657Bl4yabS5JiPw4HZ4LAhJYKTfoKz1dRlGAdZvAbSQAAAAAAAEiEjSQAAAAAAAAkwkYSAAAAAAAAEmEjCQAAAAAAAImwkQQAAAAAAIBE2EgCAAAAAABAImwkAQAAAAAAIJFM0gMr09M2j+YDp2qLgtcYm2nafGrWlyET+X2xtrbuYBnKtXmbN+Tvo7+/1+aVsr+HRQueYXNJ6u0etHl6fs7mUTO2ea1Rt3lrW8nmktRs1mxerflztLT6vLe7L1iGvu6qzTORf5b5na02L9f859dt2WVzSSrkUzZffNgim2/e+JDNxya2Bssw1Jm3ebMxFjzHwdZs+Dady+Rs7p9CQnHDxunAtn0UaI+SlM34cbZS8X13anzG5vlSweaDy317lKShgQGbL1u+zOaHr1lj84EF/vzdveGxoVRqs3mUydq8PB2ox8JwsAzVesXmRx13gs2zhRabb7z/Hps36358lKRUxrfJ+Zpv8wr0y8DpJUll36T1JPXep1yz6cuZSvk8Tvm6lKR0qCpCeezXYEpQhpB03Rcik/ZjUFen7/+pwFgvSdOzfo1UyPlxNhf5eggsRRUFH5TUDLSHZj7QN+f957PZ8M+R0zVfD9XIr/Pqgf7d2e7H4ZltE/4Ekk4+ea3ND1vi54Of/+SHNp+b9vcoSbmsH8vbMk+Dn9k3/MMKDh21wNghKYr9WdJp33cblcC7S8W/v0lSquknlCjt5/5m4B1w4ya/5h4dCa+np8f8MT/4/h02P/WPnmnz/u5Zm89VfC5Jue7l/oDWHhtXm/4ecgn6TDrn28t999xr840PbrT5kiWLbZ4r+ncnSYqbvl+kA31CCrT50JwtKRXovanQhBXwNBjdAAAAAAAAcChgIwkAAAAAAACJsJEEAAAAAACARNhIAgAAAAAAQCJsJAEAAAAAACARNpIAAAAAAACQCBtJAAAAAAAASCST9MAo7w9tacnZfHq+ErxGeaZh84H+JTbvHeizeXt7d7AMpVKbzcfGdtk8atZtnh1YZPOhgcU2l6QosP2XT0U2rwaeRarkn2UqavoCSKoErrFo6VKbt7d22XyobzBYBqVjG2fzRZt39w/ZPFLB5vet/7XNJWn9Q749HXO4by8rj1xt8xu+vyNYhnTkn9VAW/h5H2y5jB+fcrnQUJcKXqPZDNRDIM4GLpEJllGqVvwYuWvXbptPz/lnfcIxR9j87Oc9x+aSVCuXbb5kiR/HV6053Oat7X6Mzub8+CVJuWLJX6PFXyOXy9u8UgvPd4URP34sX7nS5m2dfj4rtbbafOO9d9lcksqzszafm6/ZPBv5Rh/Jj9GSFJjO1PBFOIT4ukinQ3n4Co3AOeLAzw5ToTFOfvyRpHTsH1gh49tlMdti86FBP37UmuGKKlb8GNWcG/PXmJ/x5w+MUekkD7Pm+0Y65Z9FqN8kKUM2k7V5LD/OZWq+PfUHxrCRtvD6pdGYsPnCxX6tecwJy22++Tf+/JI0ut3Pu7lAPRwSAkVMh8byQC5J2bRf45TLvj3Vq4FrNMPjUxR4gUoF8vLcnM3Xb9ps8y07/JpfknaMT9p824Qfn6pZfw+tgXebjkE/70vSs854vs1TXYfZ/Fs//Y3N4zjcZ1avXmHzRYv8+9NPb/6pzXcPD9u8pc3PZZI0OzVt80zaD9SNQD2EPi9Jqcj3u1Qq3HcdfiMJAAAAAAAAibCRBAAAAAAAgETYSAIAAAAAAEAibCQBAAAAAAAgETaSAAAAAAAAkAgbSQAAAAAAAEiEjSQAAAAAAAAkwkYSAAAAAAAAEskkPTCup2xeas36C2V9Lkndnb02X7F8jc1rtXlfBjWCZYhUtXkpHfvPRzn/+fY+mxcKRZtLUjHjn0VtctrmE+Wyzbs7SzavVP3nJWlocIHNn/GMI2weNf095rPhPdBmOrL5gkVLbD4wMGjzyZERmw/v3mxzSdo2vMWfY9J/vlbJ+3wuXE/3zYWOaAbPcbBlMr7fyTcnpRJsqRcLvq4jPzSoUfdjSxQFCimpPOP73uzElM37Fvo2fdIpJ9q8tdWPDZIUak751labl1rbbN7d7eeJJO01Sgfmo0B7SEV+bGlpaQ+WoVjy9RCl/X3EXf5Z9A/6uWZqNFSP0sgDvj1VKhWbFzK+npQN5JKyKd+xag3frw4VcezvIxUYhNLp8CAVBVd0vgyZwBiWTTBQtrb4dvmMVats3tnbb/P169f5AmQLPpfU2Tfg845Om8+UfbvPzPs2Wcz7ueRhfj5oBJazKfm+lQo3FqUDDSKXabH5aGA+UsGfv6/Xj2GStH3XDpvP1f17Q0tvh7/ApsAiTNKuX220eW+mM3iOg63RDDSowHo6MF1Jko48+kib/+rWe2xervn1TyEbbtPNRt3moXG2EeiXnT1+bIly4TXUgqEem7/+1c+3+WHL/PvXXNm36ULvUptL0sDKY2ye715m8z8+9zybx00/xkrSkiVDNg+N4/VGoNEG1uRnVs72n5f04x/+0Oa1OX+fucBaNQ7sB0gKvuDE8RN7x+M3kgAAAAAAAJAIG0kAAAAAAABIhI0kAAAAAAAAJMJGEgAAAAAAABJhIwkAAAAAAACJsJEEAAAAAACARNhIAgAAAAAAQCKZpAe2lCKbT09VbF5rTAev0dvfavPyvL9GdX7G5vNzY8EypBo1m2cjXw8dHb3+8xn/+VptzuaSVGn4xzYxOWHzloEBmzfjYBES8CcZG9nlPx54DoVcMViCQmuHv0TgGrmCv8bK1attPjy8xeaSNDM/ZfMdY7P+Gg/utHmzXg2WYWVvwecDbcFzHGzprO9XgW6rTIKRMKWmz1N+Xz4XuEit3giWYWraj6ON2Pe7bC5n82rVj7HlmbLNJWn5St8vVqw6zOYdnZ02bzZ9m85n/D1K4fucD3w+nUrZvFjyferhY0o2r837Zz2yc6vPd223eU+/n6skafaedf6Aet3GrYF7LMfhNt9I+2NKhUDnPkTEgb6ZTvvxI5vNBq+RDlRFoNkqK39ALh0eKDORv4/R8WF/jRY/73b3dtl8vhZewKQC65Ni3vffbKAaJicmbD6XzfsTSFLTzzfptO97zcBCLvanf/iYyN9oJjTvzvn17PB2P4ZFHeH2lmr6fjE760fzOPKfb23360hJSpf9GJXqDPfdgy0KvZsExvpKLTyWDw0N2bzttG6b//C7N9q8VgnN3OG1YJQODJKB9nLkMc+0+YKlK/35JTVLfn0y6IdAzUz6d91NO3zePniUv4Ckes6/rxdzfu5fvHiRzXMJuky+6Nd6Ud7ncc236Z6+Ppuf+8IX2FySpmf8Ou6mn/zE5lHGV0QceC95+KAExzwB/EYSAAAAAAAAEmEjCQAAAAAAAImwkQQAAAAAAIBE2EgCAAAAAABAImwkAQAAAAAAIBE2kgAAAAAAAJAIG0kAAAAAAABIJJP0wGzWH1qenbZ5HDUTXKVi0+GxrTbvbO+2eTbfFixBc97fRzrj994aim1eKOVtniv6XJKacw2fB6o6irI2Twf2F0dGRvwFJP3m/nU2P3bNSpsvHBqw+VQjXE/d8vdZq/l6zOb8s2zr9O2pp6fP5pLUus236W2j22xent5u8ygT7uIrhiKbn/ZM368OBanIP8tMxt9jIJYkxU3fHpT2HS9Uhmrd34MkzVVq/oDA8+7q67V5Ou37fmd7h7++pPb2Vps36vM2r1UmbR7lfL9upsL1OD4+bvOJqbLNi4WSzVNxuAzNRugY/yxHRydsvnP7DpsvWbY8cH1pwdCQzae2+muU8qnAFcLjUxT7fpNqBPrlIaIReN6hNVYUhX/ulw0ckw2sX9KBqswqwUDZ8OPgxMSozafLvu/1DS20+bIVq20uSY2aH0e72/wYkwmsoYZn/Bg3Vw2vh2uBMqYDc16lVrd5sxqYSyRlcjmbpwJrxc5sl83b634cHt45YXNJmumas3l51N9nps2vJVszncEyDPQs8AdECfrNQZaSH6t7ev16thbot5L005/ebPOTjzvN5osXL7b5g+sfCJYhCj2LwBjY09dv8+NPOcXmA0tW+QtIyg36NffYjjtsPtH0z6J/5ck2b19yuM0lqRno+9nQmjv249P4uF8HStKxK55p8/Ksr4e5uTGb1+u+jG1tfh0oSc/+o2fb/I7b/bOszvu5JNBtJUnptH8WSdYW9vxP6NMAAAAAAAD4g8FGEgAAAAAAABJhIwkAAAAAAACJsJEEAAAAAACARNhIAgAAAAAAQCJsJAEAAAAAACARNpIAAAAAAACQSCbpgaVCzuathU6bF0r54DWaab+vNbx7u81rlarNW1tbgmUoZLM2T0XNwBl83qhVbF4tTwfOLzX9KdSo1mweNwL3kPJ1MDUx5T8vaWZ63uZdHQP+BLFvCz/+/g+DZTj6WSfYfHBoyObT02P+AnHDxtlMeJ+2UCrZvDTrn8XQ0gX+8+0+f/iYbTbPFf19HgrSStk8lfJ5OhV+VqmsP0cUGL+iwOfr06GxRarX/TGxIpuns37ID9VTS4dvr5K0c9tDNv/1HSM2X77Mt9lnHLHK5rmsn6sk6dd3/trmd9/1G5sPDAza/NhjjgyWIdT3K4G5pFqPA7nvt6XA9SVp+ZLFNt9y1302b6T9PfjW9rBmNTDOpnybP2TE/nmlAmNQOh2+zygw5+Qyvv+nfRGVbgQOUHgszeUC42jOf3561q8/Jif8+CJJK4b6bN5T8mWMVQ9cwa93y3F74PNSI9Cum02/xqrWfJ5P0G0aNb+m3vTgZv/5ef/51Liv58qMX8tK0gOzm2x+xMrlNl982EKbT2yfC5ZhfN63h7b2Q/9n9lHBjw2DC/16WXOhPiHde/u9Nv+v//o/Ns+lfb8qFsPvmYEljkK/XxFFvuP85Iabbb5i5epQAXTicX79cO9tt9o8m+6x+VHHnGLzRoK5Jg7UQ+jXVMa27rB5e09HsAz5wFovFVjiTIyP2nxkxM8lpZYEa6jDVtp88eIlNr//Pr/GymbDzyodaPO5nH/PDJ7/CX0aAAAAAAAAfzDYSAIAAAAAAEAibCQBAAAAAAAgETaSAAAAAAAAkAgbSQAAAAAAAEiEjSQAAAAAAAAkwkYSAAAAAAAAEskkPbBUKj6hC9Vq4WPGZss2n56etPnM/IzNu8odwTK05Us2j7KxzRtq2Hx4eKfNC+mUzSWpmfKPLa7Xbd7S8A8jV/Wf7+kZsLkknXnWuTZfvXyFzUcD9TQx5duKJG3dut3mPb3dNp8r+/amQD1W58Nl7GjzZdi8c7PNUx2+vbYE2ooklYq+nmqB9nQoyGQjm6fTvt/Kf/zha2Sy/oDAtnxTTZ/HPpekSs2PL+2dnTbv7u33n+/qsvmSpUtsLkm/Wfcbm3/j2z+0+cnHH2vzBYsX2TzK+DqSpO3bd9v8nrvX23xkZNbmLa2FYBmOWHOkzRuxb7O5ku/7fUO+ntraw/PhzJQfA7t6fXvZOTIauEKgX0qKIn9MKhU+x6Hgd1HKKDCQpWK/vggNg+lUeH2SSgf6X/AcoZry4+TU5Fjg81K6M2fzXGAsz2V8GQv5FptPROEJZz7y55iv5W3ekWmzeSYVnm+2bt9m85YWPwZNzVdsngu0uCMWrra5JKVzfh12+w/vsfnPf/Irm+cmgkVQZdTPJ0f88dHhkxxkmYJ/FuW5OZv3lXqD1yjlfZvMRX7enJ2asnk+4/u1JIVGn1TKd/6R0RGb/+CHP7H5scceHyiBdOTqlTafmQuMX1m/Vk1F/n2+rTX8vp9t8ePT+A7/Dnfv7XfZ/P95w6uDZSjl/RiYCqyhuts7bf7AOr8OjMNLTQ0NLbT5s57l28PGBzfaPPCoE8nlnthJ+I0kAAAAAAAAJMJGEgAAAAAAABJhIwkAAAAAAACJsJEEAAAAAACARNhIAgAAAAAAQCJsJAEAAAAAACARNpIAAAAAAACQCBtJAAAAAAAASCST9MBm3LT5bLli86m5OHiN+TiyeaGt2+ctWZtXarVgGcrlEZu3tbfbvKZpm09Oz9u8u9Ric0nKRv4+s7mSzWfLYzaPI7+/mM/75yRJSvtz3H7n3TZfvfIwm//Jy14eLMLwru02n5j09TA+5nPFvj3V6uF92oElK2x++wN32XxyyrfX9HS432VL/j5mpxM874Msn/N9QmrYNBWlgtdIh44JPe6mr8dKJfys5ip1my9oa/P5oiU2b2vrsHlra3h8Guof8Oco5m2ey/u82NJp88mJKZtLUqnk62n7Tt+vNm/zeXeXH4MlaeHQQpvnc356bmnxc1G+tcfmczXfJySpvcO3h64eX49jI76eMplcsAx5+X5TDXebQ4QvaL3u+3Y2GxrjpFRoEGr6MSwVKGM2wVQQpf1B2Yy/j1RgLE/n/D3WamWbS9L02C6bryj4vrWwzY+DUdH33Q2NWZtL0pbAcjVb8n0zW/Pj4PTocLAM1ZkJm/f3+HoYHPRlXJXyY31G4fHhwd/8xuabdk7YvBzoVssC62lJSsW+7+b7g6c46HIZ32Z3bPXr6UkF1suSVq1abfNnHnOczb957X/avDI3FyxDaByO5d91SyXfZjuLrTavVf07oCT9/Oe32Pzuu/z707HHHmPzHTt323zVkWtsLkmtTd9x/uuab9k8V/DtbeXR4TJUGlWbT0/79/FCsRjI/bNuafXPWpI6Amuo448/3uY333STzccnwuN4NvPE5uQQfiMJAAAAAAAAibCRBAAAAAAAgETYSAIAAAAAAEAibCQBAAAAAAAgETaSAAAAAAAAkAgbSQAAAAAAAEiEjSQAAAAAAAAkkkl6YKPesHmlXrN5qVQMXmOwqydwjdhfIx/ZvLcQ3jerNCo2j9JZm2ciX4bRsTGbT5dtLElq1Jo+b/hrZPO+HuYavhDZTN7mkvTN//83bb7+/i02f9v/+z9tvvrwlcEybN/+kM13D4/YvFQq2XxyfNzm2dZ2m0tS38CQzRcOdtu8VKjavJqeDpahs6Ng8/mq73eHgpTvdopTKZtHke/XkhSl/UVSGZ/H8nl5dnewDPXAGDhf9+2h1Npi8/GpGZvfccedNpektqKfVp5z5gk2H1q8LHAF/yzT8nOVJJWKOZsvWbLQ5rt2+bHjsGVLgmXo6fbjw/Sk77u5nB+Hszk/507P+LlOkvJpP9fk8n6MbNb9+eM4/KwykX/e8dPk52HNpq/LcB6uq9A5UoH1ieTHl8AwKknKZn3/z+V934sKPk/nAmN1Kjxf7ZqcsPlsT6BvpX3fapEfh5d02FiSVCv7/j8+PeU/P7bN5j3l8GKzPfAsm1m/dpjJ+L5Zzftnuf6hjTaXpI07H7D50sP8WD6f8/1qaXdXsAzts77NTvYleOAHWbU85w9o+mc5PBxev5x98tk2P+WUZ9v8hh/+yOY7E7TpdGC6yAXa5Nz8vM3LVd/3/8/11/sCSLrpJ77f9fb69pRO+8+3dwzafGjO34Mk3fSd7/j8+u/b/KK3vs7mXQP+3UeSpib8GNio+wVILbRvUfTr5c7OcL/O5/zYsGiJXysuXbrU5jMzk8Ey5AJzZiqdYGI3nh4rMAAAAAAAABx0bCQBAAAAAAAgETaSAAAAAAAAkAgbSQAAAAAAAEiEjSQAAAAAAAAkwkYSAAAAAAAAEmEjCQAAAAAAAIlkkh64a6Rs80Jrh82H+juD1+hsL9m8Hvt9r1yqafNCNsG+WabF5/4SSqd9lbaU8v70zcAFJI2Nzdr8oXWbbN7X45+VopSN5+TvQZLWr9tg8we3jNp8x8hOmxdK4aY7MjZi87ZAm+3v6bV5ayHQXhXZXJJixTbvbi3avLNtgc0nou3BMrQX/LMoT9WC5zjoAm02lcraPBf5PIk41HfTvj3kC+EyZFL+PiszfpyOAkWsN/wYuWnTJn8CSW0FnxcLbTYvFfwYPLxrzOazs+O+AJIG+gdtfvppz7b59NSkzdcee1SwDOlA39+50/fdKOXbU19/n83nZ6ZsLknz036uKbX7Z9lI5fz5q5VgGbI53+YLgb5/qIhj/7zj2HfORiO8Nmg26/6ArK+rTNrn2Vx4TssX/TPPFf04l8kHxsGsL0MqG14bpAp+Xt1Rmbf5klrV5sXYt+uuQD1L0tJ5/7yb2wLjQ9mPUUtaAgO1pIm6r8uxwHp5PvLXyHT757Dx7k02l6SRjF/n9WR9GYqdfj3bftSSYBmWtSy0+d21ieA5DraUH56UC/SrVItfD0vSbbf90uZ9vX5ezuX82JJkjCwVfXvI5vx9zs7P2Xz38LDNt2/fYXNJOvWEk2z+spe9zObXfv06m///vvwfNv/2d35gc0laf/uvbP6cU//I5meec6bNy4ExVpKKgXE8k/VzyeSUXwOVSr5Nd3YG3qUlRRnfnjrb220+ODhg8/t/E97XSEf+mHo9sG4Inf8JfRoAAAAAAAB/MNhIAgAAAAAAQCJsJAEAAAAAACARNpIAAAAAAACQCBtJAAAAAAAASISNJAAAAAAAACTCRhIAAAAAAAASySQ+MpuzcVdni81LLfngJfJ5v69VCmx7ZRXZPE4l2TcLHOMvoWbctHk+lw1c339ekvoHOvwB0UIbj0wP23w+48vwrKPO8NeX1F7qtvlA34M2X3/Pz22+c0MxWIaOjiGbd3f6Mvb09tm8rbXN5pMzZZtL0viEfxZRoN+VCv782aHOYBmism+TM+XZ4DkOtijjh7J0oO/HcRy8RiYKDJeBa0RZ//mu7vZgGdIFPwDNzvpndc/9d9u8f9EyX4DqhM8lDXb7uWA6V7P5jrE7bV4qlGzeP+D7rSQddcxSmx8W+2fZqFb8BdLh9jQyttvm84FrTJf9NfJFPz7FjcDgIWlmwufzNV/G8rzP5yu+LUhSNvZtPldIvow5lDWb/nk2m43wOQLrj7hZt3k6sD4pFELrFymf98+jkPfnSAeeZ02+nhqRv0dJal/u1wa7duyw+fqJcZtnAuvdoXp4nbew7u9zqKvV5oUOX4a4Hp7X74t9Xbb2+LG4GJgzHxpfb/NSZ7jNP3P1MTaPUv4edu7eavNaYVWwDJvmp21+/2/8fep/BC/xlEsF8vnZeZtnGuH3q21bt9j8P776VX+Chu8TrS2+PUpSoejHnyjwjtfd3WnzRmAtOTEx4y8gqbO7x+Z9fQM2Hxzy49t3/s8PbF6phsfQtcccbfNzX/Fim6eygXm9GWqRUjUw383N+zZbqfj1ybbt22x+z9332lyS+s/st3ku78fpXM6/A6aCPVdqNgLrguAZPH4jCQAAAAAAAImwkQQAAAAAAIBE2EgCAAAAAABAImwkAQAAAAAAIBE2kgAAAAAAAJAIG0kAAAAAAABIhI0kAAAAAAAAJJJJemBbe6vNlw612TybT3ypR5XJpmyeTvl9sWwmCl6jGcjTCp/Dnr9ZD14hJBc4ZElhwOYbt262ea3ZsHlHW7cvgKSlA4ts3tXq29PI+G6bd/cMBcswtGCpzXP5ks3n5+dtPj0zY/NsPm9zSSoVWmze2+Of5Vx1u79AgmdVbvi6nC5PBM9x0IX6fjZn83So40vK57KBI/zYMFep+jJkw32/1OLbbLrhx5dd23zfV6CeSqEqkJQb7LP5pu2jNr/1F3fbfNXK5Tb/k5e8yOaSlI583xwa9P1uZsrfw9iYzx8+Ztzm4xNTNn9o64jNVxx+pM3nyn58k6TpqWmbl2fKNo9Sft5vz/s5XZKKgTaZqPMeAprNOJD7+wh9XpIajZrN6w0/t6cCzyubYIzK5fw4mCsE1oJZ//k4sD6Js+H2MFLfafNijx8f1u2etHm2XrB5IbCelqSOjK/rZn3O5unI1+NUJjyY37Xbry/Gs379Um73/Xti0j+HXNOPP5KUznfavNDeY/PxBx6w+V13/SZchsjXw7r7NgXPcbDFNd9eKhO+vcWN8Hq3teTXL2O7fXtoa/PvmR3t7cEyRIEhLPSamMv68asw2G/z3o4OfwFJ3V2BY7J+fDn5tNNsftbZp9s8nQ0/y0ULB20+ONBr89m5WZu3tfl6lKTZmQmbzwXWJ7VKxeZ333mXzYeH/TwgSSeccJLN04Fdh1Rg36OUC6yPJMVp3+jjdHgd5vAbSQAAAAAAAEiEjSQAAAAAAAAkwkYSAAAAAAAAEmEjCQAAAAAAAImwkQQAAAAAAIBE2EgCAAAAAABAImwkAQAAAAAAIBE2kgAAAAAAAJBIJumBQ30lm7e1+lyp8DXSgW2tKJu1eTYKfT5wgCQ1fZVUqjVfhqy/0WyuaPM4rttckprNQF6LbT7Q22XzQr7H5knqsdZo2HzFisNt3je/2Obz5flgGdT0ZWgG8omZWZsX21psXp8v21yS8nlfl6V2/6zqUxP+AulAY5E0kRuw+a7G9uA5DrZclLN5FNozT7ClXq379lKrVmzeSPl+2d7dESxDX6DvlkdHbF6bmrH58NZtNl952EKbS1JLW5vN77//Vza/554NNp+ZnrP5eS+8wOaS1N7u6zpS1ea1mq/Het2XUZLihm8P04G+XQ20NwW6fr3h5zJJmi1P23xsbMLm2cgXIh37OpAkNfyziNMJ5vVDQGi+iWM/CDVDE7+kRugaKX+NdGARFuX8GkyS8sWCzTOBc6Szfg2Wif3zHlrSbXNJqizw/XPeN3vt2D7qPx8YR4dzvo4kqS3rn0VjfsrmLZGvp7lAW5GkOyb8NaaLfm1w9KoVNp+f8+u4ngRvKLPzfp22a96vqWvya/Lp4cA4K2l4zpdB9UP/Z/aNQD21ZHw9pVPhh9Wo+Wv0BNZAuUC/Cb1DSlIq8C6aDoyRoVfZTKAMraV84AzSyOgum8/M+vHriCOPtHmlPGbz7r5+m0tSd6df583N+LGjWvU1WQ28a0vS3Jx/x5qf9/W0Zcsmm997z902n5wK9HtJU5MTNu/p7bR5LjRfZsLrn2zOvx9VE8wFtgxP6NMAAAAAAAD4g8FGEgAAAAAAABJhIwkAAAAAAACJsJEEAAAAAACARNhIAgAAAAAAQCJsJAEAAAAAACARNpIAAAAAAACQSCbpgT2dBZtH2cCeVBQFrxGl/DlKpZLNM1l/jVQ6vG82O1Ox+XytbvN0Nm/z9mLW5qkoXMa40bR5s96weTY/ELiCf9aNxnzg81JNvh5q8zWbpwPNpRJPB8tw77rNNp+dj22eChRiyeLlNu9u9fX4MF+GkHzRXyNd8fUsSdV8q83LbT2PqUwHQxynbF4J1EOjEa6nfMHXdaGlGDyHFYWH44VLfN8dTwXGp4Zvb+VZ37ebfmh5+BoZP4b19HbZPIr8GNna1mbzjq5Om0tSqdWPT3HVfz6d8mNDlGC+S6V8m52d9s8il/P3UJ6esPn01JTNJalS8e0pNBdl8/5ZxvVwv2vKXyNwiUNGaKQPzgSB9iJJ1UDfqWdC67hAHji/JDUC67Ao79ttaNZMzfs2WZ4Ot+tCxY/VsXxdV+Xb7a66X59MT8/aXJIaI77/b6qN27yn26+XT1p5RLAM7YcvtPlDI5ts3ghMaUta/Plr67f6E0ia6Wu3+W1TozbPVP1gX5sKr9EmJ2dsvqDn0F9DNWt+nC3kfM+sz4cXB6E5qyWwhkoH1uRRgvendGAYzQTyVOQPyATWcVEmvM6r1f176OjoiM1TKf8sJoa323yFH2IlSblAPWUD9dQMdKt6PbAIkzQdGOsnJvwYecONN9h8ruz79eZN620uST+98cc2/5MXXWjzVKCeMgnWmrmMPyauP7H3UH4jCQAAAAAAAImwkQQAAAAAAIBE2EgCAAAAAABAImwkAQAAAAAAIBE2kgAAAAAAAJAIG0kAAAAAAABIhI0kAAAAAAAAJJJJemAxH9k8inxebYT3rBqhMshfQ8E8XIZ6oBC7RqZsvmRRn80LhRabR1GCvb1m08aNRi10gsDnfSXMzc8Ezi+1dLbaPA7c5lxlt82rGgmW4Y4H77H5ffdstXlHh7+H5+V8e+sqHWbzh/lnkcv6a6SUtXmSneJGqWDz7gWDCc5ycM1XqzbPZXw95jK54DWiKOXPEXhWUeSfVSPB0+rqafdlUN3m49t9v2lvKdp8emra5pKUiv34cdzalTbftHGbzZ/5zDU2H+j1/VaSVPPtpVrxY9zM9ITNx8eGg0WIY59n8n6umJ4p23zzQxttXp6Z9QWQND3hn/dcw7e3iXoleI2Q1pxfpqQD9Xio8KNHAqEGIymK/fMoNX3eI3+NgQQrxo6sP6hW8DVRb/Pj5OIePx/1HDZkc0natsvP/Rt3bLf5ESceY/PZ/JzNx37jzy9JC27wY0jLnJ9vdnf4eb26alGwDJmcH2OOOuxom+/a7Oebia2TNs8Hxh9J6p30693VFd+eytk2m082/VwhSar5593WFq7rg6296OfN2nxgbGnJB6/R2uKvkUr5NVA6HVpjhddQ6cBAnE75MTCd8idIJ3mHC1i0yI9ha9astvnw8KjN5+Z9m77/Hv/uJEmjO/0YumSBv4fW7n6bZ3Oh91hpamrc5vfd5+9jy5aHbL58he+31Wpo10L6+c032vzE40+weTbjx6+2tlKwDHFg7ZB9gm2W30gCAAAAAABAImwkAQAAAAAAIBE2kgAAAAAAAJAIG0kAAAAAAABIhI0kAAAAAAAAJMJGEgAAAAAAABJhIwkAAAAAAACJZJIeWCyVbN7a1mrz6Zlm8Bq1es3nPtbM7HzgCuEybNm1y+a33/cbm1e1wuYDvb4eU4psLklx8AgvCmwfNhp1f/2mzyWptbXN5pXanM13jc3afN2mB4Nl2LB9o83H5qds3j3g23Rra94XIG74XFI92CT9AbVmxeZzlUCnkdQMNLm2tpbgOQ62Qiln83Tkh7psgmtkIl9RUZQK5L7jRalw3y8WfJtLt/t+16j6NrngsMU2n5mcsLkkTY2P2ryl4J/VqSevsXlvf4/Nd231Y7QkRY0Zn2f9s5ieGvP5tD+/JKnhr5HL+Xpq1Pz4NTU+bvOZ2WmbS9Jk4BxtgXk/1C8nZ8rBMjRqfgycLvsx8FDhRwdJDT+zx43w+qV9zs+rS1O+/x+R9uNHfz3B3D/l5+75Pt8mdOYqGw8t7Lf5QHuHP7+k+E5/H+tuv8fm6aFumy8+cpnNjyr22VyS6nf+wuZ98769tPR32Xx9ZSJYhmzZrx9aO3xdR5mCzQt9fgysZwNtRdLkmB+jevJ+jFq+aKnNf/XQr4NlaM37Z5FWeC14sOVSfhWUCrwtht4BJSmK/DUygYuE1nGhNZgkpUOHNP2zigNr8lTKr/NqtWqgAFIm68/RN+DHj0LBr9l/dsOPbT7Q58c3SSpmfUU+MOPXJwOLfD2sbA+XoV73c//9v7nX5t09fozsDeS1avj9anjnTpvfcZsf51cuP8zm9997R7AMs9N+rVcIrDVD+I0kAAAAAAAAJMJGEgAAAAAAABJhIwkAAAAAAACJsJEEAAAAAACARNhIAgAAAAAAQCJsJAEAAAAAACARNpIAAAAAAACQCBtJAAAAAAAASCST9MBsNvuE8s6OVPAajYY/R5T2+17ZjM+bagbLMNhbsvkZJx5p83K1bPMdI7tsPtDfa3NJysjX5eTUhM3L1Xmbz8/7e4iihTaXpGwmZ/NazT+LzTP+HifSxWAZjlzjn9XQMv/5Wt23p1rNf76lo8cfIKlWb9h8YjZv8+3bfHvasXM6WIb+zi5/jZGR4DkOtmzRt4fQjnkmPDRIsT+o2fTPMpf1eTqKgkVoFny/SjdabF5p82VYtXq1zSdGhm0uSePjgTbXqNh4qKfT5oVs3ea7tjzgry9pdnS7zdt7Bm1ebfi2EEX+Of33QTZu1H09NRp+ANo9Mmbz8uyMzSWpFpgLjlyy1OZ9ve02n634uUiS5qq+zU5N+3o6VESxz9OBXIE2J0nLAuPg2mzB5kvK/hqFufFgGbKxb5fZJYE5LTtr83zejy+12TmbS9JPfvUzm08+tNXmLVv9OLhq5iibL5sKPWxpZ6DvlUt+VpudmbT5dDk831R3+rl/oOyfxfKeBTbPjPvzt+2o2lyS5jeP2rxa9O2h1ufbW2fev5dI0tqly2y+ZVe43xxs82VfT4Wi77dR4P1LkqKUPyaT8a+kUeTzVCr8nhlF/pjYLy/UaPrPh8oQpcOv3c3AWN9s+PGjVvM38f3v/8DmCxb49Y8kXXDe82xeDzyK0HSWL/i56uFzBE7S8PXQ2uLny1rNr0/CI6iUyfqjJif8OL1ylV+Tx83wXFLM+7qMAnsKIfxGEgAAAAAAABJhIwkAAAAAAACJsJEEAAAAAACARNhIAgAAAAAAQCJsJAEAAAAAACARNpIAAAAAAACQCBtJAAAAAAAASCST9MDWQsHmhWzK5ulsFLzGzHTV5m1tOZvnc0WbNxUHy7BooMPmUSpr8/u2b7X51h27bL5ll88l6Yili20+PV+2+YbtD9l8dnLK5ikN2lySjop9XdeaNZvn5PNmMx8sQ1vbgM1Xrllo85vuWm/zRlunzbva2m0uSaOTkzafqfhnWan5PhM3g0VQe8H3q2bgWRwKGg2f5wLDTzrRlrpv09m0HxsyaV+Iet0/S0nKF9ps3qj6Mk5Pzdg8ExinFy9banNJmhgft3mj4e8zX/LtMZvzeaU6Z/OHj5m2ebnuG0R7Z7fNi4XWYBnypRabRzk/PZfL/llGkb+H8rT/vCS1tfhz9PZ02rxY9PeYK5aCZegK5AO9CQa5Q0EjtP7w95EKL1+UDrTbZiAfm/Z9p9QaXscV/FJQ5Unf7tat22Dz4dkJmw+2+DWcJI1WfRna2ny77Nvkx4/B79xn82wpwYQTGKs7Yj8OZsb9ONvaHa6ncuAVobhpwua1B2b9+Sf8PQ5NhRt9XPPHjMe+DMWGf9bLlj4jWIYtTd93M1U/Jx4KstnAsw6M1ZHCY0NgaND8/LzNC4H30Ewm/EobeDVRKvLruFRgnA5eP8nnU4G+nfH5HXfeYfNqzdfz7XfdZXNJemD9RpsvGOi1+fPPP8/ma//o2cEyVCr+Pjpa/Xq52qjYPAo02Eygz0hSKfDy0drl3xNb2/1aMiPfFiQpFWgvobViCL+RBAAAAAAAgETYSAIAAAAAAEAibCQBAAAAAAAgETaSAAAAAAAAkAgbSQAAAAAAAEiEjSQAAAAAAAAkwkYSAAAAAAAAEskkPbClULR5vpC3eblaCV7jznvusvmy5YtsvmrRUn+BZj1YhmbD51HUtHmrfD2MjU7avK09/Ehuu+9emy9etMDm+VTW5pXI563Fks0lSSkfz9d8RW/avN3m90/4epSkrsnNNu+OfBma2cjmlYb/fGWubHNJSjf9NYZ3jNi8q7Xb5gmak/LZms0z8vmhoD4zZ/PiQFfgDIGOL6kRGD6acWzzuh86lMr4sUOSFi1ZbvPJkXGbb7h3vc3LM9M27+kN1aNUr87bvG/A30M+ML6UCj6fmfZ1IEnVmp+PGoG8v2/I5k3fFCRJoUNWLPf1NDW6y59/3o+R0WBboARSf59/3i1tgbkgMA9k5OcaSYpj33Ey2VzwHIeCZj0w3zT9feYC87IkjQbO8auZGZv3dfrnWWgJ13V7YJzTtJ8XqxMdNh+ujdk81+/nVElq1vycFvW2+ny7v4f0gztsnuoOP0utWWjj5pT/+DOHfXubLgU6p6Sfdfpydo/5QvRN+Hq+J+vn7bn2TptL0mTaL3LGJv042DtXtfn4Ll9GSVo3stsfUD/011CZjO83tYqfE6vzft6XpMASSfXAIqta8eNPR0d7sAzZvH+XTQV+vSJKh/pNII/Dv79RKPj7bDZ8e7rrzjtsXiz5tebSzvDaYNe2nTb/1a98GY5Ye6zNg9UsaXxs1ObNQHsq5ALjcOBR5TLhcbyZ8v0q9KylwLogF37JC60tovQT+50ifiMJAAAAAAAAibCRBAAAAAAAgETYSAIAAAAAAEAibCQBAAAAAAAgETaSAAAAAAAAkAgbSQAAAAAAAEiEjSQAAAAAAAAkkkl6YCOu27xW85+vVqrBaxRKPi/lIn9A3V+jUS0Hy6Cm31tr5P01+lpzNq9NNmw+Vpu2uSSNTc7bfMeuSZsv6O/0F6j6ZpFN5/3nJdXmK4Fz+M9PZnxj2DW2MViG0R3+mI07HrR5tORImy+v+kZfWbLI5pKUzvi6LBTabN7WGtu81BnoM5J27Npq8/m5QOc+BFTn/fik2De4bC7BnnrT991sJmvzWt1/fuHQkmARBvv7fBnS/nkXOnx727Z1s80H+vttLkmNamgc9mND54C/RmupxebFfLjNN+q+vUxP+3F4ruzzYrEQLkPDt7nFQwv95488yua9bf5Zt7X32FySpufnbD466seO9s7QXOGfpSSp4efUsZGR8DkOAXHDt7k479tDe7YZvMaiVt/uahMTNu/K+bpO5f18I0nlvJ+7y1k/n8xVfJsr5HwZKmNTNpekZtmPxVOBuh7r8WP9jh0+Xxr5XJIGFvtxMApMy9se2mHzLQ/4vitJs0t8/8xPpmyeavhnVe4t2nznVHjtsaruy/CMed8et1V9e5lT4MVEUmrUv1tMybfpQ0Fc832iKp+3FP2z/O+r2DQX+WeZyfgxMheF5/7Q+qDZ9H0/DgzDqVARwsO4WgqB8SH2a6xc4OOlvH/HyxfCWwNdK/16tbZssc3XHHG4zZuhipa0fZtfr0aByi5k/HyntG+PUTo8jqcCbbajzc/Z6bS/h1xoX0RSreL7bpR4J+jA+I0kAAAAAAAAJMJGEgAAAAAAABJhIwkAAAAAAACJsJEEAAAAAACARNhIAgAAAAAAQCJsJAEAAAAAACARNpIAAAAAAACQSCbpgeVy2eatgT2pZqUevEYp1eUPaPhrjEyM2zxqNoJlqDZqNm9OVG2eLbTbvK2zzeY33rrB5pKUiXw9tBRbfRny8zYf6i7YPBdFNpekTNofM16u2HxsetJfoBB+louPO8bm1R0PBsqw1eYdRx1r80YzvE87O73b5hMTszZf/+ADNj9q6WCwDI2qfxaVyXDfPdjiQD49NW3z9o5s8BqZbM7muVze5nHKjy35bCpYhond22w+PbHd5sW07zf5rL+HBF1fxYI/qDbvn0V5diZwhUA9xeGxoVFv2rynq9vm1ZqfD2u1cJ/J5VpsXin7eirlfHtcumSZzTNFf31Jag4P23yXHyI1G3gUjbSvR0maGPPzerEUvo9DQTPybWJhtmjzowNrB0la0PT12V0q2XzVvB+jspVw37o/MEY81PD1MDEyYvOi/PpmQH79Ikl9HX5enCjvtPl4i5/b78j4GanZ7e9Bklrv32jzasrPWbuHfHv5eWBOlKTCBr/+qM77eoi6/XzSMeM/f9dWP/5I0pqow+aLA685wyXfphcneG+4rezfC6ayiV+1Dpp0ys+rodVslA6vd/N5Xw89PX7ejTL+84W8b2+SlAmcoxn7MTAVWH/EgdVos+HXHpLUUgiUsRF4hxvssfnWLj82pNLh9Uu64euhkfLrk2XLl9q8PBMenyplv1Ys5v0YGXiVVhRY8KYT/C5OLtAm04H16nx5wub5XPjdpV7341MuwTkcfiMJAAAAAAAAibCRBAAAAAAAgETYSAIAAAAAAEAibCQBAAAAAAAgETaSAAAAAAAAkAgbSQAAAAAAAEiEjSQAAAAAAAAkwkYSAAAAAAAAEskkPXBsctrm5XLV5rPzteA17ntgm813j47YvKu9ZPO2Vp9LUhRlbT42PWfz6dkpm89Oz9p8sK/d5pI0OjbjyzDqy7iuXLF578lLbb5r12abS9KihattXp2ZsHlneaPNs1vXB8vw0IORzbuKvk22ZHz3mBp+wObDu4dsLkmVqi/Dz399t81/dfcvbF57zonBMmSzfj9568bJ4DkOtrZO37dnZso2b+/uDV4jk8vZPE75ekylUzaPfHN9+JjY991aedzm1ZofpwsFX48LhxbYXJIqFd9epsYmbD495u8hSvl+mcsVbC5J+bx/lo1mw+bVWjNQhnywDJmMf+DVOf+soyi2ebatzeYT075PSNLslJ/3fYuWtm3fYvP2zp5gGfoHBvwBT5Mfh7UVfG2dlmq1ecuYXztI0pT881rcFui/Y379ovHwXJDP+XZXGPJ9Y77i+9bopF//tC0s2lySFLhGuuH7ZrPkx8ltmR027wt1HEmzDT9WjwbWmh3yfWtV98JgGept8zYvbZ+w+eEjdZu3pn3nvbMz0PclDVcCc+KU7zctC3w9TWd8n5Kk7oUd/hwNP98cCgoZX8ZMxr8bFfLhebe9zffNfGBODE04afk5UZIi+bm9mPf3GQXKmAm8NzSbfuyRpIH+bpsXcv4aA32+TYfPn2CAavpj0lk/ny1c6Mef3cM7g0Voa2mxeWe7f5+uNvzYkU77ek7Fvq1IUimw1hwd2WXzyalRm0fZ8LPK5vw4m06H+439/BP6NAAAAAAAAP5gsJEEAAAAAACARNhIAgAAAAAAQCJsJAEAAAAAACARNpIAAAAAAACQCBtJAAAAAAAASISNJAAAAAAAACSSSXpgebpq82nVbN5UHLxGX1+XzfPZlD9BOm/jmUqwCJIim06n+23eKPiL1BpjgdzXoyTNV/0xUez3B4stvp4m5so2b45tsbkk5e//pc3HJodt3pZt2HxJdylYhl3D4zZPBZp/Vk2b333P7Tafn/afl6RCwd9Hed4/i+7uAZtv3zEdLkN13h8w6evxUFAqFWw+V56zeaXs25skFfN+bGg0fb/MZvz4Va3Xg2VoxoFj0r49pfItNt+1a5fNd+/2/VaS+ge7bd7e7ftdpezH0NkJ3x7LUc7mktTe4+eabOSfdVqBuagRbk/1QN+u1/2cm2/xz7pS9/U4Pu7nIknaunWzzYuFrM0XLlti85lpXweSlIpC8/7T4+dhqzNFmy9O+7pMx+EFTJTx7XbdqO/fmUBd9qfCc1ouMNY2Au2+mfH9dy7Qv3dnw+26VPPr0clZP2/OBKqhXvL1ODLr+7YkbV/i12njg602H7phwuat8s9JkiZO9OvdseERm8eB+1za0WbzbIL3hqZmbd6Z8w8r57uMhod8GSWps+H79q/X7Q6e42Br7/DtKZfz/a5Q9GswKTw+hZ52KjAVNOPw+FRv+qvEVd9mozjw2pzy/TZOUMaurk6bl9r8GitX8m02tH4JP0mpHnhY+UB7yGV9Pc5MTAbLMDHhx/pczs+p2ZQvQ5z29RR6h5SkRmDNft+999g8HShDJsF6N4p8OVOBa4Q8PVZgAAAAAAAAOOjYSAIAAAAAAEAibCQBAAAAAAAgETaSAAAAAAAAkAgbSQAAAAAAAEiEjSQAAAAAAAAkwkYSAAAAAAAAEskkPXB43QM2T2fzNo+yUfAahShxcQ6oPumvkU6wbVZrBsoZyKO4YfMF6djm+Sjrry9pQXfB5t2lVpu3tuX8BWbLNm6JwxU5fs9PbT4zO27zUuSvsbzm61mSelM+jxo1m+fTTZuXJ3bZfHT793wBJLV0tNn8yFSgvXX6eph5aF2wDNXpWX+N+ZngOQ62VMbXU2tryeYz09PBaxRbfb/JpHyDyxaLNq/U68Ey1OXbZKmz3+Zr1vgy3Hv3b2x+xy9vt7kkHXfCMTZva223eSbn67kyN2fzbIJxfrY85csQmosavt+lQvOIpGqtavN67NtDNuPn3EZgjMxkwnPNwOACf0DKt8coCtVD+GFNTfhn1d7TEzzHoWAo5Z/XdNbXZUszMKFJaon8NbYV/TnWx359MlYNj5ONpn+mLS2dNu/pbLF5vs/Pmf2d/vySVNs1avPGuO+bs4H+r1bftzbG/vySFO+u2DyT8vU8UvL5zOhksAxTv/LrtGrGt6db2/wYtnLMr6H6a+F3gjjl54O8j1WZ8PWwfbYrWIapwPtNnAvP7QdbsdW/V4TG8sBS9WGB95/QS1o649tDOjjfKDhnBYYvpQJjZD3252/U/HuHJNVDa8G0r4dU2q+h6nVfhmrD34MkNVK+DC05Pwa2tfn31N0j24NlmJkJzEeB5pbN+npK50Lrk8AFJMWBebtaC6zpc/7dRUnafEDcDN+Hw28kAQAAAAAAIBE2kgAAAAAAAJAIG0kAAAAAAABIhI0kAAAAAAAAJMJGEgAAAAAAABJhIwkAAAAAAACJsJEEAAAAAACARDJJD0xPT9u8mKv6vJgNXqOtrc3mpUIpeA4nUiPBUf6YWm3e5pXyjM2zKX/+Z/SEH0k2arV5s1mzeaXq76E2N2fz6u7tNpekWqCq0zVfxmbD541K+Flma01/jTi2eVz3n2/xH1chQXObH95l80bKl6GtN7L5xGS4DBXfdZVOhc9xsMXyD6Olw48tY7t8n5Ck6pyvqGzJj09xoD2qEcglpTI5n6f8+NHb22fzwQV+nN/y0FabS9KaY460eS5XsXm1Euj7dZ/nikWbS+HxpVLzz7oR6DSzjQSdPzD+pDK+byvlO2YcaE5RoK1IUrHUYvNq3c8V9cA4X2rx55ekatXX5eyUn3MPFVsDc7/qfgzqTnCf3V0dNp9P+76xLVDGiUa4DMHul/dtItvlx9GVq5fbvCMwL0vS6HjZ5l1pP19UA8vZRo//GW11dtafQNLSrb6MUblu8wdXLrJ5as2KYBm6N++2+faH1tu8I+XrIT3v73G+GF7z92R9g6tl/DhZLnTZfN1O314l6YH6qM1LveE56WDLRH6+CeVRFJ5PUqEpLbCOS4fe4eLwYjWT9W0ym/WFTAduIp0OtPlMuJ52bvfvWHf84mc2v+2Wm3wZAvWsQB1IUjPQt9u7/VyUzftrhNZoktTe6seHWtOPs3EqsAYLNqfwZJPO+XoqFgJroEAhmgo/q8BSU81EeyOPjt9IAgAAAAAAQCJsJAEAAAAAACARNpIAAAAAAACQCBtJAAAAAAAASISNJAAAAAAAACTCRhIAAAAAAAASYSMJAAAAAAAAibCRBAAAAAAAgEQySQ88ZuUim7e3lWze29EVvEZHZ6c/oFGz8eTYsM1nZ8aDZajMTtp8vjbny1Au+ws0/Ofrtbr/vKRKs2nz+ZrPa1V//kYt9p+v+ecgSc1myucNf404cI8p//H/FtgnDVyjGUc2j/3H1VS4kJH8NRTIKxVfiLlGuIvP1/2zyqXng+c42KLI32c2l7N5ocWPX5I0Pe37dltbm81TkX+WjUB7kqR6pWLzTMp37lTk62FocMDm05N+fJSk4eFd/hoDR9q8kG/YvF73FVWvh8fQ8d0jNq81/RhXmfPPoRJ4TpK0dMkSmxeyvl8q7e+zrdW3x6npGX9+STPz/llEmdD4FRjng+Of1NXbZ/ORYf8sDxUT7VmbNyf92qCWLQSvMTrnx6hK1bfrRru/RtTtn4UkZXL+HGMp3+527dpu8/oGP4Y12jptLkk7dvk2M7Xbj3PtPd02X9DRb/NSftbmktS1eYs/oODnvFJXh82zWZ9L0qxf9qtrdtrmuUnfHm+tTtl8VWB9I0krA8P9ZMOPo/dtG7P5HbHvl5I0W/LjfX+v7/uHgkLGr5ezWX8PqSgwX0lKhdbEqcBaNOP7fiYbXu9ms37OiQL1kAqUUfJ5OrBWlaQdWzbb/Cv/9r9tngk8q65C3hcg/ChVyPtn0dXVbvONG+63eVp+7SFJpaK/j7k533ergXfZetUPLsVAHUgJ1qPpwLtu5J9lnAqPkXGg24Xen0L4jSQAAAAAAAAkwkYSAAAAAAAAEmEjCQAAAAAAAImwkQQAAAAAAIBE2EgCAAAAAABAImwkAQAAAAAAIBE2kgAAAAAAAJBIJumBkxt+bfNyPmvzsUIheI1svsvmccpfI0qnbN6ozgbL0GzW/DlqPm/KlyET5W2ejoo2l8K7f+la0+b1fMPm1Xl/j9mafw6SpFrdxw1fhooC16j7epakZrUcOMKXwdeiVG/4I6rNcPcqB8pQCTzLxoQ///YJ/ywlqbvoW1Q6ehrsN6ciGzcC/Tpf9P1SkqanZmw+V/XXyOT9NRrNOFgGNX17aWR8PahRtXEm4/vd0IIF/vySpianbT497fP2jjabF1t9Pj46bnNJ2rJti80zWV+PxRY/Tke5cJ9p62y3eb7gn0Ux58eXXK7V5oXJMZtLUnPMt8lU2tdTqB7r9QRtPvL32dndGz7HIaAz5eesnYEmsyMdmpGkZYFzrO3I2Xwk58eX4a6OYBmypR6bN+p+HKxv3mTzyRGfbyr4e5SkmTk/BmXLfiwPjfXlwHxTjMNr0a5RP98Ui/5ZbHhos83b28P9pqPLjyELTzrG5iMPrLf57pp/Dot2hdZwUku/L+MDlYrNb9y10+a7C4E5VdLiPv/uUp4Or8MOtlKg36QD71eZbPi9IBM9sfkik/FzQTodnndDbw6hGSkVGMdDeZSgjKF6KgRKWSz69+10KvgWGcilTOSf9/jOHTbfHhqno/A7XjEXWKd1+DFybMKvgRp132/T6fD6JRM4JBV4lqHmEgXefSQplaDNPRFPgzdEAAAAAAAAHArYSAIAAAAAAEAibCQBAAAAAAAgETaSAAAAAAAAkAgbSQAAAAAAAEiEjSQAAAAAAAAkwkYSAAAAAAAAEknFcRwf7EIAAAAAAADg0MdvJAEAAAAAACARNpIAAAAAAACQCBtJAAAAAAAASISNJAAAAAAAACTCRhIAAAAAAAASYSMJAAAAAAAAibCRBAAAAAAAgETYSAIAAAAAAEAibCQBAAAAAAAgkf8Pvkn27LBX00QAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 1200x300 with 4 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "data_list = [dataset[int(n)] for n in neighbors[0][1:]]\n",
+    "show_image_grid(data_list)"
+   ]
   }
  ],
  "metadata": {

--- a/docs/pre_executed/vector_db_demo.ipynb
+++ b/docs/pre_executed/vector_db_demo.ipynb
@@ -28,7 +28,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[2025-05-20 12:13:30,438 hyrax:INFO] Runtime Config read from: /home/drew/code/hyrax/src/hyrax/hyrax_default_config.toml\n"
+      "[2025-05-20 14:59:59,703 hyrax:INFO] Runtime Config read from: /home/drew/code/hyrax/src/hyrax/hyrax_default_config.toml\n"
      ]
     }
    ],
@@ -48,21 +48,21 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[2025-05-20 12:13:42,566 hyrax.models.model_registry:INFO] Using criterion: torch.nn.CrossEntropyLoss with default arguments.\n",
-      "2025-05-20 12:13:42,836 ignite.distributed.auto.auto_dataloader INFO: Use data loader kwargs for dataset '<hyrax.data_sets.hyr': \n",
-      "\t{'sampler': <hyrax.pytorch_ignite.SubsetSequentialSampler object at 0x7f513f564cb0>, 'batch_size': 512, 'shuffle': False, 'pin_memory': True}\n",
-      "2025-05-20 12:13:42,837 ignite.distributed.auto.auto_dataloader INFO: Use data loader kwargs for dataset '<hyrax.data_sets.hyr': \n",
-      "\t{'sampler': <hyrax.pytorch_ignite.SubsetSequentialSampler object at 0x7f513ea93740>, 'batch_size': 512, 'shuffle': False, 'pin_memory': True}\n",
+      "[2025-05-20 15:00:12,510 hyrax.models.model_registry:INFO] Using criterion: torch.nn.CrossEntropyLoss with default arguments.\n",
+      "2025-05-20 15:00:12,568 ignite.distributed.auto.auto_dataloader INFO: Use data loader kwargs for dataset '<hyrax.data_sets.hyr': \n",
+      "\t{'sampler': <hyrax.pytorch_ignite.SubsetSequentialSampler object at 0x7fccbe457350>, 'batch_size': 512, 'shuffle': False, 'pin_memory': True}\n",
+      "2025-05-20 15:00:12,569 ignite.distributed.auto.auto_dataloader INFO: Use data loader kwargs for dataset '<hyrax.data_sets.hyr': \n",
+      "\t{'sampler': <hyrax.pytorch_ignite.SubsetSequentialSampler object at 0x7fccbe1b8440>, 'batch_size': 512, 'shuffle': False, 'pin_memory': True}\n",
       "/home/drew/miniconda3/envs/hyrax/lib/python3.12/site-packages/ignite/handlers/tqdm_logger.py:127: TqdmExperimentalWarning: Using `tqdm.autonotebook.tqdm` in notebook mode. Use `tqdm.tqdm` instead to force console mode (e.g. in jupyter console)\n",
       "  from tqdm.autonotebook import tqdm\n",
-      "2025/05/20 12:13:43 INFO mlflow.system_metrics.system_metrics_monitor: Started monitoring system metrics.\n",
-      "[2025-05-20 12:13:43,260 hyrax.pytorch_ignite:INFO] Training model on device: cuda\n"
+      "2025/05/20 15:00:12 INFO mlflow.system_metrics.system_metrics_monitor: Started monitoring system metrics.\n",
+      "[2025-05-20 15:00:12,823 hyrax.pytorch_ignite:INFO] Training model on device: cuda\n"
      ]
     },
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "71a15190ee064854ba4ccd481895491e",
+       "model_id": "fd6cf99391d5409f916e2e53981ffafd",
        "version_major": 2,
        "version_minor": 0
       },
@@ -76,7 +76,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "9c6aaea9ef9a4ccd9a7d3658d1ba13b1",
+       "model_id": "626b046abf824ba584177ea938df3c2c",
        "version_major": 2,
        "version_minor": 0
       },
@@ -90,7 +90,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "dbb3c0d7e69448a6b5c3d1b373dd5157",
+       "model_id": "dc513e62417b492697c4132c3b6663c2",
        "version_major": 2,
        "version_minor": 0
       },
@@ -104,7 +104,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "db143c17030e446abf0908719750d799",
+       "model_id": "07a62bf384d14aa8bc8a2feb18679cae",
        "version_major": 2,
        "version_minor": 0
       },
@@ -118,7 +118,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "1dc77cbcabb04e8cafa6490829e3668e",
+       "model_id": "53cc4958796447539bfded2bc5878348",
        "version_major": 2,
        "version_minor": 0
       },
@@ -132,7 +132,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "9b2036dcc30c402887f202d83a162dfa",
+       "model_id": "954d5d3175614c58b8ce128aef1fcf66",
        "version_major": 2,
        "version_minor": 0
       },
@@ -146,7 +146,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "2c313299934b4673906f89322f3cb20c",
+       "model_id": "e9962399f4f34948b0e6dcec9edfb87d",
        "version_major": 2,
        "version_minor": 0
       },
@@ -160,7 +160,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "eeba8d3331c24b6a970666718e0ca792",
+       "model_id": "a9f54959d01e46629b711800b04da14d",
        "version_major": 2,
        "version_minor": 0
       },
@@ -174,7 +174,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "73f73eb95c434b65902c6ba1e4e68248",
+       "model_id": "477d1073fa2a43d7976f9f1f9e3a7bd6",
        "version_major": 2,
        "version_minor": 0
       },
@@ -188,7 +188,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "44543a54f7a849068f6700f0583eda4d",
+       "model_id": "f23f7b382a0e45e0ab352fc1475f6238",
        "version_major": 2,
        "version_minor": 0
       },
@@ -202,7 +202,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "b482c063e7cf4e2a8f01e3f0288e03f7",
+       "model_id": "aacf976f2ada44818cdfbdbed2e65d95",
        "version_major": 2,
        "version_minor": 0
       },
@@ -216,7 +216,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "6c8ce04941e544339b4ccb00b896ae4c",
+       "model_id": "254a435980c04c9a92396482f2e8ae56",
        "version_major": 2,
        "version_minor": 0
       },
@@ -230,7 +230,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "9fb6e3737f304356a212fd16b74bf2b9",
+       "model_id": "50ae71d9dd08476881b7abddeddacfea",
        "version_major": 2,
        "version_minor": 0
       },
@@ -244,7 +244,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "437c2398c327491991748cbf26fdde5d",
+       "model_id": "3a1b6067537941f7b1d34159257c55cf",
        "version_major": 2,
        "version_minor": 0
       },
@@ -258,7 +258,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "a27690d19f1440d3a53dc79999ff6d63",
+       "model_id": "3f58a3f5ca7a4a19baaee0012339843a",
        "version_major": 2,
        "version_minor": 0
       },
@@ -272,7 +272,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "721f7768fe814377827003930dbef042",
+       "model_id": "ad52b67aef834936af8ac3e049524c02",
        "version_major": 2,
        "version_minor": 0
       },
@@ -286,7 +286,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "bb08d6c8e4ee4616816f4f4d5d787df6",
+       "model_id": "cbd46f47f8fd4edf91e22887dc5b092d",
        "version_major": 2,
        "version_minor": 0
       },
@@ -300,7 +300,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "69b337b9b2f1472a90844e3551130e7e",
+       "model_id": "7605c7b2cf434cce875453928aea5ced",
        "version_major": 2,
        "version_minor": 0
       },
@@ -314,7 +314,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "55ec042bea16448dbc8451fd56cf8c2a",
+       "model_id": "3f092339ffeb46c3b76b68272f991880",
        "version_major": 2,
        "version_minor": 0
       },
@@ -328,7 +328,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f9a555742890498dbc1a85c920c836eb",
+       "model_id": "0c2f1f693dc3433ea8f26d1aed59e5b2",
        "version_major": 2,
        "version_minor": 0
       },
@@ -342,7 +342,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "d757d418e7c94fcda26c9caa32d2fb0c",
+       "model_id": "04200b31d6704bdcb6054df85a62e470",
        "version_major": 2,
        "version_minor": 0
       },
@@ -356,7 +356,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f0a8d7ed30384a07a0b455ff3d07d87f",
+       "model_id": "4413109d28af47fd956e969c597a293a",
        "version_major": 2,
        "version_minor": 0
       },
@@ -370,7 +370,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "88d4c25d06874fa8b347855de4cdbf0e",
+       "model_id": "44c2daa1f2134b078d1a43c5380e818c",
        "version_major": 2,
        "version_minor": 0
       },
@@ -384,7 +384,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "555908069121498f94872824874aae26",
+       "model_id": "a5a8015acc13426d8b717c902fc82663",
        "version_major": 2,
        "version_minor": 0
       },
@@ -398,357 +398,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "4d3b882d1e6e45ad8459e922c0020322",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "  2%|1         | 1/59 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c1fc9ff22e1844418e57655d107b3a9d",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "  2%|1         | 1/59 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "a55c62307a7a4f43aa1ef363840249f1",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "  2%|1         | 1/59 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "68bcde48e5d54b88a1899cb36056e5ae",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "  2%|1         | 1/59 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "ca4813296832442eae8f8efc653bc26f",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "  2%|1         | 1/59 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "58c2c0f963904f178006a571158b74fe",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "  2%|1         | 1/59 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "9f2a18f527c7431dab7167ba9dedc927",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "  2%|1         | 1/59 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "cd10c4b78e4846f4be45c3225f895449",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "  2%|1         | 1/59 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "67af84ca01e147859a4468d9784eb7e9",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "  2%|1         | 1/59 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "312b62aee50641278e7c5e3469aefefd",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "  2%|1         | 1/59 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "607a4c2ab2674c35ad2c3eeec8102846",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "  2%|1         | 1/59 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "24519018d3ea4f3393734484dc090caa",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "  2%|1         | 1/59 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f8e95819999241319b25033ecac96131",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "  2%|1         | 1/59 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c6b71e70e8944bce85753663151ebff7",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "  2%|1         | 1/59 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "08177120b61a4117839e1a106217a63a",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "  2%|1         | 1/59 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "67f021029a8c40b68d583aa28702f5bd",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "  2%|1         | 1/59 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "ad7db3f7eb784d97932c483c5b9f490b",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "  2%|1         | 1/59 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "3f3eb1840b0942caa9c21106bcb0458d",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "  2%|1         | 1/59 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "0437e056471143de9051cc2edcee4e5c",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "  2%|1         | 1/59 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "8906565ef917471e9e0a39735960b3cb",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "  2%|1         | 1/59 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "69d3e6f4fd0f4909ad7272bfc4407548",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "  2%|1         | 1/59 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "effdceb1d9f04b4dbc01490a14cf9d7a",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "  2%|1         | 1/59 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "8cd4fbc978a444d9874e356f8ef7faac",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "  2%|1         | 1/59 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "2ac3d31c774d480e84d8e5ebcfeb876f",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "  2%|1         | 1/59 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "7f5be65c224340c3bfd4fcfb4a2bebee",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "  2%|1         | 1/59 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f97a22b362134688bed2913760b60ad6",
+       "model_id": "96c3d9913fbb4a4899375ebe7d0c0a42",
        "version_major": 2,
        "version_minor": 0
       },
@@ -763,26 +413,26 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[2025-05-20 12:21:34,259 hyrax.pytorch_ignite:INFO] Total training time: 471.00[s]\n",
-      "[2025-05-20 12:21:34,260 hyrax.pytorch_ignite:INFO] Latest checkpoint saved as: /home/drew/code/hyrax/docs/pre_executed/results/20250520-121334-train-ETSe/checkpoint_epoch_50.pt\n",
-      "[2025-05-20 12:21:34,261 hyrax.pytorch_ignite:INFO] Best metric checkpoint saved as: /home/drew/code/hyrax/docs/pre_executed/results/20250520-121334-train-ETSe/checkpoint_50_loss=-88.8590.pt\n",
-      "2025/05/20 12:21:34 INFO mlflow.system_metrics.system_metrics_monitor: Stopping system metrics monitoring...\n",
-      "2025/05/20 12:21:34 INFO mlflow.system_metrics.system_metrics_monitor: Successfully terminated system metrics monitoring!\n",
-      "[2025-05-20 12:21:34,275 hyrax.train:INFO] Finished Training\n",
-      "[2025-05-20 12:21:34,563 hyrax.model_exporters:INFO] Exported model to ONNX format: /home/drew/code/hyrax/docs/pre_executed/results/20250520-121334-train-ETSe/example_model_opset_20.onnx\n",
-      "[2025-05-20 12:21:42,764 hyrax.models.model_registry:INFO] Using criterion: torch.nn.CrossEntropyLoss with default arguments.\n",
-      "[2025-05-20 12:21:42,765 hyrax.verbs.infer:INFO] data set has length 50000\n",
-      "2025-05-20 12:21:42,766 ignite.distributed.auto.auto_dataloader INFO: Use data loader kwargs for dataset '<hyrax.data_sets.hyr': \n",
+      "[2025-05-20 15:04:14,099 hyrax.pytorch_ignite:INFO] Total training time: 241.28[s]\n",
+      "[2025-05-20 15:04:14,100 hyrax.pytorch_ignite:INFO] Latest checkpoint saved as: /home/drew/code/hyrax/docs/pre_executed/results/20250520-150004-train-Is49/checkpoint_epoch_25.pt\n",
+      "[2025-05-20 15:04:14,100 hyrax.pytorch_ignite:INFO] Best metric checkpoint saved as: /home/drew/code/hyrax/docs/pre_executed/results/20250520-150004-train-Is49/checkpoint_25_loss=-91.8765.pt\n",
+      "2025/05/20 15:04:14 INFO mlflow.system_metrics.system_metrics_monitor: Stopping system metrics monitoring...\n",
+      "2025/05/20 15:04:14 INFO mlflow.system_metrics.system_metrics_monitor: Successfully terminated system metrics monitoring!\n",
+      "[2025-05-20 15:04:14,115 hyrax.train:INFO] Finished Training\n",
+      "[2025-05-20 15:04:14,391 hyrax.model_exporters:INFO] Exported model to ONNX format: /home/drew/code/hyrax/docs/pre_executed/results/20250520-150004-train-Is49/example_model_opset_20.onnx\n",
+      "[2025-05-20 15:04:22,593 hyrax.models.model_registry:INFO] Using criterion: torch.nn.CrossEntropyLoss with default arguments.\n",
+      "[2025-05-20 15:04:22,593 hyrax.verbs.infer:INFO] data set has length 50000\n",
+      "2025-05-20 15:04:22,595 ignite.distributed.auto.auto_dataloader INFO: Use data loader kwargs for dataset '<hyrax.data_sets.hyr': \n",
       "\t{'sampler': None, 'batch_size': 512, 'shuffle': False, 'pin_memory': True}\n",
-      "[2025-05-20 12:21:42,786 hyrax.verbs.infer:INFO] Saving inference results at: /home/drew/code/hyrax/docs/pre_executed/results/20250520-122134-infer-OpIj\n",
-      "[2025-05-20 12:21:42,998 hyrax.pytorch_ignite:INFO] Evaluating model on device: cuda\n",
-      "[2025-05-20 12:21:43,000 hyrax.pytorch_ignite:INFO] Total epochs: 1\n"
+      "[2025-05-20 15:04:22,618 hyrax.verbs.infer:INFO] Saving inference results at: /home/drew/code/hyrax/docs/pre_executed/results/20250520-150414-infer-v7i0\n",
+      "[2025-05-20 15:04:22,887 hyrax.pytorch_ignite:INFO] Evaluating model on device: cuda\n",
+      "[2025-05-20 15:04:22,889 hyrax.pytorch_ignite:INFO] Total epochs: 1\n"
      ]
     },
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "d2ac64c94ed742eb94bb6c504e3d283b",
+       "model_id": "25594032566344b29a35719f2107b185",
        "version_major": 2,
        "version_minor": 0
       },
@@ -797,17 +447,17 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[2025-05-20 12:21:54,057 hyrax.pytorch_ignite:INFO] Total evaluation time: 11.06[s]\n",
-      "[2025-05-20 12:21:54,131 hyrax.verbs.infer:INFO] Inference Complete.\n",
-      "[2025-05-20 12:21:54,383 hyrax.config_utils:WARNING] Cannot find default_config.toml for torch.\n",
-      "[2025-05-20 12:21:54,384 hyrax.config_utils:WARNING] Cannot find default_config.toml for torch.\n",
-      "[2025-05-20 12:21:57,851 hyrax.config_utils:WARNING] Cannot find default_config.toml for umap.\n"
+      "[2025-05-20 15:04:33,962 hyrax.pytorch_ignite:INFO] Total evaluation time: 11.07[s]\n",
+      "[2025-05-20 15:04:34,088 hyrax.verbs.infer:INFO] Inference Complete.\n",
+      "[2025-05-20 15:04:34,143 hyrax.config_utils:WARNING] Cannot find default_config.toml for torch.\n",
+      "[2025-05-20 15:04:34,144 hyrax.config_utils:WARNING] Cannot find default_config.toml for torch.\n",
+      "[2025-05-20 15:04:37,769 hyrax.config_utils:WARNING] Cannot find default_config.toml for umap.\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "<hyrax.data_sets.inference_dataset.InferenceDataSet at 0x7f513c509670>"
+       "<hyrax.data_sets.inference_dataset.InferenceDataSet at 0x7fcccb544140>"
       ]
      },
      "execution_count": 2,
@@ -816,7 +466,7 @@
     }
    ],
    "source": [
-    "h.config[\"train\"][\"epochs\"] = 50\n",
+    "h.config[\"train\"][\"epochs\"] = 25\n",
     "h.train()\n",
     "h.infer()"
    ]
@@ -850,11 +500,11 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[2025-05-20 12:22:06,574 hyrax.config_utils:WARNING] Cannot find default_config.toml for torch.\n",
-      "[2025-05-20 12:22:06,575 hyrax.config_utils:WARNING] Cannot find default_config.toml for torch.\n",
-      "[2025-05-20 12:22:06,576 hyrax.config_utils:WARNING] Cannot find default_config.toml for umap.\n",
-      "[2025-05-20 12:22:14,750 hyrax.verbs.save_to_database:INFO] Number of inference result batches to index: 98.\n",
-      "100%|██████████| 98/98 [00:11<00:00,  8.81it/s]\n"
+      "[2025-05-20 15:04:46,286 hyrax.config_utils:WARNING] Cannot find default_config.toml for torch.\n",
+      "[2025-05-20 15:04:46,287 hyrax.config_utils:WARNING] Cannot find default_config.toml for torch.\n",
+      "[2025-05-20 15:04:46,288 hyrax.config_utils:WARNING] Cannot find default_config.toml for umap.\n",
+      "[2025-05-20 15:04:54,737 hyrax.verbs.save_to_database:INFO] Number of inference result batches to index: 98.\n",
+      "100%|██████████| 98/98 [00:12<00:00,  8.06it/s]\n"
      ]
     }
    ],
@@ -898,7 +548,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 5,
    "id": "9f61c605",
    "metadata": {},
    "outputs": [
@@ -906,28 +556,28 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Id: 334, Vector: [-3.24798942  1.98119485  1.55406356 -0.62645012  3.10358572 -3.61395788\n",
-      " -2.6421597  -0.61600274 -1.84572554  0.82733208  0.89585263 -0.05108402\n",
-      "  0.78944761 -1.05129087 -1.2733053  -0.88881552 -1.13432014  1.90325677\n",
-      " -2.20901775 -1.75057256  1.72877145  0.63546658  0.50094151 -1.30287147\n",
-      "  0.20819613  1.92933834 -0.10779276  2.74875712 -1.38990939  0.99484938\n",
-      " -3.42075944  2.14404345 -3.83847785  5.28903532 -0.82823217  1.65449035\n",
-      " -0.04479901 -0.74067652 -1.49031544  3.332618   -0.42576975  0.82981318\n",
-      " -4.09225798 -1.0847671  -0.29326448 -2.29713273 -0.0332582  -0.17452615\n",
-      "  0.31300914 -0.21796861 -2.86028075  2.05296707 -0.82099587  0.09970309\n",
-      "  1.45865738 -2.23555088 -0.17257968  2.91896725 -1.94137704 -0.20339584\n",
-      " -2.15755415  1.02150869 -0.65463024  2.33411288]\n",
-      "Id: 19022, Vector: [-2.33262563  0.04649137  3.31983447  0.50175482  1.54706371 -2.84869981\n",
-      " -0.27642718 -0.30221859 -1.88166511  1.20784402  0.14550534 -0.6565448\n",
-      "  1.47187555 -0.3599979  -0.53884566 -0.10859923  0.27937558  1.82549071\n",
-      " -0.60621667 -2.43768144  1.11523855  0.64238709 -0.73361105 -1.06656742\n",
-      " -0.18609504 -0.37470672 -0.17663226  2.28438187 -1.90835869  2.27438331\n",
-      " -1.47124481  2.12520504 -3.83304524  3.5974195  -1.34257436  0.05598652\n",
-      "  0.73499131  0.14249866 -1.02003539  3.26024556  0.73118341  0.62491828\n",
-      " -3.26831579 -1.6454109  -0.65517992 -1.52420259  0.52505571  0.08770087\n",
-      "  0.39371127 -0.10824432 -3.22489595  3.86399245 -1.10378337 -0.7202642\n",
-      "  1.86410856 -1.28097677 -0.20346631  1.94834697 -1.50692284 -0.0404964\n",
-      " -1.73626339  0.24650386  0.85735005  2.3722589 ]\n"
+      "Id: 334, Vector: [ 0.21406414  4.38409519  0.49727368 -0.7893768  -2.87350202  0.11476225\n",
+      "  1.8274399  -0.09784815 -1.2193296  -0.77086699  1.34052861  1.65932298\n",
+      " -2.07148337 -2.34664512  2.28803968  0.86179125  0.86639947 -2.3657589\n",
+      " -1.03186095  1.59934366 -0.38279176 -0.92782491 -1.26808596  1.49409449\n",
+      " -2.36837769 -2.97786927 -1.81079423 -1.38344455 -1.11257839  1.33133769\n",
+      "  0.86067116 -2.94752669  0.02824669  1.38922858 -0.20957161 -0.15272772\n",
+      "  0.01273713 -0.05502158 -0.28467956 -0.06139451 -1.35991454 -0.46939212\n",
+      " -1.15573668 -3.90672135  1.14438629  4.01489925  0.87542021 -1.55964196\n",
+      " -0.27592164  1.35570014 -0.8417064   0.40743572 -0.45822605  0.36299995\n",
+      " -4.36139441 -0.92870319  1.6725179  -0.35636529  0.2801117  -1.55952835\n",
+      " -2.01857901  0.28982323 -2.65234852  2.10563254]\n",
+      "Id: 19022, Vector: [ 1.01997221  3.27541471  0.07880742  0.40190896 -2.069767    0.22248952\n",
+      "  0.63698471  0.91667783 -1.42546344 -0.78596801  1.58609724  0.09808031\n",
+      " -2.03873038 -1.99726641  1.99178457  0.30669096  1.55701888 -1.48524356\n",
+      " -0.9965176   0.82624108 -0.4912349  -0.61169094 -0.96432102  2.02064347\n",
+      " -1.09434426 -1.66586471 -0.8439483  -0.19334477 -0.20327687  1.13053894\n",
+      "  0.90265465 -1.52364016  0.38151348  0.74716371 -0.0561714  -0.10911166\n",
+      " -0.34963098 -0.36962882  0.66240174  0.64269614 -0.68175811 -1.75478578\n",
+      " -1.9701103  -3.3509984   2.56497812  4.5865469   0.91742259 -0.29954159\n",
+      " -0.07238744  1.71732593 -0.27246445 -0.20318703 -1.55732191  1.46810496\n",
+      " -2.89273024 -0.77957153  1.27631938 -0.19323938  0.73189634 -1.65531635\n",
+      " -1.78045166 -0.07765396 -3.09991169  1.34831798]\n"
      ]
     }
    ],
@@ -950,17 +600,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 6,
    "id": "b7d4b69e",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{'19022': ['19022', '29955', '30105', '43441', '431']}"
+       "{'19022': ['19022', '431', '30105', '4532', '27167']}"
       ]
      },
-     "execution_count": 25,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -983,17 +633,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 7,
    "id": "81088de0",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{0: ['19022', '29955', '30105', '43441', '431']}"
+       "{0: ['19022', '431', '30105', '4532', '27167']}"
       ]
      },
-     "execution_count": 26,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1013,7 +663,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 8,
    "id": "32946b37",
    "metadata": {},
    "outputs": [
@@ -1021,7 +671,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[2025-05-20 12:29:02,797 hyrax.prepare:INFO] Finished Prepare\n"
+      "[2025-05-20 15:05:15,134 hyrax.prepare:INFO] Finished Prepare\n"
      ]
     }
    ],
@@ -1039,7 +689,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 9,
    "id": "2d245a5f",
    "metadata": {},
    "outputs": [],
@@ -1109,7 +759,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 10,
    "id": "bd6f001f",
    "metadata": {},
    "outputs": [
@@ -1133,18 +783,18 @@
    "id": "64aa055b",
    "metadata": {},
    "source": [
-    "Next we'll display the 4 nearest neighbors. We'll exclude the absolute nearest neighbor, because in our case, that is the original search image. It seems that the model is doing something vaguely reasonable since 3 of 4 nearest neighbors appear to be similar types of dogs as the original search image. Though, clearly, there is room for model improvement."
+    "Next we'll display the 4 nearest neighbors. We'll exclude the absolute nearest neighbor, because in our case, that is the original search image. It seems that the model is doing something vaguely reasonable. By eye, some of the nearest neighbors appear similar to the original search image. Though, clearly, there is room for model improvement."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 11,
    "id": "8ac4f559",
    "metadata": {},
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAABJIAAAEwCAYAAADsAVtdAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjEsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvc2/+5QAAAAlwSFlzAAAPYQAAD2EBqD+naQAAaetJREFUeJzt/Xm4XWVh9/9/9l57PvN8TuaEJBjGiIyW2SoowoMV63D5dcSxT4t+q1CtYlunWqnSRyvUp06t+tOKUP1ZH3EWEAURREZDQkLm5MzTPmeP6/sHTR5DwudeTCbo+3VdXJfms/Za97rXPa37nGSn4jiOBQAAAAAAAASkD3YBAAAAAAAA8PTARhIAAAAAAAASYSMJAAAAAAAAibCRBAAAAAAAgETYSAIAAAAAAEAibCQBAAAAAAAgETaSAAAAAAAAkAgbSQAAAAAAAEiEjSQAAAAAAAAkwkbSk2jTpk1KpVK64oornrRz/vjHP1YqldKPf/zjJ+2cv0tnnnmmzjzzzINdDOAPHuPT/hifgEMD49P+XvOa12jZsmUHuxgAHgPGsv2x1vr99Qe/kfT5z39eqVRKt91228EuylPib/7mb5RKpfb7r1AoPOFzjoyMPIkl3d+WLVv0t3/7tzrxxBPV1dWl3t5enXnmmfr+979/wOO/973v6dRTT1WpVFJXV5cuuugibdq0ab/jZmZm9La3vU2LFi1SPp/XmjVrdNVVV+133J62caD/du7cuc+xy5YtO+Bxb37zm5+UusAfJsanx3/Op3p8mpub0+tf/3odddRR6ujoUGtrq4499lj90z/9k2q12n7HT0xM6I1vfKP6+vrU0tKis846S7fffvt+x331q1/VK1/5Sq1atUqpVMouviqVii677DItWLBAxWJRJ510kr73ve/td9yZZ555wHo+99xzn1Ad4A/b7/v4dO211+qlL32pVqxYoVKppMMPP1x/+Zd/qYmJicd9zoNVZxs2bFChUDjgtW+44QZdcMEFWrx4sQqFggYHB3Xuuefqpz/9qT3nxMSE+vv7lUqldM0119hjP/jBDyqVSumoo47aL/vud7+7dyyNoojNM/zO/b6PZU/ntdYj3XTTTXvL/8hrX3fddTrnnHO0YMEC5fN5LVq0SBdddJHuvvvu/c7zWNZaeHSZg10A/G5cddVVam1t3fv/oyg6iKVJ5hvf+IY+8pGP6MILL9SrX/1q1et1/du//Zue+9zn6rOf/axe+9rX7j32W9/6lv7H//gfOu644/T3f//3mpqa0j/90z/p1FNP1R133KG+vj5JUqPR0DnnnKPbbrtNf/Znf6ZVq1bp+uuv11vf+laNj4/r3e9+937l+Lu/+zstX758nz/r7Ozc77i1a9fqL//yL/f5s9WrVz8JNQH8fns6jk9zc3O655579IIXvEDLli1TOp3WzTffrLe//e265ZZb9OUvf3nvsc1mU+edd57uvPNOvfOd71Rvb68+9alP6cwzz9Qvf/lLrVq1au+xV111lX75y1/qhBNO0OjoqC3Da17zGl1zzTV629veplWrVunzn/+8XvCCF+hHP/qRTj311H2OXbRokT784Q/v82cLFix4EmoC+P30xje+UQsWLNArX/lKLVmyRHfddZc++clP6tvf/rZuv/12FYvFg13ExN7+9rcrk8moUqnsl61bt07pdFpvfvObNTg4qPHxcX3xi1/U6aefrv/6r/961A3nyy+/XOVyOXjtrVu36kMf+pBaWloOmH/5y1/WV7/6VR133HGMScBT6Om41vptzWZTf/7nf66WlhbNzs7ul991113q6urSJZdcot7eXu3cuVOf/exndeKJJ+pnP/uZjj322L3HPpa1Fh4dG0l/IC666CL19vYe7GI8JmeddZY2b968T7nf/OY3a+3atbr88sv32Ui67LLLtGLFCv30pz9VLpeTJJ1//vl7N5b+8R//UdLDP2G8+eab9ZnPfEave93rJElvectbdNFFF+n973+/Lr74YvX39+9Tjuc///k6/vjjg+VduHChXvnKVz7h+wb+0Dwdx6fu7m79/Oc/3+fP3vzmN6ujo0Of/OQn9bGPfUyDg4OSpGuuuUY333yzvva1r+miiy6SJP3pn/6pVq9erfe97337bDr9+7//uxYuXKh0On3An97vceutt+orX/mKPvrRj+od73iHJOlVr3qVjjrqKF166aW6+eab9zm+o6OD8Ql4DK655pr9fkr9rGc9S69+9av1pS99SRdffPHBKdhjdP311+v666/XpZdeqg984AP75RdffPF+9/LWt75VK1as0JVXXnnAjaS7775bV111lS6//HJdfvnl9vrveMc7dPLJJ6vRaBzwtxc+9KEP6X//7/+tbDarF77whQf87QEAT9zTca312z796U9ry5Ytuvjii/VP//RP++UHGosuvvhiLVq0SFdddZWuvvrqvX+edK0F7w/+r7YlUa1Wdfnll+tZz3qWOjo61NLSotNOO00/+tGPHvUzH//4x7V06VIVi0WdccYZB5wY77//fl100UXq7u5WoVDQ8ccfr29+85vB8pTLZd1///2P6dcJ4zjW1NSU4jhO/JnH6tOf/rQOO+wwFYtFnXjiibrxxhsPeNzmzZt1//33B8935JFH7jfg5fN5veAFL9DWrVs1PT0tSRobG9O9996rF73oRXs3kSTp2GOP1Zo1a/SVr3xl75/tKdPLXvayfc77spe9TPPz8/rGN75xwLJMT0+r0WgEy1ytVg+4Sw48VRifknmyx6dHs+evZfz2X3+55pprNDAwoD/5kz/Z+2d9fX360z/9U33jG9/Y57cEFi9erHQ6PDVfc801iqJIb3zjG/f+WaFQ0Otf/3r97Gc/05YtW/b7TL1e18zMzOO4K+DxeTqPTwf6qw4vetGLJEn33Xdf8POPxX/+53/qqKOOUqFQ0FFHHaXrrrvugMft2LFD999//wH/+uyB1Go1XXLJJbrkkkt02GGHJS5PqVRSX1/fo/41vksuuUQvetGLdNppp9nz3HDDDbrmmmt05ZVXPuoxCxYsUDabTVw24GB4Oo9lezyd11pjY2N6z3veo7/7u7874N8KeTT9/f0qlUr7jWVJ11rwqMEEpqam9K//+q8688wz9ZGPfER/8zd/o+HhYZ1zzjn61a9+td/x//Zv/6b/9b/+l/7sz/5M73rXu3T33Xfr7LPP1q5du/Yec8899+jkk0/Wfffdp7/6q7/SP/7jP6qlpUUXXnjhoy4g9rj11lu1Zs0affKTn0x8DytWrFBHR4fa2tr0yle+cp+yPBk+85nP6E1vepMGBwf1D//wD/qjP/ojXXDBBQd8mXnVq16lNWvWPO5r7dy5U6VSSaVSSZL2voQd6NfMS6WStm/fvvffNKpUKoqiaJ8Npz3HSdIvf/nL/c5x1llnqb29XaVSSRdccIEeeOCBA5brhz/8oUqlklpbW7Vs2bID7pYDTzbGp7CncnyqVqsaGRnRli1bdN111+mKK67Q0qVLtXLlyr3H3HHHHTruuOP2W7SceOKJKpfLWrdu3WO+pzvuuEOrV69We3v7fueUtN+zX7dunVpaWtTW1qbBwUG9973vTfwyCjxevw/j02/bs5Z4Mn+q/93vflcvfvGLlUql9OEPf1gXXnihXvva1x7w32t517vepTVr1mjbtm2Jzn3llVdqfHxc73nPe4LHTk1NaWRkRPfff7/e/e536+6779ZznvOc/Y772te+pptvvln/8A//YM/XaDT053/+57r44ot19NFHJyovcKj6fRjLns5rrfe+970aHBzUm970puCxExMTGh4e1l133aWLL75YU1NTBxzL8MTxV9sS6Orq0qZNm/bZfHjDG96gZzzjGfrEJz6hz3zmM/scv379ej3wwANauHChJOncc8/VSSedpI985CP62Mc+Junhn+YsWbJEv/jFL5TP5yU9/KvEp556qi677LK9P/V6Msr+P//n/9Qpp5yifD6vG2+8Uf/8z/+sW2+9Vbfddtt+LyGPR61W07vf/W6tXbtWP/rRj/bW0xFHHKE3vvGNWrx48RO+xh7r16/Xtddeq5e85CV7/27vwMCAOjs79/uHIUdHR3XvvfdKkrZt26bBwUEdfvjhajQa+vnPf77PvyGyZ8f8txdnpVJJr3nNa/ZuJP3yl7/Uxz72MT372c/W7bffvs99HXPMMTr11FN1+OGHa3R0VJ///Of1tre9Tdu3b9dHPvKRJ+3+gUdifPKe6vHp2muv1ctf/vK9///444/XZz/7WWUy/3d63bFjh04//fT9Pjs0NCRJ2r59+2N+0dqxY8fezz/aOfc47LDDdNZZZ+noo4/W7OysrrnmGn3gAx/QunXr9NWvfvUxXRd4LJ7O49OBfOQjH1EURXv/iuqT4bLLLtPAwIBuuukmdXR0SJLOOOMMPe95z9PSpUsf93l37typ97///briiisSjaV/+qd/quuvv16SlMvl9KY3vUnvfe979zlmbm5O73jHO/T2t79dy5YtO+AXmuxx9dVX66GHHnrUL0gBnk6ezmPZ032t9etf/1r/8i//om9/+9uJ/l2nk08+Wb/5zW8kSa2trXrPe96j17/+9Y/7+jDiP3Cf+9znYknxL37xi0THNxqNeHR0NB4eHo7PO++8eO3atXuzjRs3xpLil7/85ft97qSTTooPP/zwOI7jeHR0NE6lUvH73//+eHh4eJ///vZv/zaWFG/dujWO4zj+0Y9+FEuKf/SjHz3xm/1vX/rSl2JJ8Yc//OHH9fn3ve99saR4eHg4juM4vvnmm2NJ8dVXX73PcdVqNe7o6IjPOOOMJ1rkOI7jeHZ2Nl67dm3c1dUVb9u2bZ/ssssuiyXFf/VXfxWvW7cuvu222+Kzzz47zmazsaT4xhtvjOM4jnfs2BF3dHTEq1atir/73e/GGzdujP/lX/4lbm9vjyXFz3nOc2wZbrzxxjiVSsVvetOb7HHNZjM+55xz4kwmE2/ZsuWJ3Tj+YDE+PXa/6/Fp586d8fe+9734a1/7WvzmN785PuWUU+Kf/exn+xyTTqfjt7zlLft99gc/+EEsKb7uuusOeO4jjzzyUcu3YsWK+PnPf/5+f75hw4ZYUvzxj3/clvsNb3hDLGm/sgJJ/aGNT3vGpksvvfRxn+ORdbZ9+/a9a5dHOuKII+KlS5c+7mu96lWvio899ti40Wgc8NqPdMcdd8Tf/e5348985jPx6aefHr/2ta+Np6en9znm8ssvj4eGhvb++Z46/trXvrbPcSMjI3F3d3d8xRVX7P2zM844Iz7yyCNtmc8777wndM/A4/GHNpbF8dNrrXXGGWfEL3zhCx/12o908803x9/5znfiT33qU/EJJ5wQ/+Vf/mVcrVYf9fxurQWPv9qW0Be+8AUdc8wxKhQK6unpUV9fn/7rv/5Lk5OT+x3729/As8fq1av3/uRm/fr1iuNY733ve9XX17fPf+973/skSbt3737K7uUVr3iFBgcHn7SfEj300EOS9r/vbDarFStWPCnXaDQaetnLXqZ7771X11xzzX7f7PF3f/d3ev3rX69/+Id/0OrVq3X88ccrk8ns3YHe8y0Fg4OD+uY3v6lKpaLnPe95Wr58ud75znfqE5/4xD7HPZpTTz1VJ510UrDuUqmU3v72t6ter+vHP/7x47xrIBnGp0f3VI9PAwMD+uM//mNddNFFuuqqq/TCF75Qz33uc/f+FRjp4b92e6BvS5qfn9+bP1ZP9Jx7vmGS3xbAU+33YXy68cYb9frXv17nnHOOPvjBDz5p53208UmSDj/88Md93p///Of693//d3384x9P/O+ArF27Vs997nP1ute9Tt/73vd066236jWvec3efNOmTfroRz+qD37wg8G10nve8x51d3frz//8zx/3PQCHmt+HsWyPp8ta66tf/apuvvnmvV+alMQpp5yic845R295y1t0/fXX64tf/KLe9a53Pe4y4NHxV9sS+OIXv6jXvOY1uvDCC/XOd75T/f39iqJIH/7wh7Vhw4bHfL5msynp4W+yOOeccw54zG//+xpPhcWLF2tsbOwpvcaT6Q1veIO+9a1v6Utf+pLOPvvs/fJcLqd//dd/1Qc/+EGtW7dOAwMDWr16tV7xilconU7vU5+nn366HnzwQd11112anZ3Vscceu/evgaxevTpYlsWLF+/9lcnQcZKeVvWMpx/Gp0PLRRddpL/+67/WN77xjb1/l39oaEg7duzY79g9f/Z4vvJ6aGjogP9OStJzMj7hd+H3YXy68847dcEFF+ioo47SNddcs89fWz1UXXrppTrttNO0fPnyvS+ue/5R3h07dmjz5s1asmTJo34+l8vpggsu0N///d9rbm5OxWJRl19+uRYuXKgzzzxz7zn3bJgPDw9r06ZNWrJkiTZs2KBPf/rTuvLKK/f5K7bz8/Oq1WratGmT2tvb1d3d/dTcPPAU+H0Yyx7p6bDWeuc736mXvOQlyuVye8edPf9w9pYtW1StVu16p6urS2effba+9KUv6YorrvgdlPgPy6E/Gx4CrrnmGq1YsULXXnutUqnU3j/fs2P8SAf6x5jXrVu399t89uzMZrNZ/fEf//GTX+CAOI61adMmPfOZz3xSzrfn7/A/8MAD+2zy1Go1bdy4Uccee+wTOv873/lOfe5zn9OVV165z79FciADAwMaGBiQ9PBvMf34xz/WSSedtN9Pz6Io0tq1a/f+/z078kmex4MPPqi+vr5Ex0lKdCzweDE+eU/1+PRIc3NzkrTPTyjXrl2rG2+8Uc1mc5/fDrjllltUKpUSbWA/0p5/h2Bqamqff9/glltu2Zs7jE/4XXi6j08bNmzQueeeq/7+fn37298O/ibOY/Xb49MjJfmB1aPZvHmzHnroIS1fvny/7IILLlBHR8ejfiPbHnNzc4rjWNPT0yoWi9q8ebPWr19/wN8ueOtb3ypJGh8f17Zt29RsNvUXf/EX+ou/+Iv9jl2+fLkuueQS+01uwKHm6T6WPdLTZa21ZcsWffnLX9aXv/zl/bLjjjtOxx577AH/sfPfNjc3d8DfGsMTx19tS2DPP+wV/9bXJd5yyy362c9+dsDj//M//3OfnxTfeuutuuWWW/T85z9f0sNfRXjmmWfqX/7lXw74U+rh4WFbnsfylY8HOtdVV12l4eFhnXvuucHPJ3H88cerr69PV199tarV6t4///znP3/Ahcpj+crHj370o7riiiv07ne/W5dccsljKtcVV1yhHTt27P0rHI9meHhYH/nIR3TMMcfsM5gfqO6+/e1v65e//OU+dTc2NqZGo7HPcbVaTX//93+vXC6ns8466zGVG3gsGJ+8p2p8GhkZOeBX6P7rv/7r3uvucdFFF2nXrl269tpr9/n81772NZ1//vl7/5HNx+Kiiy5So9HQpz/96b1/VqlU9LnPfU4nnXTS3t84mpqa2u+vwMVxrA984AOS9Kg/CQWeDE/n8Wnnzp163vOep3Q6reuvv/4p2XQdGhrS2rVr9YUvfGGfF53vfe97e78s5Lft2LFD999/f/AbFz/96U/ruuuu2+e/PX/N7IorrtCXvvSlvcce6K/PTExM6Otf/7oWL16s/v5+SdIHPvCB/c75/ve/X9LDvwF13XXXqaWlRUcdddR+x1133XU68sgjtWTJEl133XX8w7d42nk6j2VP57XWgcaSl770pZIe/ma8j3/843uPPdBYtmnTJv3gBz/YZ02GJw+/kfTfPvvZz+o73/nOfn9+ySWX6IUvfKGuvfZavehFL9J5552njRs36uqrr9YRRxyhmZmZ/T6zcuVKnXrqqXrLW96iSqWiK6+8Uj09Pbr00kv3HvPP//zPOvXUU3X00UfrDW94g1asWKFdu3bpZz/7mbZu3ao777zzUct666236qyzztL73vc+/c3f/I29r6VLl+qlL32pjj76aBUKBd100036yle+orVr1+73FYpnnnmmfvKTnxzw5cjJZrP6wAc+oDe96U06++yz9dKXvlQbN27U5z73uQP+5OpVr3pVoutcd911uvTSS7Vq1SqtWbNGX/ziF/fJn/vc5+797aMvfvGL+vrXv67TTz9dra2t+v73v6//+I//0MUXX6wXv/jF+3zujDPO0CmnnKKVK1dq586d+vSnP62ZmRl961vf2ue3BZ797Gfrmc98po4//nh1dHTo9ttv12c/+1ktXrxY7373u/ce981vflMf+MAHdNFFF2n58uUaGxvTl7/8Zd1999360Ic+pMHBwcdUn8AjMT4deuPTF7/4RV199dW68MILtWLFCk1PT+v666/X9773PZ1//vn7/ETuoosu0sknn6zXvva1uvfee9Xb26tPfepTajQa+tu//dt9znvDDTfohhtukPTw4m92dnbvps/pp5++99vfTjrpJL3kJS/Ru971Lu3evVsrV67UF77wBW3atGmfb4+5/fbb9fKXv1wvf/nLtXLlSs3Nzem6667TT3/6U73xjW/Ucccd95jqE3ik39fx6dxzz9WDDz6oSy+9VDfddJNuuummvdnAwICe+9zn7v3/r3nNa/SFL3xBGzdu3PsbB0l9+MMf1nnnnadTTz1Vr3vd6zQ2NqZPfOITOvLII/ero3e9612JrvO85z1vvz/b8zJ3xhln7PNS9fznP1+LFi3SSSedpP7+fm3evFmf+9zntH379n2+1fG3v+l2j87OTknSCSecoAsvvFCS1Nvbu/d//7Y9v4H0yOzXv/61vvnNb0p6+N+NmZyc3DvmHXvssTr//PMf9T6BJ9Pv61j2dF5rHWgs2fMbSM9//vPV29u798+PPvpoPec5z9HatWvV1dWlBx54QJ/5zGf2/nD/tyVdayHgd/tvex969vxL/Y/235YtW+Jmsxl/6EMfipcuXRrn8/n4mc98Zvytb30rfvWrX73Pt0vs+Zf6P/rRj8b/+I//GC9evDjO5/PxaaedFt955537XXvDhg3xq171qnhwcDDOZrPxwoUL4xe+8IXxNddcs/eYA/1L/Xv+7H3ve1/w/i6++OL4iCOOiNva2uJsNhuvXLkyvuyyy+Kpqan9jn3Ws54VDw4OBs/5aP9a/qc+9al4+fLlcT6fj48//vj4hhtuiM8444z9/iX8M844I07S9PZc59H+++06ueWWW+LTTz897urqiguFQnzsscfGV199ddxsNvc779vf/vZ4xYoVcT6fj/v6+uJXvOIV8YYNG/Y77q//+q/jtWvXxh0dHXE2m42XLFkSv+Utb4l37ty5z3G33XZbfP7558cLFy6Mc7lc3NraGp966qnxf/zHfwTvEXAYn/6vQ218+sUvfhG/5CUviZcsWRLn8/m4paUlPu644+KPfexjca1W2+/4sbGx+PWvf33c09MTl0ql+IwzzjjgN8S4ce+RdTo3Nxe/4x3viAcHB+N8Ph+fcMIJ8Xe+8519jnnwwQfjl7zkJfGyZcviQqEQl0ql+FnPetajjo9AUr/v45O7t0eOGy9+8YvjYrEYj4+PJ6qzR/b9r3/96/GaNWvifD4fH3HEEfG11167Xx3FcRy/+tWvjiXFGzduDJY/6bU/+clPxqeeemrc29sbZzKZuK+vLz7//PPjG264IXjOR/vWtgN5tG9tc+3o1a9+deL7Ax6v3/ex7Om81nos137f+94XH3/88XFXV1ecyWTiBQsWxC972cviX//61496jiRrLTy6VBw/xi1H/F6anp5Wd3e3rrzySv3Zn/3ZwS4OAOzF+ATgUDYwMKBXvepV+uhHP3qwiwIAjwtrLTxW/BtJkPTwr/gtXLhQb3jDGw52UQBgH4xPAA5V99xzj+bm5nTZZZcd7KIAwOPGWguPFb+RBAAAAAAAgET4jSQAAAAAAAAkwkYSAAAAAAAAEmEjCQAAAAAAAImwkQQAAAAAAIBE2EgCAAAAAABAIpmkB77pTafZfKbWsHkj1RW8Rq41Z/PWQtbmY1s3+wvMV4NlGBjotfnW3bttfuSqIZt3trXYvBaoR0lqNPwx9XrTnyD2+4eZbMHm4zMVf35J9/1mk817e3psXujutnkpE/6ywWZl2uazs/4+tm7davPutjabL+nwuSTtvufnNi+l8jZfsPZEm/cvXRIsw9YH/X3e8+Mbbf4fD4Tbw1Pt6MMGbJ5K+TYfpVPBa6Sf4L57KniJQL+VVK/7vh+6Rmve9+2gBFUQBeo6FThJHAfmkqbPoyiyuSRlosDUF/gy02qgDKHPJxFqko2GP6AZeFZxM1zGRuzbZPBLXwP3sH10MliGZq1u82LGP+8Nu2eC1/hdOGWNH4tD81EceqCS4rR/Hk35dptJ+brMhh6opEyg/2Wzfh2Xzfq+2dbq59WOrvBas9Te6vNSyeatgTIUi36cTed8HUhS3PTtvjY/b/Py1LjN52bGgmWozPm+U67WbB4FxtlUya/56+nwejg16dd52S7/LONuvyavjswGy9AaKGcs3y+v/vIvg9d4qh3+rNAayrfZWi28fqnM+DYdB17R0pEvQz7vn6UkVcplmzcC/SodeP9qLfrrr1ji330kqaPgT7Jz57DNGw3f3lKBcT7XEl5DzczM2bxS8+fYNevruVZPsib37SG0PskE1g6hEiT50vtUYFEeysPnD68L0oFrpCN/jge3bfGfD5YAAAAAAAAAEBtJAAAAAAAASIiNJAAAAAAAACTCRhIAAAAAAAASYSMJAAAAAAAAibCRBAAAAAAAgEQC34H8f434b0xUR8l/5erSgfBXoW/13yaomXn/9bgrl/TavFEJf1VflPVfR5ob8183uG2b/0rVlsP8V5E2Al8tKUnNpv8qv2K+2+ZR5L9aMpR3dvp7kKSutiGbB7+xMPAVwtX5iWAZopJ/Vl1t/qtrc1n/daaNOf/5Qku7zSUp0xL4KtDJURuPPrTR5u39/itdJWn3dv9VorW5wHeyHgKiwNdXhr6GOErwDZypwPAR+KZ0pdKBMga+klWSMhnfput13yabTV/IfD5v83SoEiQFv1U+UE+hr2TNBx5WJufHcElqaemweTMwDFfrvk9UZsNfOR/6KvZ0oE02Gr49heaSwMclSVHwZ02+kNMVP2c36uGvjG4JtIds5ol9fe7vSuhrfqPApNhI8DXBceCQdBx4noGvM04FxlFJygbm7mzWFzKX9Z8vFANfAV7w+cNl8MeE8tAYFQXG6UxgnfnfZ/FxYKxPZwLzTTo834TqoZAODPaBZxEN+feCUmv4WVZ3+TI0G36sXrTEr5dbVg8GyzAeWENtXL8zeI6DbS7QnjKB8aea4N0ltPAPtbfQV53Xa/4eJKlSDfSbwH3mAvP26gX+PXTtqnB76u/ybXJuqX9vqATelXfs9O21LUG/m5n2edTh7/On6/1Xym/YPhUsQzEwjqaj0H0E1h+B4S0dmnB/B+LQi4ekZmAd90R/o4jfSAIAAAAAAEAibCQBAAAAAAAgETaSAAAAAAAAkAgbSQAAAAAAAEiEjSQAAAAAAAAkwkYSAAAAAAAAEmEjCQAAAAAAAIlkkh5Yq/tDc1EukIevsaAjFTiiZNPefNPm0+VqsAz1hj/HYYt7bV6pVmxeq/m82WzYXJIy2W6bd/ettHmp1G7zeq1u8yS7j4V8wR/gq1lxM7Z5JevbgiTNV6ZtPlkZtnlHW4f/fG3S5oVSoA4ktQ+ssPnohL9Gc9Lfw7YNG4NlGN024q+RSTxMHDSpVGjs8O0p9GlJitJ+EEtlnti+fJJPRyl/H5GyNq/X/PgSBfp+vuDH+YfLEJDynT/K+jN09fXY/PDDnxEqgVY+Y43NJ2dmbL5zxxab3/erO4NlmJv245PSgXpq+BZTq/tWHSk81zSaT6xNV2f8PWTicM+LAn278TT5eVgmMI5GWV9XqUa4rmry/TcOzLuhkTBKJ3he2cB9Rv4c2Zwfw3K5wFoz6z8vSamUbzOh+SQbuEYh78uYSlDGONA965EfJ0PtLR34vCRl0v4ccdbPR+XAMm06M2fzZuxzSUrnfZsv1H2jLwXK2DNUDJYhW1pg83vWbQue42BLB/qEokCfCbw7SeGxIVUNjPVNf43Q+kaSCkX/wOtzZf/5wBqoNe/79qKFgzaXpKOfdYzNd6y/1+a1sr+HXNH3W01P+FxSseLrutiV92UIjIGNQBElqR77g1oCc0Wh6N/RZib9Gi0VeK/4XUiyZxB64Y7jp/7dBQAAAAAAAGAjCQAAAAAAAMmwkQQAAAAAAIBE2EgCAAAAAABAImwkAQAAAAAAIBE2kgAAAAAAAJAIG0kAAAAAAABIhI0kAAAAAAAAJJJJemAhH9m8karZfKrSDF6jLe/zZmDfa2yyYfNazZdRkmqVii9DHNs8nUrZfHJm1n9evp4laWCg2+YtpS6bd3V1+gukfD2PT4z5z0sqpv05mk3/LObnfT11dPt7lKRo2jfv4eEdNi83qjZv1P31W0slf4Ck/LJFNt+15SGb1yu7bT62eX2wDOXpaZuXunuC5zjYsjnfb0L9KtzrpCjyfTsdGJ9CI2Dc9OOXJPkSSFHgiGw+688fuEAUJakpf6f1QD0V29tsfvQzj7P5iaecaHNJ6h/ot/nYxITN+/r9+NOWoO9vf2izzbdu3mjz0FyVzvhn3YzDzzLUJKt1PwhWaj7PhBqcpHRgLpmrh9cWh4LA0kGpQF2EcklKxYGfDaZ9XaUC40c6sDaQwuNkKM9m/TVyOT+vZwO5JGWy/pgoempzpRP0Pfm+E7pGJjBWR1k/PkiS6n4NlMr5jzd6fRk3z/r1y/yov74kZQPjYEG+4/WMDtu8I3APktTW2Wfz9o6W4DkOukC/qwcmgzgKjw2Nmn8WqcA1QvNRLhd4iZTUDEwX9cB7Yq0ZGMhzBRsfd8pp/vOSlPGFbCn6jtfaXrR5OuvXJ7sf2mBzSWrJ+eed7+y0+fy8X9+kovCzDLXJ08483ebnnHOOzT9x5ZU23/bQFptLUjYwzob2FBRqbwnmkigwbwfnqwB+IwkAAAAAAACJsJEEAAAAAACARNhIAgAAAAAAQCJsJAEAAAAAACARNpIAAAAAAACQCBtJAAAAAAAASISNJAAAAAAAACSSSXrg7OSMzRvz8zbPxoXgNWpZv69VrlVsXqnU/Pmr/vOSVJ6r2ryhrM0L2Zz/fMPX0/IlK20uSZ1dQzZPN3w9FCJ/D9mWNptXqg2bS5KavgzT0yM2zxV8e2lt82V8uAhNm7cUOmxenvJtYWLW5+MzZZtL0qJ+X4b+pStsvvlXvh6707PBMnS3+nqKOluC5zjY8rnAUOZvUan4SShEyl8k3QhcJJ0KXiIb6Ltx5D/faPi+mwr8aGE+MLZIUjbjx8Cuvk6brzpitc1XPmOVzfsHemwuSdlAe+nv77V5a7Fk894u/3lJ2jq0wObprH+Ymzes959v1m3eTDD9x03fZqfn/HxWr/oxspQLNFhJCrRZ1QOd+xARx76ccRwahMLjQypwSCrQwTOBny1msuE2E6X9Mw0MYcqG2kRonA1XU7CM2Yy/z2zW30Q68vWYzoR/htts+DI0AtfIRKF7yAfLENX9eN/I+jV1rc1fY3bUr5Emt0/ZXJKOPuJwmxcCzWnnrlGbL10Wnk9KRT/n9XW1B89xsFWrfr5oBIbZbDrQsRUewdKBI+JAHvq8JJXL/l222Qysh3O+TfcMLrZ5byCXpLtu/anNG4FuMbTIrz+6WoZtvjMwxkpSobPL5sMzfuwYm/BjR77g11iSVJ+fs/niJUtsfv7559v85p/657Bl4yabS5JiPw4HZ4LAhJYKTfoKz1dRlGAdZvAbSQAAAAAAAEiEjSQAAAAAAAAkwkYSAAAAAAAAEmEjCQAAAAAAAImwkQQAAAAAAIBE2EgCAAAAAABAImwkAQAAAAAAIJFM0gMr09M2j+YDp2qLgtcYm2nafGrWlyET+X2xtrbuYBnKtXmbN+Tvo7+/1+aVsr+HRQueYXNJ6u0etHl6fs7mUTO2ea1Rt3lrW8nmktRs1mxerflztLT6vLe7L1iGvu6qzTORf5b5na02L9f859dt2WVzSSrkUzZffNgim2/e+JDNxya2Bssw1Jm3ebMxFjzHwdZs+Dady+Rs7p9CQnHDxunAtn0UaI+SlM34cbZS8X13anzG5vlSweaDy317lKShgQGbL1u+zOaHr1lj84EF/vzdveGxoVRqs3mUydq8PB2ox8JwsAzVesXmRx13gs2zhRabb7z/Hps36358lKRUxrfJ+Zpv8wr0y8DpJUll36T1JPXep1yz6cuZSvk8Tvm6lKR0qCpCeezXYEpQhpB03Rcik/ZjUFen7/+pwFgvSdOzfo1UyPlxNhf5eggsRRUFH5TUDLSHZj7QN+f957PZ8M+R0zVfD9XIr/Pqgf7d2e7H4ZltE/4Ekk4+ea3ND1vi54Of/+SHNp+b9vcoSbmsH8vbMk+Dn9k3/MMKDh21wNghKYr9WdJp33cblcC7S8W/v0lSquknlCjt5/5m4B1w4ya/5h4dCa+np8f8MT/4/h02P/WPnmnz/u5Zm89VfC5Jue7l/oDWHhtXm/4ecgn6TDrn28t999xr840PbrT5kiWLbZ4r+ncnSYqbvl+kA31CCrT50JwtKRXovanQhBXwNBjdAAAAAAAAcChgIwkAAAAAAACJsJEEAAAAAACARNhIAgAAAAAAQCJsJAEAAAAAACARNpIAAAAAAACQCBtJAAAAAAAASCST9MAo7w9tacnZfHq+ErxGeaZh84H+JTbvHeizeXt7d7AMpVKbzcfGdtk8atZtnh1YZPOhgcU2l6QosP2XT0U2rwaeRarkn2UqavoCSKoErrFo6VKbt7d22XyobzBYBqVjG2fzRZt39w/ZPFLB5vet/7XNJWn9Q749HXO4by8rj1xt8xu+vyNYhnTkn9VAW/h5H2y5jB+fcrnQUJcKXqPZDNRDIM4GLpEJllGqVvwYuWvXbptPz/lnfcIxR9j87Oc9x+aSVCuXbb5kiR/HV6053Oat7X6Mzub8+CVJuWLJX6PFXyOXy9u8UgvPd4URP34sX7nS5m2dfj4rtbbafOO9d9lcksqzszafm6/ZPBv5Rh/Jj9GSFJjO1PBFOIT4ukinQ3n4Co3AOeLAzw5ToTFOfvyRpHTsH1gh49tlMdti86FBP37UmuGKKlb8GNWcG/PXmJ/x5w+MUekkD7Pm+0Y65Z9FqN8kKUM2k7V5LD/OZWq+PfUHxrCRtvD6pdGYsPnCxX6tecwJy22++Tf+/JI0ut3Pu7lAPRwSAkVMh8byQC5J2bRf45TLvj3Vq4FrNMPjUxR4gUoF8vLcnM3Xb9ps8y07/JpfknaMT9p824Qfn6pZfw+tgXebjkE/70vSs854vs1TXYfZ/Fs//Y3N4zjcZ1avXmHzRYv8+9NPb/6pzXcPD9u8pc3PZZI0OzVt80zaD9SNQD2EPi9Jqcj3u1Qq3HcdfiMJAAAAAAAAibCRBAAAAAAAgETYSAIAAAAAAEAibCQBAAAAAAAgETaSAAAAAAAAkAgbSQAAAAAAAEiEjSQAAAAAAAAkwkYSAAAAAAAAEskkPTCup2xeas36C2V9Lkndnb02X7F8jc1rtXlfBjWCZYhUtXkpHfvPRzn/+fY+mxcKRZtLUjHjn0VtctrmE+Wyzbs7SzavVP3nJWlocIHNn/GMI2weNf095rPhPdBmOrL5gkVLbD4wMGjzyZERmw/v3mxzSdo2vMWfY9J/vlbJ+3wuXE/3zYWOaAbPcbBlMr7fyTcnpRJsqRcLvq4jPzSoUfdjSxQFCimpPOP73uzElM37Fvo2fdIpJ9q8tdWPDZIUak751labl1rbbN7d7eeJJO01Sgfmo0B7SEV+bGlpaQ+WoVjy9RCl/X3EXf5Z9A/6uWZqNFSP0sgDvj1VKhWbFzK+npQN5JKyKd+xag3frw4VcezvIxUYhNLp8CAVBVd0vgyZwBiWTTBQtrb4dvmMVats3tnbb/P169f5AmQLPpfU2Tfg845Om8+UfbvPzPs2Wcz7ueRhfj5oBJazKfm+lQo3FqUDDSKXabH5aGA+UsGfv6/Xj2GStH3XDpvP1f17Q0tvh7/ApsAiTNKuX220eW+mM3iOg63RDDSowHo6MF1Jko48+kib/+rWe2xervn1TyEbbtPNRt3moXG2EeiXnT1+bIly4TXUgqEem7/+1c+3+WHL/PvXXNm36ULvUptL0sDKY2ye715m8z8+9zybx00/xkrSkiVDNg+N4/VGoNEG1uRnVs72n5f04x/+0Oa1OX+fucBaNQ7sB0gKvuDE8RN7x+M3kgAAAAAAAJAIG0kAAAAAAABIhI0kAAAAAAAAJMJGEgAAAAAAABJhIwkAAAAAAACJsJEEAAAAAACARNhIAgAAAAAAQCKZpAe2lCKbT09VbF5rTAev0dvfavPyvL9GdX7G5vNzY8EypBo1m2cjXw8dHb3+8xn/+VptzuaSVGn4xzYxOWHzloEBmzfjYBES8CcZG9nlPx54DoVcMViCQmuHv0TgGrmCv8bK1attPjy8xeaSNDM/ZfMdY7P+Gg/utHmzXg2WYWVvwecDbcFzHGzprO9XgW6rTIKRMKWmz1N+Xz4XuEit3giWYWraj6ON2Pe7bC5n82rVj7HlmbLNJWn5St8vVqw6zOYdnZ02bzZ9m85n/D1K4fucD3w+nUrZvFjyferhY0o2r837Zz2yc6vPd223eU+/n6skafaedf6Aet3GrYF7LMfhNt9I+2NKhUDnPkTEgb6ZTvvxI5vNBq+RDlRFoNkqK39ALh0eKDORv4/R8WF/jRY/73b3dtl8vhZewKQC65Ni3vffbKAaJicmbD6XzfsTSFLTzzfptO97zcBCLvanf/iYyN9oJjTvzvn17PB2P4ZFHeH2lmr6fjE760fzOPKfb23360hJSpf9GJXqDPfdgy0KvZsExvpKLTyWDw0N2bzttG6b//C7N9q8VgnN3OG1YJQODJKB9nLkMc+0+YKlK/35JTVLfn0y6IdAzUz6d91NO3zePniUv4Ckes6/rxdzfu5fvHiRzXMJuky+6Nd6Ud7ncc236Z6+Ppuf+8IX2FySpmf8Ou6mn/zE5lHGV0QceC95+KAExzwB/EYSAAAAAAAAEmEjCQAAAAAAAImwkQQAAAAAAIBE2EgCAAAAAABAImwkAQAAAAAAIBE2kgAAAAAAAJAIG0kAAAAAAABIJJP0wGzWH1qenbZ5HDUTXKVi0+GxrTbvbO+2eTbfFixBc97fRzrj994aim1eKOVtniv6XJKacw2fB6o6irI2Twf2F0dGRvwFJP3m/nU2P3bNSpsvHBqw+VQjXE/d8vdZq/l6zOb8s2zr9O2pp6fP5pLUus236W2j22xent5u8ygT7uIrhiKbn/ZM368OBanIP8tMxt9jIJYkxU3fHpT2HS9Uhmrd34MkzVVq/oDA8+7q67V5Ou37fmd7h7++pPb2Vps36vM2r1UmbR7lfL9upsL1OD4+bvOJqbLNi4WSzVNxuAzNRugY/yxHRydsvnP7DpsvWbY8cH1pwdCQzae2+muU8qnAFcLjUxT7fpNqBPrlIaIReN6hNVYUhX/ulw0ckw2sX9KBqswqwUDZ8OPgxMSozafLvu/1DS20+bIVq20uSY2aH0e72/wYkwmsoYZn/Bg3Vw2vh2uBMqYDc16lVrd5sxqYSyRlcjmbpwJrxc5sl83b634cHt45YXNJmumas3l51N9nps2vJVszncEyDPQs8AdECfrNQZaSH6t7ev16thbot5L005/ebPOTjzvN5osXL7b5g+sfCJYhCj2LwBjY09dv8+NPOcXmA0tW+QtIyg36NffYjjtsPtH0z6J/5ck2b19yuM0lqRno+9nQmjv249P4uF8HStKxK55p8/Ksr4e5uTGb1+u+jG1tfh0oSc/+o2fb/I7b/bOszvu5JNBtJUnptH8WSdYW9vxP6NMAAAAAAAD4g8FGEgAAAAAAABJhIwkAAAAAAACJsJEEAAAAAACARNhIAgAAAAAAQCJsJAEAAAAAACARNpIAAAAAAACQSCbpgaVCzuathU6bF0r54DWaab+vNbx7u81rlarNW1tbgmUoZLM2T0XNwBl83qhVbF4tTwfOLzX9KdSo1mweNwL3kPJ1MDUx5T8vaWZ63uZdHQP+BLFvCz/+/g+DZTj6WSfYfHBoyObT02P+AnHDxtlMeJ+2UCrZvDTrn8XQ0gX+8+0+f/iYbTbPFf19HgrSStk8lfJ5OhV+VqmsP0cUGL+iwOfr06GxRarX/TGxIpuns37ID9VTS4dvr5K0c9tDNv/1HSM2X77Mt9lnHLHK5rmsn6sk6dd3/trmd9/1G5sPDAza/NhjjgyWIdT3K4G5pFqPA7nvt6XA9SVp+ZLFNt9y1302b6T9PfjW9rBmNTDOpnybP2TE/nmlAmNQOh2+zygw5+Qyvv+nfRGVbgQOUHgszeUC42jOf3561q8/Jif8+CJJK4b6bN5T8mWMVQ9cwa93y3F74PNSI9Cum02/xqrWfJ5P0G0aNb+m3vTgZv/5ef/51Liv58qMX8tK0gOzm2x+xMrlNl982EKbT2yfC5ZhfN63h7b2Q/9n9lHBjw2DC/16WXOhPiHde/u9Nv+v//o/Ns+lfb8qFsPvmYEljkK/XxFFvuP85Iabbb5i5epQAXTicX79cO9tt9o8m+6x+VHHnGLzRoK5Jg7UQ+jXVMa27rB5e09HsAz5wFovFVjiTIyP2nxkxM8lpZYEa6jDVtp88eIlNr//Pr/GymbDzyodaPO5nH/PDJ7/CX0aAAAAAAAAfzDYSAIAAAAAAEAibCQBAAAAAAAgETaSAAAAAAAAkAgbSQAAAAAAAEiEjSQAAAAAAAAkwkYSAAAAAAAAEskkPbBUKj6hC9Vq4WPGZss2n56etPnM/IzNu8odwTK05Us2j7KxzRtq2Hx4eKfNC+mUzSWpmfKPLa7Xbd7S8A8jV/Wf7+kZsLkknXnWuTZfvXyFzUcD9TQx5duKJG3dut3mPb3dNp8r+/amQD1W58Nl7GjzZdi8c7PNUx2+vbYE2ooklYq+nmqB9nQoyGQjm6fTvt/Kf/zha2Sy/oDAtnxTTZ/HPpekSs2PL+2dnTbv7u33n+/qsvmSpUtsLkm/Wfcbm3/j2z+0+cnHH2vzBYsX2TzK+DqSpO3bd9v8nrvX23xkZNbmLa2FYBmOWHOkzRuxb7O5ku/7fUO+ntraw/PhzJQfA7t6fXvZOTIauEKgX0qKIn9MKhU+x6Hgd1HKKDCQpWK/vggNg+lUeH2SSgf6X/AcoZry4+TU5Fjg81K6M2fzXGAsz2V8GQv5FptPROEJZz7y55iv5W3ekWmzeSYVnm+2bt9m85YWPwZNzVdsngu0uCMWrra5JKVzfh12+w/vsfnPf/Irm+cmgkVQZdTPJ0f88dHhkxxkmYJ/FuW5OZv3lXqD1yjlfZvMRX7enJ2asnk+4/u1JIVGn1TKd/6R0RGb/+CHP7H5scceHyiBdOTqlTafmQuMX1m/Vk1F/n2+rTX8vp9t8ePT+A7/Dnfv7XfZ/P95w6uDZSjl/RiYCqyhuts7bf7AOr8OjMNLTQ0NLbT5s57l28PGBzfaPPCoE8nlnthJ+I0kAAAAAAAAJMJGEgAAAAAAABJhIwkAAAAAAACJsJEEAAAAAACARNhIAgAAAAAAQCJsJAEAAAAAACARNpIAAAAAAACQCBtJAAAAAAAASCST9MBm3LT5bLli86m5OHiN+TiyeaGt2+ctWZtXarVgGcrlEZu3tbfbvKZpm09Oz9u8u9Ric0nKRv4+s7mSzWfLYzaPI7+/mM/75yRJSvtz3H7n3TZfvfIwm//Jy14eLMLwru02n5j09TA+5nPFvj3V6uF92oElK2x++wN32XxyyrfX9HS432VL/j5mpxM874Msn/N9QmrYNBWlgtdIh44JPe6mr8dKJfys5ip1my9oa/P5oiU2b2vrsHlra3h8Guof8Oco5m2ey/u82NJp88mJKZtLUqnk62n7Tt+vNm/zeXeXH4MlaeHQQpvnc356bmnxc1G+tcfmczXfJySpvcO3h64eX49jI76eMplcsAx5+X5TDXebQ4QvaL3u+3Y2GxrjpFRoEGr6MSwVKGM2wVQQpf1B2Yy/j1RgLE/n/D3WamWbS9L02C6bryj4vrWwzY+DUdH33Q2NWZtL0pbAcjVb8n0zW/Pj4PTocLAM1ZkJm/f3+HoYHPRlXJXyY31G4fHhwd/8xuabdk7YvBzoVssC62lJSsW+7+b7g6c46HIZ32Z3bPXr6UkF1suSVq1abfNnHnOczb957X/avDI3FyxDaByO5d91SyXfZjuLrTavVf07oCT9/Oe32Pzuu/z707HHHmPzHTt323zVkWtsLkmtTd9x/uuab9k8V/DtbeXR4TJUGlWbT0/79/FCsRjI/bNuafXPWpI6Amuo448/3uY333STzccnwuN4NvPE5uQQfiMJAAAAAAAAibCRBAAAAAAAgETYSAIAAAAAAEAibCQBAAAAAAAgETaSAAAAAAAAkAgbSQAAAAAAAEiEjSQAAAAAAAAkkkl6YKPesHmlXrN5qVQMXmOwqydwjdhfIx/ZvLcQ3jerNCo2j9JZm2ciX4bRsTGbT5dtLElq1Jo+b/hrZPO+HuYavhDZTN7mkvTN//83bb7+/i02f9v/+z9tvvrwlcEybN/+kM13D4/YvFQq2XxyfNzm2dZ2m0tS38CQzRcOdtu8VKjavJqeDpahs6Ng8/mq73eHgpTvdopTKZtHke/XkhSl/UVSGZ/H8nl5dnewDPXAGDhf9+2h1Npi8/GpGZvfccedNpektqKfVp5z5gk2H1q8LHAF/yzT8nOVJJWKOZsvWbLQ5rt2+bHjsGVLgmXo6fbjw/Sk77u5nB+Hszk/507P+LlOkvJpP9fk8n6MbNb9+eM4/KwykX/e8dPk52HNpq/LcB6uq9A5UoH1ieTHl8AwKknKZn3/z+V934sKPk/nAmN1Kjxf7ZqcsPlsT6BvpX3fapEfh5d02FiSVCv7/j8+PeU/P7bN5j3l8GKzPfAsm1m/dpjJ+L5Zzftnuf6hjTaXpI07H7D50sP8WD6f8/1qaXdXsAzts77NTvYleOAHWbU85w9o+mc5PBxev5x98tk2P+WUZ9v8hh/+yOY7E7TpdGC6yAXa5Nz8vM3LVd/3/8/11/sCSLrpJ77f9fb69pRO+8+3dwzafGjO34Mk3fSd7/j8+u/b/KK3vs7mXQP+3UeSpib8GNio+wVILbRvUfTr5c7OcL/O5/zYsGiJXysuXbrU5jMzk8Ey5AJzZiqdYGI3nh4rMAAAAAAAABx0bCQBAAAAAAAgETaSAAAAAAAAkAgbSQAAAAAAAEiEjSQAAAAAAAAkwkYSAAAAAAAAEmEjCQAAAAAAAIlkkh64a6Rs80Jrh82H+juD1+hsL9m8Hvt9r1yqafNCNsG+WabF5/4SSqd9lbaU8v70zcAFJI2Nzdr8oXWbbN7X45+VopSN5+TvQZLWr9tg8we3jNp8x8hOmxdK4aY7MjZi87ZAm+3v6bV5ayHQXhXZXJJixTbvbi3avLNtgc0nou3BMrQX/LMoT9WC5zjoAm02lcraPBf5PIk41HfTvj3kC+EyZFL+PiszfpyOAkWsN/wYuWnTJn8CSW0FnxcLbTYvFfwYPLxrzOazs+O+AJIG+gdtfvppz7b59NSkzdcee1SwDOlA39+50/fdKOXbU19/n83nZ6ZsLknz036uKbX7Z9lI5fz5q5VgGbI53+YLgb5/qIhj/7zj2HfORiO8Nmg26/6ArK+rTNrn2Vx4TssX/TPPFf04l8kHxsGsL0MqG14bpAp+Xt1Rmbf5klrV5sXYt+uuQD1L0tJ5/7yb2wLjQ9mPUUtaAgO1pIm6r8uxwHp5PvLXyHT757Dx7k02l6SRjF/n9WR9GYqdfj3bftSSYBmWtSy0+d21ieA5DraUH56UC/SrVItfD0vSbbf90uZ9vX5ezuX82JJkjCwVfXvI5vx9zs7P2Xz38LDNt2/fYXNJOvWEk2z+spe9zObXfv06m///vvwfNv/2d35gc0laf/uvbP6cU//I5meec6bNy4ExVpKKgXE8k/VzyeSUXwOVSr5Nd3YG3qUlRRnfnjrb220+ODhg8/t/E97XSEf+mHo9sG4Inf8JfRoAAAAAAAB/MNhIAgAAAAAAQCJsJAEAAAAAACARNpIAAAAAAACQCBtJAAAAAAAASISNJAAAAAAAACTCRhIAAAAAAAASySQ+MpuzcVdni81LLfngJfJ5v69VCmx7ZRXZPE4l2TcLHOMvoWbctHk+lw1c339ekvoHOvwB0UIbj0wP23w+48vwrKPO8NeX1F7qtvlA34M2X3/Pz22+c0MxWIaOjiGbd3f6Mvb09tm8rbXN5pMzZZtL0viEfxZRoN+VCv782aHOYBmism+TM+XZ4DkOtijjh7J0oO/HcRy8RiYKDJeBa0RZ//mu7vZgGdIFPwDNzvpndc/9d9u8f9EyX4DqhM8lDXb7uWA6V7P5jrE7bV4qlGzeP+D7rSQddcxSmx8W+2fZqFb8BdLh9jQyttvm84FrTJf9NfJFPz7FjcDgIWlmwufzNV/G8rzP5yu+LUhSNvZtPldIvow5lDWb/nk2m43wOQLrj7hZt3k6sD4pFELrFymf98+jkPfnSAeeZ02+nhqRv0dJal/u1wa7duyw+fqJcZtnAuvdoXp4nbew7u9zqKvV5oUOX4a4Hp7X74t9Xbb2+LG4GJgzHxpfb/NSZ7jNP3P1MTaPUv4edu7eavNaYVWwDJvmp21+/2/8fep/BC/xlEsF8vnZeZtnGuH3q21bt9j8P776VX+Chu8TrS2+PUpSoejHnyjwjtfd3WnzRmAtOTEx4y8gqbO7x+Z9fQM2Hxzy49t3/s8PbF6phsfQtcccbfNzX/Fim6eygXm9GWqRUjUw383N+zZbqfj1ybbt22x+z9332lyS+s/st3ku78fpXM6/A6aCPVdqNgLrguAZPH4jCQAAAAAAAImwkQQAAAAAAIBE2EgCAAAAAABAImwkAQAAAAAAIBE2kgAAAAAAAJAIG0kAAAAAAABIhI0kAAAAAAAAJJJJemBbe6vNlw612TybT3ypR5XJpmyeTvl9sWwmCl6jGcjTCp/Dnr9ZD14hJBc4ZElhwOYbt262ea3ZsHlHW7cvgKSlA4ts3tXq29PI+G6bd/cMBcswtGCpzXP5ks3n5+dtPj0zY/NsPm9zSSoVWmze2+Of5Vx1u79AgmdVbvi6nC5PBM9x0IX6fjZn83So40vK57KBI/zYMFep+jJkw32/1OLbbLrhx5dd23zfV6CeSqEqkJQb7LP5pu2jNr/1F3fbfNXK5Tb/k5e8yOaSlI583xwa9P1uZsrfw9iYzx8+Ztzm4xNTNn9o64jNVxx+pM3nyn58k6TpqWmbl2fKNo9Sft5vz/s5XZKKgTaZqPMeAprNOJD7+wh9XpIajZrN6w0/t6cCzyubYIzK5fw4mCsE1oJZ//k4sD6Js+H2MFLfafNijx8f1u2etHm2XrB5IbCelqSOjK/rZn3O5unI1+NUJjyY37Xbry/Gs379Um73/Xti0j+HXNOPP5KUznfavNDeY/PxBx6w+V13/SZchsjXw7r7NgXPcbDFNd9eKhO+vcWN8Hq3teTXL2O7fXtoa/PvmR3t7cEyRIEhLPSamMv68asw2G/z3o4OfwFJ3V2BY7J+fDn5tNNsftbZp9s8nQ0/y0ULB20+ONBr89m5WZu3tfl6lKTZmQmbzwXWJ7VKxeZ333mXzYeH/TwgSSeccJLN04Fdh1Rg36OUC6yPJMVp3+jjdHgd5vAbSQAAAAAAAEiEjSQAAAAAAAAkwkYSAAAAAAAAEmEjCQAAAAAAAImwkQQAAAAAAIBE2EgCAAAAAABAImwkAQAAAAAAIBE2kgAAAAAAAJBIJumBQ30lm7e1+lyp8DXSgW2tKJu1eTYKfT5wgCQ1fZVUqjVfhqy/0WyuaPM4rttckprNQF6LbT7Q22XzQr7H5knqsdZo2HzFisNt3je/2Obz5flgGdT0ZWgG8omZWZsX21psXp8v21yS8nlfl6V2/6zqUxP+AulAY5E0kRuw+a7G9uA5DrZclLN5FNozT7ClXq379lKrVmzeSPl+2d7dESxDX6DvlkdHbF6bmrH58NZtNl952EKbS1JLW5vN77//Vza/554NNp+ZnrP5eS+8wOaS1N7u6zpS1ea1mq/Het2XUZLihm8P04G+XQ20NwW6fr3h5zJJmi1P23xsbMLm2cgXIh37OpAkNfyziNMJ5vVDQGi+iWM/CDVDE7+kRugaKX+NdGARFuX8GkyS8sWCzTOBc6Szfg2Wif3zHlrSbXNJqizw/XPeN3vt2D7qPx8YR4dzvo4kqS3rn0VjfsrmLZGvp7lAW5GkOyb8NaaLfm1w9KoVNp+f8+u4ngRvKLPzfp22a96vqWvya/Lp4cA4K2l4zpdB9UP/Z/aNQD21ZHw9pVPhh9Wo+Wv0BNZAuUC/Cb1DSlIq8C6aDoyRoVfZTKAMraV84AzSyOgum8/M+vHriCOPtHmlPGbz7r5+m0tSd6df583N+LGjWvU1WQ28a0vS3Jx/x5qf9/W0Zcsmm997z902n5wK9HtJU5MTNu/p7bR5LjRfZsLrn2zOvx9VE8wFtgxP6NMAAAAAAAD4g8FGEgAAAAAAABJhIwkAAAAAAACJsJEEAAAAAACARNhIAgAAAAAAQCJsJAEAAAAAACARNpIAAAAAAACQSCbpgT2dBZtH2cCeVBQFrxGl/DlKpZLNM1l/jVQ6vG82O1Ox+XytbvN0Nm/z9mLW5qkoXMa40bR5s96weTY/ELiCf9aNxnzg81JNvh5q8zWbpwPNpRJPB8tw77rNNp+dj22eChRiyeLlNu9u9fX4MF+GkHzRXyNd8fUsSdV8q83LbT2PqUwHQxynbF4J1EOjEa6nfMHXdaGlGDyHFYWH44VLfN8dTwXGp4Zvb+VZ37ebfmh5+BoZP4b19HbZPIr8GNna1mbzjq5Om0tSqdWPT3HVfz6d8mNDlGC+S6V8m52d9s8il/P3UJ6esPn01JTNJalS8e0pNBdl8/5ZxvVwv2vKXyNwiUNGaKQPzgSB9iJJ1UDfqWdC67hAHji/JDUC67Ao79ttaNZMzfs2WZ4Ot+tCxY/VsXxdV+Xb7a66X59MT8/aXJIaI77/b6qN27yn26+XT1p5RLAM7YcvtPlDI5ts3ghMaUta/Plr67f6E0ia6Wu3+W1TozbPVP1gX5sKr9EmJ2dsvqDn0F9DNWt+nC3kfM+sz4cXB6E5qyWwhkoH1uRRgvendGAYzQTyVOQPyATWcVEmvM6r1f176OjoiM1TKf8sJoa323yFH2IlSblAPWUD9dQMdKt6PbAIkzQdGOsnJvwYecONN9h8ruz79eZN620uST+98cc2/5MXXWjzVKCeMgnWmrmMPyauP7H3UH4jCQAAAAAAAImwkQQAAAAAAIBE2EgCAAAAAABAImwkAQAAAAAAIBE2kgAAAAAAAJAIG0kAAAAAAABIhI0kAAAAAAAAJJJJemAxH9k8inxebYT3rBqhMshfQ8E8XIZ6oBC7RqZsvmRRn80LhRabR1GCvb1m08aNRi10gsDnfSXMzc8Ezi+1dLbaPA7c5lxlt82rGgmW4Y4H77H5ffdstXlHh7+H5+V8e+sqHWbzh/lnkcv6a6SUtXmSneJGqWDz7gWDCc5ycM1XqzbPZXw95jK54DWiKOXPEXhWUeSfVSPB0+rqafdlUN3m49t9v2lvKdp8emra5pKUiv34cdzalTbftHGbzZ/5zDU2H+j1/VaSVPPtpVrxY9zM9ITNx8eGg0WIY59n8n6umJ4p23zzQxttXp6Z9QWQND3hn/dcw7e3iXoleI2Q1pxfpqQD9Xio8KNHAqEGIymK/fMoNX3eI3+NgQQrxo6sP6hW8DVRb/Pj5OIePx/1HDZkc0natsvP/Rt3bLf5ESceY/PZ/JzNx37jzy9JC27wY0jLnJ9vdnf4eb26alGwDJmcH2OOOuxom+/a7Oebia2TNs8Hxh9J6p30693VFd+eytk2m082/VwhSar5593WFq7rg6296OfN2nxgbGnJB6/R2uKvkUr5NVA6HVpjhddQ6cBAnE75MTCd8idIJ3mHC1i0yI9ha9astvnw8KjN5+Z9m77/Hv/uJEmjO/0YumSBv4fW7n6bZ3Oh91hpamrc5vfd5+9jy5aHbL58he+31Wpo10L6+c032vzE40+weTbjx6+2tlKwDHFg7ZB9gm2W30gCAAAAAABAImwkAQAAAAAAIBE2kgAAAAAAAJAIG0kAAAAAAABIhI0kAAAAAAAAJMJGEgAAAAAAABJhIwkAAAAAAACJZJIeWCyVbN7a1mrz6Zlm8Bq1es3nPtbM7HzgCuEybNm1y+a33/cbm1e1wuYDvb4eU4psLklx8AgvCmwfNhp1f/2mzyWptbXN5pXanM13jc3afN2mB4Nl2LB9o83H5qds3j3g23Rra94XIG74XFI92CT9AbVmxeZzlUCnkdQMNLm2tpbgOQ62Qiln83Tkh7psgmtkIl9RUZQK5L7jRalw3y8WfJtLt/t+16j6NrngsMU2n5mcsLkkTY2P2ryl4J/VqSevsXlvf4/Nd231Y7QkRY0Zn2f9s5ieGvP5tD+/JKnhr5HL+Xpq1Pz4NTU+bvOZ2WmbS9Jk4BxtgXk/1C8nZ8rBMjRqfgycLvsx8FDhRwdJDT+zx43w+qV9zs+rS1O+/x+R9uNHfz3B3D/l5+75Pt8mdOYqGw8t7Lf5QHuHP7+k+E5/H+tuv8fm6aFumy8+cpnNjyr22VyS6nf+wuZ98769tPR32Xx9ZSJYhmzZrx9aO3xdR5mCzQt9fgysZwNtRdLkmB+jevJ+jFq+aKnNf/XQr4NlaM37Z5FWeC14sOVSfhWUCrwtht4BJSmK/DUygYuE1nGhNZgkpUOHNP2zigNr8lTKr/NqtWqgAFIm68/RN+DHj0LBr9l/dsOPbT7Q58c3SSpmfUU+MOPXJwOLfD2sbA+XoV73c//9v7nX5t09fozsDeS1avj9anjnTpvfcZsf51cuP8zm9997R7AMs9N+rVcIrDVD+I0kAAAAAAAAJMJGEgAAAAAAABJhIwkAAAAAAACJsJEEAAAAAACARNhIAgAAAAAAQCJsJAEAAAAAACARNpIAAAAAAACQCBtJAAAAAAAASCST9MBsNvuE8s6OVPAajYY/R5T2+17ZjM+bagbLMNhbsvkZJx5p83K1bPMdI7tsPtDfa3NJysjX5eTUhM3L1Xmbz8/7e4iihTaXpGwmZ/NazT+LzTP+HifSxWAZjlzjn9XQMv/5Wt23p1rNf76lo8cfIKlWb9h8YjZv8+3bfHvasXM6WIb+zi5/jZGR4DkOtmzRt4fQjnkmPDRIsT+o2fTPMpf1eTqKgkVoFny/SjdabF5p82VYtXq1zSdGhm0uSePjgTbXqNh4qKfT5oVs3ea7tjzgry9pdnS7zdt7Bm1ebfi2EEX+Of33QTZu1H09NRp+ANo9Mmbz8uyMzSWpFpgLjlyy1OZ9ve02n634uUiS5qq+zU5N+3o6VESxz9OBXIE2J0nLAuPg2mzB5kvK/hqFufFgGbKxb5fZJYE5LTtr83zejy+12TmbS9JPfvUzm08+tNXmLVv9OLhq5iibL5sKPWxpZ6DvlUt+VpudmbT5dDk831R3+rl/oOyfxfKeBTbPjPvzt+2o2lyS5jeP2rxa9O2h1ufbW2fev5dI0tqly2y+ZVe43xxs82VfT4Wi77dR4P1LkqKUPyaT8a+kUeTzVCr8nhlF/pjYLy/UaPrPh8oQpcOv3c3AWN9s+PGjVvM38f3v/8DmCxb49Y8kXXDe82xeDzyK0HSWL/i56uFzBE7S8PXQ2uLny1rNr0/CI6iUyfqjJif8OL1ylV+Tx83wXFLM+7qMAnsKIfxGEgAAAAAAABJhIwkAAAAAAACJsJEEAAAAAACARNhIAgAAAAAAQCJsJAEAAAAAACARNpIAAAAAAACQCBtJAAAAAAAASCST9MDWQsHmhWzK5ulsFLzGzHTV5m1tOZvnc0WbNxUHy7BooMPmUSpr8/u2b7X51h27bL5ll88l6Yili20+PV+2+YbtD9l8dnLK5ikN2lySjop9XdeaNZvn5PNmMx8sQ1vbgM1Xrllo85vuWm/zRlunzbva2m0uSaOTkzafqfhnWan5PhM3g0VQe8H3q2bgWRwKGg2f5wLDTzrRlrpv09m0HxsyaV+Iet0/S0nKF9ps3qj6Mk5Pzdg8ExinFy9banNJmhgft3mj4e8zX/LtMZvzeaU6Z/OHj5m2ebnuG0R7Z7fNi4XWYBnypRabRzk/PZfL/llGkb+H8rT/vCS1tfhz9PZ02rxY9PeYK5aCZegK5AO9CQa5Q0EjtP7w95EKL1+UDrTbZiAfm/Z9p9QaXscV/FJQ5Unf7tat22Dz4dkJmw+2+DWcJI1WfRna2ny77Nvkx4/B79xn82wpwYQTGKs7Yj8OZsb9ONvaHa6ncuAVobhpwua1B2b9+Sf8PQ5NhRt9XPPHjMe+DMWGf9bLlj4jWIYtTd93M1U/Jx4KstnAsw6M1ZHCY0NgaND8/LzNC4H30Ewm/EobeDVRKvLruFRgnA5eP8nnU4G+nfH5HXfeYfNqzdfz7XfdZXNJemD9RpsvGOi1+fPPP8/ma//o2cEyVCr+Pjpa/Xq52qjYPAo02Eygz0hSKfDy0drl3xNb2/1aMiPfFiQpFWgvobViCL+RBAAAAAAAgETYSAIAAAAAAEAibCQBAAAAAAAgETaSAAAAAAAAkAgbSQAAAAAAAEiEjSQAAAAAAAAkwkYSAAAAAAAAEskkPbClULR5vpC3eblaCV7jznvusvmy5YtsvmrRUn+BZj1YhmbD51HUtHmrfD2MjU7avK09/Ehuu+9emy9etMDm+VTW5pXI563Fks0lSSkfz9d8RW/avN3m90/4epSkrsnNNu+OfBma2cjmlYb/fGWubHNJSjf9NYZ3jNi8q7Xb5gmak/LZms0z8vmhoD4zZ/PiQFfgDIGOL6kRGD6acWzzuh86lMr4sUOSFi1ZbvPJkXGbb7h3vc3LM9M27+kN1aNUr87bvG/A30M+ML6UCj6fmfZ1IEnVmp+PGoG8v2/I5k3fFCRJoUNWLPf1NDW6y59/3o+R0WBboARSf59/3i1tgbkgMA9k5OcaSYpj33Ey2VzwHIeCZj0w3zT9feYC87IkjQbO8auZGZv3dfrnWWgJ13V7YJzTtJ8XqxMdNh+ujdk81+/nVElq1vycFvW2+ny7v4f0gztsnuoOP0utWWjj5pT/+DOHfXubLgU6p6Sfdfpydo/5QvRN+Hq+J+vn7bn2TptL0mTaL3LGJv042DtXtfn4Ll9GSVo3stsfUD/011CZjO83tYqfE6vzft6XpMASSfXAIqta8eNPR0d7sAzZvH+XTQV+vSJKh/pNII/Dv79RKPj7bDZ8e7rrzjtsXiz5tebSzvDaYNe2nTb/1a98GY5Ye6zNg9UsaXxs1ObNQHsq5ALjcOBR5TLhcbyZ8v0q9KylwLogF37JC60tovQT+50ifiMJAAAAAAAAibCRBAAAAAAAgETYSAIAAAAAAEAibCQBAAAAAAAgETaSAAAAAAAAkAgbSQAAAAAAAEiEjSQAAAAAAAAkkkl6YCOu27xW85+vVqrBaxRKPi/lIn9A3V+jUS0Hy6Cm31tr5P01+lpzNq9NNmw+Vpu2uSSNTc7bfMeuSZsv6O/0F6j6ZpFN5/3nJdXmK4Fz+M9PZnxj2DW2MViG0R3+mI07HrR5tORImy+v+kZfWbLI5pKUzvi6LBTabN7WGtu81BnoM5J27Npq8/m5QOc+BFTn/fik2De4bC7BnnrT991sJmvzWt1/fuHQkmARBvv7fBnS/nkXOnx727Z1s80H+vttLkmNamgc9mND54C/RmupxebFfLjNN+q+vUxP+3F4ruzzYrEQLkPDt7nFQwv95488yua9bf5Zt7X32FySpufnbD466seO9s7QXOGfpSSp4efUsZGR8DkOAXHDt7k479tDe7YZvMaiVt/uahMTNu/K+bpO5f18I0nlvJ+7y1k/n8xVfJsr5HwZKmNTNpekZtmPxVOBuh7r8WP9jh0+Xxr5XJIGFvtxMApMy9se2mHzLQ/4vitJs0t8/8xPpmyeavhnVe4t2nznVHjtsaruy/CMed8et1V9e5lT4MVEUmrUv1tMybfpQ0Fc832iKp+3FP2z/O+r2DQX+WeZyfgxMheF5/7Q+qDZ9H0/DgzDqVARwsO4WgqB8SH2a6xc4OOlvH/HyxfCWwNdK/16tbZssc3XHHG4zZuhipa0fZtfr0aByi5k/HyntG+PUTo8jqcCbbajzc/Z6bS/h1xoX0RSreL7bpR4J+jA+I0kAAAAAAAAJMJGEgAAAAAAABJhIwkAAAAAAACJsJEEAAAAAACARNhIAgAAAAAAQCJsJAEAAAAAACARNpIAAAAAAACQSCbpgeVy2eatgT2pZqUevEYp1eUPaPhrjEyM2zxqNoJlqDZqNm9OVG2eLbTbvK2zzeY33rrB5pKUiXw9tBRbfRny8zYf6i7YPBdFNpekTNofM16u2HxsetJfoBB+louPO8bm1R0PBsqw1eYdRx1r80YzvE87O73b5hMTszZf/+ADNj9q6WCwDI2qfxaVyXDfPdjiQD49NW3z9o5s8BqZbM7muVze5nHKjy35bCpYhond22w+PbHd5sW07zf5rL+HBF1fxYI/qDbvn0V5diZwhUA9xeGxoVFv2rynq9vm1ZqfD2u1cJ/J5VpsXin7eirlfHtcumSZzTNFf31Jag4P23yXHyI1G3gUjbSvR0maGPPzerEUvo9DQTPybWJhtmjzowNrB0la0PT12V0q2XzVvB+jspVw37o/MEY81PD1MDEyYvOi/PpmQH79Ikl9HX5enCjvtPl4i5/b78j4GanZ7e9Bklrv32jzasrPWbuHfHv5eWBOlKTCBr/+qM77eoi6/XzSMeM/f9dWP/5I0pqow+aLA685wyXfphcneG+4rezfC6ayiV+1Dpp0ys+rodVslA6vd/N5Xw89PX7ejTL+84W8b2+SlAmcoxn7MTAVWH/EgdVos+HXHpLUUgiUsRF4hxvssfnWLj82pNLh9Uu64euhkfLrk2XLl9q8PBMenyplv1Ys5v0YGXiVVhRY8KYT/C5OLtAm04H16nx5wub5XPjdpV7341MuwTkcfiMJAAAAAAAAibCRBAAAAAAAgETYSAIAAAAAAEAibCQBAAAAAAAgETaSAAAAAAAAkAgbSQAAAAAAAEiEjSQAAAAAAAAkwkYSAAAAAAAAEskkPXBsctrm5XLV5rPzteA17ntgm813j47YvKu9ZPO2Vp9LUhRlbT42PWfz6dkpm89Oz9p8sK/d5pI0OjbjyzDqy7iuXLF578lLbb5r12abS9KihattXp2ZsHlneaPNs1vXB8vw0IORzbuKvk22ZHz3mBp+wObDu4dsLkmVqi/Dz399t81/dfcvbF57zonBMmSzfj9568bJ4DkOtrZO37dnZso2b+/uDV4jk8vZPE75ekylUzaPfHN9+JjY991aedzm1ZofpwsFX48LhxbYXJIqFd9epsYmbD495u8hSvl+mcsVbC5J+bx/lo1mw+bVWjNQhnywDJmMf+DVOf+soyi2ebatzeYT075PSNLslJ/3fYuWtm3fYvP2zp5gGfoHBvwBT5Mfh7UVfG2dlmq1ecuYXztI0pT881rcFui/Y379ovHwXJDP+XZXGPJ9Y77i+9bopF//tC0s2lySFLhGuuH7ZrPkx8ltmR027wt1HEmzDT9WjwbWmh3yfWtV98JgGept8zYvbZ+w+eEjdZu3pn3nvbMz0PclDVcCc+KU7zctC3w9TWd8n5Kk7oUd/hwNP98cCgoZX8ZMxr8bFfLhebe9zffNfGBODE04afk5UZIi+bm9mPf3GQXKmAm8NzSbfuyRpIH+bpsXcv4aA32+TYfPn2CAavpj0lk/ny1c6Mef3cM7g0Voa2mxeWe7f5+uNvzYkU77ek7Fvq1IUimw1hwd2WXzyalRm0fZ8LPK5vw4m06H+439/BP6NAAAAAAAAP5gsJEEAAAAAACARNhIAgAAAAAAQCJsJAEAAAAAACARNpIAAAAAAACQCBtJAAAAAAAASISNJAAAAAAAACSSSXpgebpq82nVbN5UHLxGX1+XzfPZlD9BOm/jmUqwCJIim06n+23eKPiL1BpjgdzXoyTNV/0xUez3B4stvp4m5so2b45tsbkk5e//pc3HJodt3pZt2HxJdylYhl3D4zZPBZp/Vk2b333P7Tafn/afl6RCwd9Hed4/i+7uAZtv3zEdLkN13h8w6evxUFAqFWw+V56zeaXs25skFfN+bGg0fb/MZvz4Va3Xg2VoxoFj0r49pfItNt+1a5fNd+/2/VaS+ge7bd7e7ftdpezH0NkJ3x7LUc7mktTe4+eabOSfdVqBuagRbk/1QN+u1/2cm2/xz7pS9/U4Pu7nIknaunWzzYuFrM0XLlti85lpXweSlIpC8/7T4+dhqzNFmy9O+7pMx+EFTJTx7XbdqO/fmUBd9qfCc1ouMNY2Au2+mfH9dy7Qv3dnw+26VPPr0clZP2/OBKqhXvL1ODLr+7YkbV/i12njg602H7phwuat8s9JkiZO9OvdseERm8eB+1za0WbzbIL3hqZmbd6Z8w8r57uMhod8GSWps+H79q/X7Q6e42Br7/DtKZfz/a5Q9GswKTw+hZ52KjAVNOPw+FRv+qvEVd9mozjw2pzy/TZOUMaurk6bl9r8GitX8m02tH4JP0mpHnhY+UB7yGV9Pc5MTAbLMDHhx/pczs+p2ZQvQ5z29RR6h5SkRmDNft+999g8HShDJsF6N4p8OVOBa4Q8PVZgAAAAAAAAOOjYSAIAAAAAAEAibCQBAAAAAAAgETaSAAAAAAAAkAgbSQAAAAAAAEiEjSQAAAAAAAAkwkYSAAAAAAAAEskkPXB43QM2T2fzNo+yUfAahShxcQ6oPumvkU6wbVZrBsoZyKO4YfMF6djm+Sjrry9pQXfB5t2lVpu3tuX8BWbLNm6JwxU5fs9PbT4zO27zUuSvsbzm61mSelM+jxo1m+fTTZuXJ3bZfHT793wBJLV0tNn8yFSgvXX6eph5aF2wDNXpWX+N+ZngOQ62VMbXU2tryeYz09PBaxRbfb/JpHyDyxaLNq/U68Ey1OXbZKmz3+Zr1vgy3Hv3b2x+xy9vt7kkHXfCMTZva223eSbn67kyN2fzbIJxfrY85csQmosavt+lQvOIpGqtavN67NtDNuPn3EZgjMxkwnPNwOACf0DKt8coCtVD+GFNTfhn1d7TEzzHoWAo5Z/XdNbXZUszMKFJaon8NbYV/TnWx359MlYNj5ONpn+mLS2dNu/pbLF5vs/Pmf2d/vySVNs1avPGuO+bs4H+r1bftzbG/vySFO+u2DyT8vU8UvL5zOhksAxTv/LrtGrGt6db2/wYtnLMr6H6a+F3gjjl54O8j1WZ8PWwfbYrWIapwPtNnAvP7QdbsdW/V4TG8sBS9WGB95/QS1o649tDOjjfKDhnBYYvpQJjZD3252/U/HuHJNVDa8G0r4dU2q+h6nVfhmrD34MkNVK+DC05Pwa2tfn31N0j24NlmJkJzEeB5pbN+npK50Lrk8AFJMWBebtaC6zpc/7dRUnafEDcDN+Hw28kAQAAAAAAIBE2kgAAAAAAAJAIG0kAAAAAAABIhI0kAAAAAAAAJMJGEgAAAAAAABJhIwkAAAAAAACJsJEEAAAAAACARDJJD0xPT9u8mKv6vJgNXqOtrc3mpUIpeA4nUiPBUf6YWm3e5pXyjM2zKX/+Z/SEH0k2arV5s1mzeaXq76E2N2fz6u7tNpekWqCq0zVfxmbD541K+Flma01/jTi2eVz3n2/xH1chQXObH95l80bKl6GtN7L5xGS4DBXfdZVOhc9xsMXyD6Olw48tY7t8n5Ck6pyvqGzJj09xoD2qEcglpTI5n6f8+NHb22fzwQV+nN/y0FabS9KaY460eS5XsXm1Euj7dZ/nikWbS+HxpVLzz7oR6DSzjQSdPzD+pDK+byvlO2YcaE5RoK1IUrHUYvNq3c8V9cA4X2rx55ekatXX5eyUn3MPFVsDc7/qfgzqTnCf3V0dNp9P+76xLVDGiUa4DMHul/dtItvlx9GVq5fbvCMwL0vS6HjZ5l1pP19UA8vZRo//GW11dtafQNLSrb6MUblu8wdXLrJ5as2KYBm6N++2+faH1tu8I+XrIT3v73G+GF7z92R9g6tl/DhZLnTZfN1O314l6YH6qM1LveE56WDLRH6+CeVRFJ5PUqEpLbCOS4fe4eLwYjWT9W0ym/WFTAduIp0OtPlMuJ52bvfvWHf84mc2v+2Wm3wZAvWsQB1IUjPQt9u7/VyUzftrhNZoktTe6seHWtOPs3EqsAYLNqfwZJPO+XoqFgJroEAhmgo/q8BSU81EeyOPjt9IAgAAAAAAQCJsJAEAAAAAACARNpIAAAAAAACQCBtJAAAAAAAASISNJAAAAAAAACTCRhIAAAAAAAASYSMJAAAAAAAAibCRBAAAAAAAgEQySQ88ZuUim7e3lWze29EVvEZHZ6c/oFGz8eTYsM1nZ8aDZajMTtp8vjbny1Au+ws0/Ofrtbr/vKRKs2nz+ZrPa1V//kYt9p+v+ecgSc1myucNf404cI8p//H/FtgnDVyjGUc2j/3H1VS4kJH8NRTIKxVfiLlGuIvP1/2zyqXng+c42KLI32c2l7N5ocWPX5I0Pe37dltbm81TkX+WjUB7kqR6pWLzTMp37lTk62FocMDm05N+fJSk4eFd/hoDR9q8kG/YvF73FVWvh8fQ8d0jNq81/RhXmfPPoRJ4TpK0dMkSmxeyvl8q7e+zrdW3x6npGX9+STPz/llEmdD4FRjng+Of1NXbZ/ORYf8sDxUT7VmbNyf92qCWLQSvMTrnx6hK1bfrRru/RtTtn4UkZXL+HGMp3+527dpu8/oGP4Y12jptLkk7dvk2M7Xbj3PtPd02X9DRb/NSftbmktS1eYs/oODnvFJXh82zWZ9L0qxf9qtrdtrmuUnfHm+tTtl8VWB9I0krA8P9ZMOPo/dtG7P5HbHvl5I0W/LjfX+v7/uHgkLGr5ezWX8PqSgwX0lKhdbEqcBaNOP7fiYbXu9ms37OiQL1kAqUUfJ5OrBWlaQdWzbb/Cv/9r9tngk8q65C3hcg/ChVyPtn0dXVbvONG+63eVp+7SFJpaK/j7k533ergXfZetUPLsVAHUgJ1qPpwLtu5J9lnAqPkXGg24Xen0L4jSQAAAAAAAAkwkYSAAAAAAAAEmEjCQAAAAAAAImwkQQAAAAAAIBE2EgCAAAAAABAImwkAQAAAAAAIBE2kgAAAAAAAJBIJumBkxt+bfNyPmvzsUIheI1svsvmccpfI0qnbN6ozgbL0GzW/DlqPm/KlyET5W2ejoo2l8K7f+la0+b1fMPm1Xl/j9mafw6SpFrdxw1fhooC16j7epakZrUcOMKXwdeiVG/4I6rNcPcqB8pQCTzLxoQ///YJ/ywlqbvoW1Q6ehrsN6ciGzcC/Tpf9P1SkqanZmw+V/XXyOT9NRrNOFgGNX17aWR8PahRtXEm4/vd0IIF/vySpianbT497fP2jjabF1t9Pj46bnNJ2rJti80zWV+PxRY/Tke5cJ9p62y3eb7gn0Ux58eXXK7V5oXJMZtLUnPMt8lU2tdTqB7r9QRtPvL32dndGz7HIaAz5eesnYEmsyMdmpGkZYFzrO3I2Xwk58eX4a6OYBmypR6bN+p+HKxv3mTzyRGfbyr4e5SkmTk/BmXLfiwPjfXlwHxTjMNr0a5RP98Ui/5ZbHhos83b28P9pqPLjyELTzrG5iMPrLf57pp/Dot2hdZwUku/L+MDlYrNb9y10+a7C4E5VdLiPv/uUp4Or8MOtlKg36QD71eZbPi9IBM9sfkik/FzQTodnndDbw6hGSkVGMdDeZSgjKF6KgRKWSz69+10KvgWGcilTOSf9/jOHTbfHhqno/A7XjEXWKd1+DFybMKvgRp132/T6fD6JRM4JBV4lqHmEgXefSQplaDNPRFPgzdEAAAAAAAAHArYSAIAAAAAAEAibCQBAAAAAAAgETaSAAAAAAAAkAgbSQAAAAAAAEiEjSQAAAAAAAAkwkYSAAAAAAAAEknFcRwf7EIAAAAAAADg0MdvJAEAAAAAACARNpIAAAAAAACQCBtJAAAAAAAASISNJAAAAAAAACTCRhIAAAAAAAASYSMJAAAAAAAAibCRBAAAAAAAgETYSAIAAAAAAEAibCQBAAAAAAAgkf8Pvkn27LBX00QAAAAASUVORK5CYII=",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABJIAAAEwCAYAAADsAVtdAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjEsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvc2/+5QAAAAlwSFlzAAAPYQAAD2EBqD+naQAAYLpJREFUeJzt/Xm8JmV95/+/q+rez356O91ANzSbyL5DREGNuyaYH7hMMiZRcZlkxsnDGMckRpNxxpgYYxKjxp9RQ9TRr/xknIdxyKhBQUFQQWSVtaG76b379Nnu/a7fH3zpse3m/ammwT7I6/l48Af9rrvqqqrr+tRVV58+d5LneS4AAAAAAAAgkB7qBgAAAAAAAOCpgYUkAAAAAAAAFMJCEgAAAAAAAAphIQkAAAAAAACFsJAEAAAAAACAQlhIAgAAAAAAQCEsJAEAAAAAAKAQFpIAAAAAAABQCAtJAAAAAAAAKISFpENk3bp1SpJEH/zgB5+wfX7rW99SkiT61re+9YTt8+fpoosu0kUXXXSomwH8QqLm7IuaAyxu1K19UbeAnz9q0b6oRWAh6QB85jOfUZIk+sEPfnCom/KkeO9736skSfb5r1arHfQ+t2/f/gS2NPad73xnT/t/9thXXnmlXvSiF2nVqlWqVqs6/PDDdckll+i2227bZz9f/OIX9Ru/8Rs69thjlSQJBRM/V9Scx7/PJ7vmNJtNveENb9BJJ52ksbExDQ8P69RTT9Xf/M3fqNvt7rP99PS03vSmN2nZsmUaGhrSc5/7XN100037bHcgNafdbuud73ynVq1apXq9rnPPPVdf//rX99nuoosu2u91fvGLX3xQ1wDYH+rW49/nYporFT3PA6mF3/zmN/X6179exx13nBqNhtauXas3vvGN2rRp05N+rnj6+UWvRT/rBS94gZIk0e/+7u8+7n38vGrR+vXr9ad/+qc655xzNDExoaVLl+qiiy7SN77xjX22faw5TJIkKpfLe217oO9tN910k37lV35Fk5OTajQaOumkk/S3f/u3e/JHFxAf67/LLrvsCbkeT1WlQ90ALD4f+9jHNDw8vOf/syw7hK05cIPBQP/xP/5HDQ0NaX5+fp/81ltv1cTEhN72trdp6dKl2rx5sz71qU/pnHPO0fXXX69TTz11z7Yf+9jH9MMf/lBnn322duzY8fM8DeBp46lYc5rNpm6//Xa99KUv1ZFHHqk0TXXdddfp937v93TDDTfo85///J5tB4OBXvayl+mWW27RO97xDi1dulQf/ehHddFFF+mHP/yhjj322D3bHkjN+a3f+i1dccUV+s//+T/r2GOP1Wc+8xm99KUv1dVXX60LLrhgr20PP/xwvf/979/rz1atWvUEXAng6empWLd+WjRXelR0ngdSC9/5zndq586duvTSS3Xsscfq/vvv10c+8hF99atf1Y9+9CNNTU098ScKPA18+ctf1vXXX3+om1HYV77yFX3gAx/QxRdfrN/8zd9Ur9fT5Zdfrhe84AX61Kc+pd/+7d/es+0f/dEf6Y1vfONen5+fn9db3vIWvfCFL9zrzw9kDvV//s//0Ste8Qqdfvrpeve7363h4WHdd9992rBhw55tli1bpn/+53/e57NXXXWVPve5z+1z/KcbFpKwj0suuURLly491M143D7xiU9o/fr1euMb36i/+Zu/2Sf/kz/5k33+7I1vfKMOP/xwfexjH9PHP/7xPX/+z//8zzrssMOUpqlOOumkJ7XdwNPVU7HmTE5O6nvf+95ef/aWt7xFY2Nj+shHPqIPfehDe16KrrjiCl133XX60pe+pEsuuUSS9KpXvUrHHXec3vOe9+z1olW05tx44436whe+oL/8y7/U7//+70uSXve61+mkk07SH/zBH+i6667ba/uxsTH9xm/8xhNy7gCemnXrp0VzpUdF53kgtfBDH/qQLrjgAqXp//0HES9+8Yt14YUX6iMf+Yje9773HeRZAU8/rVZLb3/72/XOd75zv+84i9Fzn/tcPfTQQ3vVlre85S067bTT9Cd/8id7LSS94AUv2Ofzn/3sZyVJv/7rv77XnxedQ83MzOh1r3udXvayl+mKK67Yqyb9tKGhof3OnT7zmc9odHRUr3jFK/yJ/oLjn7Y9wTqdjv7kT/5EZ555psbGxjQ0NKRnP/vZuvrqqx/zM3/913+tNWvWqF6v68ILL9zvP7G66667dMkll2hyclK1Wk1nnXWW/tf/+l9hexYWFnTXXXcd0I8o5nmumZkZ5Xle+DMH6hOf+ISOPvpo1et1nXPOObr22mv3u91DDz2ku+66q/B+d+7cqT/+4z/Wn/3Zn2l8fLzw55YvX65Go6Hp6em9/vyII454zOICLAbUnGKerJrzs4488khJ2quWXHHFFVqxYoV+7dd+bc+fLVu2TK961av0la98Re12e8+fF605V1xxhbIs05ve9KY9f1ar1fSGN7xB119/vdavX7/PZ3q9nubm5h7HWQFPLOpWMYthrvR4z3N/tfA5z3nOPvXtOc95jiYnJ3XnnXce0P6BJ8IvQi36i7/4Cw0Ggz1/qfRkeKJr0YknnrjPAnW1WtVLX/pSbdiwQbOzs/bzn//85zU0NKRf/dVf3evPi86hPv/5z2vLli36b//tvylNU83Pz2swGISfk6RNmzbp6quv1q/92q8d1D9p/kXAG/ITbGZmRp/85Cd10UUX6QMf+IDe+973atu2bXrRi16kH/3oR/tsf/nll+tv//Zv9Tu/8zt617vepdtuu03Pe97ztGXLlj3b3H777TrvvPN055136r/8l/+iv/qrv9LQ0JAuvvhiXXnllbY9N954o0444QR95CMfKXwOa9eu1djYmEZGRvQbv/Ebe7XlifCP//iPevOb36ypqSn9xV/8hZ71rGfpV37lV/b74vO6171OJ5xwQuF9v/vd79bU1JTe/OY3h9tOT09r27ZtuvXWW/XGN75RMzMzev7zn39A5wIcatSc2JNZczqdjrZv367169fryiuv1Ac/+EGtWbNGxxxzzJ5tbr75Zp1xxhn7TG7OOeccLSws6O677z7gc7r55pt13HHHaXR0dJ99Strn3t99990aGhrSyMiIpqam9O53v3u/v8sJ+HmgbsUWy1yp6HkWqYX7Mzc3p7m5uaf0T3fhqeupXoseeugh/fmf/7k+8IEPqF6vH9C5F/Vk1qKftXnzZjUaDTUajcfcZtu2bfr617+uiy++WENDQ4/rON/4xjc0OjqqjRs36vjjj9fw8LBGR0f11re+Va1Wy372C1/4ggaDwT4/DfV0xD9te4JNTExo3bp1qlQqe/7ssssu0zOe8Qz93d/9nf7xH/9xr+3vvfde3XPPPTrssMMkPfIjvueee64+8IEP6EMf+pAk6W1ve5tWr16t73//+6pWq5Kk//Af/oMuuOACvfOd79QrX/nKJ6ztv/u7v6vzzz9f1WpV1157rf7+7/9eN954o37wgx/s88LyeHS7Xf3hH/6hTjvtNF199dV7rtMzn/lMvelNb9IRRxzxuPf94x//WP/wD/+gr33ta4V+V8F5552nn/zkJ5Kk4eFh/fEf/7He8IY3PO7jA4cCNcd7MmuO9MjvJXjta1+75//POussfepTn1Kp9H8fr5s2bdJznvOcfT67cuVKSdLDDz+sk08++YCOu2nTpj2ff6x9Puroo4/Wc5/7XJ188sman5/XFVdcofe97326++679cUvfvGAjgs8Eahb3mKYKx3oeRaphfvz4Q9/WJ1OR69+9asf9zkBj9dTuRZJ0tvf/nadfvrpes1rXvOE7fOnPdlzqJ9277336stf/rIuvfRSW5u++MUvqtfrHdRCzj333KNer6df/dVf1Rve8Aa9//3v17e+9S393d/9naanp/U//sf/eMzPfu5zn9PKlSv1vOc973Ef/xdGjsI+/elP55Ly73//+4W27/f7+Y4dO/Jt27blL3vZy/LTTjttT/bAAw/kkvLXvva1+3zu3HPPzY8//vg8z/N8x44deZIk+X/9r/8137Zt217//emf/mkuKd+wYUOe53l+9dVX55Lyq6+++uBP9v/1uc99LpeUv//9739cn3/Pe96TS8q3bduW53meX3fddbmk/OMf//he23U6nXxsbCy/8MILH3dbL7zwwvzlL3/5Yx77Z1133XX5VVddlX/0ox/Nzz777Pztb3973ul0HnP/J5544kG1DzhQ1JwD9/OsOXme55s3b86//vWv51/60pfyt7zlLfn555+fX3/99Xttk6Zp/ta3vnWfz37zm9/MJeVXXnnlfvftas7atWvzl7zkJfv8+X333ZdLyv/6r//atvuyyy7LJe3TVuBgUbcO3GKeK/00d55FauHP+va3v52XSqX8Va961YGfCBD4Ra9F//Zv/5YnSZLfeOONe/5MUv47v/M7j2t/ef7zn0M9an5+Pj/ttNPyiYmJfOPGjXbb888/P1+2bFne7XbtdtEcSlL+lre8Za8/f/Ob35xLyu++++79fu4nP/lJLin/vd/7PXvspwv+aduT4J/+6Z90yimnqFaracmSJVq2bJn+5V/+Rbt3795n25/+tp5HHXfccVq3bp2kR1Zn8zzXu9/9bi1btmyv/97znvdIkrZu3fqkncu/+3f/TlNTU/v9OsbH48EHH5S073mXy2WtXbv2ce/3i1/8oq677jr91V/9VeHPnH/++XrRi16kt771rfrXf/1Xffazn9W73vWux90G4FCh5jy2J6vmPGrFihX65V/+ZV1yySX62Mc+ppe//OV6wQteoM2bN+/Zpl6v7/V7kB716I9PP54fRz/Yfb797W+XpCfsOgMHirr12BbTXOmnufMsUgt/2l133aVXvvKVOumkk/TJT37ycbUHeCI8FWtRr9fTf/pP/0n//t//e5199tkHvb/H8mTPoSSp3+/rNa95je644w5dccUV9htl77//fl1//fV69atfHf60o/PoHOmnf4pSeqTGSXrMb8D73Oc+J2nfX/L9dMU/bXuCffazn9Vv/dZv6eKLL9Y73vEOLV++XFmW6f3vf7/uu+++A97fo7/46/d///f1ohe9aL/bRP/+/GAdccQR2rlz55N6jIP1jne8Q5deeqkqlcqeYv7oL3hcv369Op2OLUwTExN63vOep8997nP64Ac/+HNoMfDEoOYsLpdccon+6I/+SF/5ylf2/P6RlStXatOmTfts++ifudr0WFauXKmNGzc+7n0++uPoT9XrjKc26tahcbBzJan4ee6vFj5q/fr1euELX6ixsTF97Wtf08jIyOM6H+BgPVVr0eWXX66f/OQn+od/+Ic9Y/lRs7OzWrdu3Z4vElrsLrvsMn31q1/V5z73ufCfiz36LbcHu5CzatUq3X777VqxYsVef758+XJJ0q5dux7z+Mcff7zOPPPMgzr+LwoWkp5gV1xxhdauXasvf/nLSpJkz58/ugr9s+655559/uzuu+/e820Xj672lstl/fIv//IT3+BAnudat26dTj/99Cdkf2vWrJH0yHn/dLHodrt64IEHdOqppz6u/a5fv16f//zn9/oa7UedccYZOvXUU/f7S/N+WrPZ3O/fPgCLGTXHe7JqzmNpNpuStFctOe2003TttddqMBjs9Qu3b7jhBjUaDR133HEHfJxHf1/BzMzMXr+r5IYbbtiTO/fff7+kR749Dvh5o255i3WudCDnub9aKEk7duzQC1/4QrXbbX3zm9/c7+96A35enqq16KGHHlK329WznvWsfbLLL79cl19+ua688kpdfPHFB3WcJ3sO9Y53vEOf/vSn9eEPf3ifnw7an89//vM6+uijdd555x3Ucc8880x9/etf3/PLth/16O+X3N/c6IYbbtC9996rP/uzPzuoY/8i4Z+2PcEe/eVg+U99TeoNN9zwmD8i9z//5//c62+Vb7zxRt1www16yUteIumRldGLLrpI//AP/7Dfv9Hetm2bbc+BfI3k/vb1sY99TNu2bdOLX/zi8PNFnHXWWVq2bJk+/vGPq9Pp7Pnzz3zmM3t9Reyjin6N5JVXXrnPf4/+4sbLL79cf/3Xf71n2/39SOm6dev0zW9+U2edddbjOCvg0KHmeE9Wzdm+fft+vw770X+i8dO15JJLLtGWLVv05S9/ea/Pf+lLX9IrXvGKPb+M80Bccskl6vf7+sQnPrHnz9rttj796U/r3HPP3fMTRzMzM/v8E7g8z/W+971Pkh7zb0yBJxN1y1sMc6Wi53kgtXB+fl4vfelLtXHjRn3ta1/b7z8TAn6enqq16DWvec1+x7MkvfSlL9WVV16pc8891+6jiCerFknSX/7lX+qDH/yg/vAP/1Bve9vbwu1vvvlm3XnnnXv++dnBeNWrXiVJ+/wy9U9+8pMqlUq66KKL9vnMowvwT8Txf1HwE0mPw6c+9SldddVV+/z52972Nr385S/Xl7/8Zb3yla/Uy172Mj3wwAP6+Mc/rmc+85mam5vb5zPHHHOMLrjgAr31rW9Vu93Whz/8YS1ZskR/8Ad/sGebv//7v9cFF1ygk08+WZdddpnWrl2rLVu26Prrr9eGDRt0yy23PGZbb7zxRj33uc/Ve97zHr33ve+157VmzRq9+tWv1sknn6xarabvfOc7+sIXvqDTTjttnx9Lvuiii/Ttb397v5MHp1wu633ve5/e/OY363nPe55e/epX64EHHtCnP/3p/f5b29e97nWFjrO/FfdH/1btJS95yV5fK3vyySfr+c9/vk477TRNTEzonnvu0T/+4z+q2+3qz//8z/faxzXXXKNrrrlG0iPFf35+fs8L2HOe85z9fhMT8ESj5iy+mvPZz35WH//4x3XxxRdr7dq1mp2d1b/+67/q61//ul7xilfs9Td3l1xyic477zz99m//tu644w4tXbpUH/3oR9Xv9/Wnf/qne+23aM0599xzdemll+pd73qXtm7dqmOOOUb/9E//pHXr1u01Mbrpppv02te+Vq997Wt1zDHHqNls6sorr9R3v/tdvelNb9IZZ5xxQNcTKIq6tfjq1oHMlYqe54HUwl//9V/XjTfeqNe//vW68847deedd+7JhoeHD/qnJ4D9+UWsRc94xjP0jGc8Y7/ZUUcdtc9YWmy16Morr9Qf/MEf6Nhjj9UJJ5ygz372s3vlL3jBC/b5Z2dFfj9R0TnU6aefrte//vX61Kc+pV6vpwsvvFDf+ta39KUvfUnvete79vknvv1+X1/84hd13nnn6eijj7bn9rTyc/zF3k95j/72/8f6b/369flgMMj/+3//7/maNWvyarWan3766flXv/rV/Dd/8zfzNWvW7NnXo7/9/y//8i/zv/qrv8qPOOKIvFqt5s9+9rPzW265ZZ9j33ffffnrXve6fGpqKi+Xy/lhhx2Wv/zlL8+vuOKKPdvs77f/P/pn73nPe8Lze+Mb35g/85nPzEdGRvJyuZwfc8wx+Tvf+c58ZmZmn23PPPPMfGpqKtznY30byEc/+tH8qKOOyqvVan7WWWfl11xzTX7hhRfu89v1L7zwwvzxdtPHOvZ73vOe/KyzzsonJibyUqmUr1q1Kn/Na16T//jHP37MfezvvyLXFDgY1Jz/a7HVnO9///v5pZdemq9evTqvVqv50NBQfsYZZ+Qf+tCH9vtNIjt37szf8IY35EuWLMkbjUZ+4YUX7vebZA6k5jSbzfz3f//386mpqbxareZnn312ftVVV+21zf33359feuml+ZFHHpnXarW80WjkZ555Zv7xj388HwwG4XkCB4q69X8ttrp1IMcuep4HUgvXrFnzmP3ip+878ET4Ra9F+6PH+Na2xVaL3FznZ69Jnj/yjXqHHXZYfsYZZzzu/f7sNe10Ovl73/vefM2aNXtq3GN94+1VV12VS8r/9m//Njy3p5Mkzw9waRJPe7Ozs5qcnNSHP/xh/c7v/M6hbg6AX3DUHABPNdQtAIsBtQhPFn5HEg7YNddco8MOO0yXXXbZoW4KgKcBag6ApxrqFoDFgFqEJws/kQQAAAAAAIBC+IkkAAAAAAAAFMJCEgAAAAAAAAphIQkAAAAAAACFsJAEAAAAAACAQlhIAgAAAAAAQCGlohsef+YKmydJ2ebd7iA8RnuuZ/O84z+fZr4N1epQ3IaFBZv3Wy3fhn7f5sN1f/y1q5f4DSSN1fxONm/eZvN+339RX5JkNq8M+VyS5uaaNm93/T62zPvr3O0lYRtS+f4QfWFhqeTbGLWgyBciJonfS5TH+4/XitPgGGnm93H/xvUH1KYnw8lHR/XJn0OWFulPB7fuHt/KuEb2er6+RMcYrtbCY1gFLkEWXOsk2Eme+3PsD3yeZXF9KmXBoy8Yu52gDdHni4i6ZL/vNxgE9yofxG3s575PhjUuOIeHd+wO2zDo+nlBPajT922dC4/x83D06IjNm8G1ng7mHpKUB8/uJLohUQkKngWSlAabZAqeu0GfSga+keUCz7xKyW8zOuav49JJ/7w56sjjbd7rz9tcktZvus/mc7N+rrpti+8vs+2ghknKgyI0CGp1L6iTefDA6gd9RZKWL1tm8zNOPMfmo8N+XM434/oxM7vD5jt2bLH5TXfdGx7jyTYx5u9FrebnDkVmqlH5WDY+avMlY/4dLkvi/lKrVWw+tcK/g9Urvja05vwzrdWctbkkZcE8rdwYs/mOaV9fHtiw3ebz822bS/E8q1yO1gT8c72IarVq8+j9qTbq+1Or7a9Dkbnmwryv0+s3+vf1Qe7PodeLr2Op7Oe73b5/pi7s7tqcn0gCAAAAAABAISwkAQAAAAAAoBAWkgAAAAAAAFAIC0kAAAAAAAAohIUkAAAAAAAAFMJCEgAAAAAAAAoJvgP5/2r2/Ne/lYKv2ev0468aVfC1rdHXCUZf8d3r+nOQpHYn+Jq74Dwr8ud53KqlNj/t2CmbS9LyiUmbN9f4r69st/xXGm7a7L+OcGTY3wdJmgu+4TIb8+f53Xv9V8rf9/BM2IZ62X/NZ5pF5xF8F3LwTaNp8LWNPw958JXSkjQI1pOfCqvNWfC9slnwde9ZgVsVfbNsdKmT4Huxs+CruyWpVPJ9thfU6UHw1dnR16mmBb5eN/xW+eA6lYKvc68GN6tU8eNekoaG/NfnBt9arU6vY/P2fPyV0YPgWRF887b6fd+f+sEzN/i4JCkLR79v5Gzw9bn9XlyfhoL+UC4d+jpbRNb3AyMP5idp8PlHNvLbpNGXdAe3YxDsX5IUPPfyYJ6WB8eopL6Rw/Hw15qV4zY/89TVNj/+mafY/FnPebHNp6c321yS7rnz+zbfsdV/pfydt66z+d2bmnEb1vtjzAbfEp4Ez9086E7ZIP5q61rJHyMJ+svcgp+s7trlvypdkmZnpoN9+HwxGB2q27wUXOfo3UiSekG9j6pLu+1rZLXAs2B+vmXz/sAfI5pjVSoNm6eZn2NJUhrNgarBMcb9vZreFcxPun5+I0nl4Cvlh4L+1AvmWFHtkKQ8+Nr6JJgrdjq+gGV9X3+iOZokjQ7VfD4yZPOFlu+vWdBXJKmU+m3SJJ6H2c8f1KcBAAAAAADwtMFCEgAAAAAAAAphIQkAAAAAAACFsJAEAAAAAACAQlhIAgAAAAAAQCEsJAEAAAAAAKAQFpIAAAAAAABQSKnohmkSrDllPk/6g/AYWdk3J+kkNu8P/DF63X7Yhlq94ffRXPCfr1VsPlwt2/zww6ZsLkknn3mKzTfde4fNuwv+HCr13Ddgdtrnkuptf63rE1XfhrK/Tv2giZLUy/1GQxV/r2r1ms3nds/aPFGBRj7JBoO4z0t+3OT54l9vThJfGxTci+jTkpSlmd9H6eCuU5FPZ4k/j0x+3EQ1MOv2bF4N6tsjbQgkvr9lZb+HiWVLbH788c+IWqBjnnGCzXfPzdl886b1Nr/zR7eEbWjO+vqhNLhOfd9juj3fqzPFtaE/OLg+3Znz51DK45GXBWO7/xT5+7BB8DzqB3lUwwptEVzLqIwmwRxLkvIkqADRXDH1ZzHc8M/l55xxvD++pBOPXG7zE05Za/MzznuuzZeuOdHmvd4am0vS0ccutfk9P7rR5hMVP8c6fDpsgvT92218y10P2nwQPI+i94K0QI1qlHx/W//gvTafnvG1fsnERNyG4SGbN9vNcB+H2vLgPMfGxmxeKsWvk1t27LB5v9ux+cL8vM2DV8RHBPO4drdl80bFn2et4q9TeWjU5o/w46Ja8ic61GnbvLfSz/PGiszzgnE3Pj5p837ir+PuWX+vJWnXju02b877e7nQ9dep3enaPM/j5+HQ8LDNaw1/HZodf4wkj2tkNC8oB/0p8tSYgQEAAAAAAOCQYyEJAAAAAAAAhbCQBAAAAAAAgEJYSAIAAAAAAEAhLCQBAAAAAACgEBaSAAAAAAAAUAgLSQAAAAAAACiEhSQAAAAAAAAUUiq8ZdmvOfUGfZvnWbxm1e/mNk+CYwSxKpVq2IbBwOe9btfm3YE/B1VqNj7j/Gf7z0tSyTdyqF6x+fBo3eZpuWHzrQ/eZ3NJGqr4+10dH7d5q/WAzZMsvpdRn3z2Rc+x+Yte9CKb/92HP2zzjQ+ut7kklctlmw/yoD9F/S3NwjZkib9XWVa8TBwq5Yo/z1Q+j6+SlGVJcAx/HYPSojwqYJJ8C6Qs2KJc9f0tCQ6QZUWulD/TXnCd6qMjNj/59DNsfs7559hckpavWG7zndPTNl+2fMLmIw1fQyXp4QcfsvmGh3wN7LbbNk9LUW2J72XUJTu9ns3bXZ+Xog4nKU19f2n2opG1OLTlL2aUd+JLJSX+edAP8jSocVn0PJKUyG8zCGpUnvp8+fJJmx91+FKbS9J4w7exUh+2eXl0pc0HZd/GrOr3L0mdXVttvn13MP4zP/6zfD5sQ7c5Y/Mk6E959EwM+lMlmJtIUqPk69juhTmbB+VFS5b6Wi9JpZKfIw2iF4tFoF7157B0cszm07unw2NEJSzv++vUGfj3LwW1Q5LSYA7TaS/4HQwP2bhW8+9XlYavDZI0yIOx3Wv6YwTv20vH/fyknMZz0cjSJaM23zXfsXm/F7/jVZYvsXm77Y+xa3ba5jPzQY2M3r8kpcHzsFLy96pc8eMy81OsQvqdYFwF+IkkAAAAAAAAFMJCEgAAAAAAAAphIQkAAAAAAACFsJAEAAAAAACAQlhIAgAAAAAAQCEsJAEAAAAAAKAQFpIAAAAAAABQSKnohp1Oz+b9gf98OS2Hx0iCPA22yIM8+rwkLSzM2Xww8CeaVao2XzJ1hM2XBrkk3Xrjd23en/GfX3n4UptPDG2z+eYkuNmSauMTNt8217X5zum2zau1RtiGXqtp8yNWr7b5K17xCptf911/H9Y/sM7mkqTcD8FwpTf1fTpJ4j5fLvuxmWVZuI9DrVoJSlnQZZP8CWhEMC7SfnCQ4F5KUjnz9yoPblW/37d5EnS4Vt+PW0kqlyo2n1g2bvNjn3mczY95xrE2X75iic0lqRz0l+XLfY0crvv6s3TCf16SNqxcZfO07G/mQ/fd6z8/8M/sQYHHfz7wfXa22bJ5r9OxeaNSoLYEfVa9+Hm0GLSDuUMelIdSgfqQZX4Al0r+nneD+5UoLpTRIyc6jVrwvNm9e9rm92940B9A0uTJR9n8x7fcafNBxc/TzrxgyublRjwfvv/+LTbfst1P9I5avdLm3aGFsA3da260eTQfToJOXU59f0xyX8MkacPmTTZv932HGx4N5qrbdoZtGB4esXm9Nhzu41CrVv1ze/OWh23eWvDPAkmqZP5+ZzXfhvA9tMDPRqTlms17wSQqzXwb+33fxl7u320kqZv7eVat5Pt0qeTrSxrcqmow95Ck3XPzNn9w81abtwf+XlUK3MsVE5M2rw37ez0TzF+2b/djf35u1uaS1O35/lAK5i+dju8LzU58nXo9P4fKC7zTO/xEEgAAAAAAAAphIQkAAAAAAACFsJAEAAAAAACAQlhIAgAAAAAAQCEsJAEAAAAAAKAQFpIAAAAAAABQCAtJAAAAAAAAKKRUeMt+ZuMk+HjeHYSHyHK/lzSt2Lzfzm3ebbfCNiSDns2ztGzzgfx1emDdBpvv2L7T5pI0u9Nv881v3GzzC551us2XT87bvNn2uSRVJo/yGwwvsXFn4M+hUorXQNOK7y933n6HzR+4/wGbr159hM0r9arNJSkf+HGRBmNCCvp8Ho+7JBi9Sbb415sHfX8dKiXfF6KrXEjet3EaXMYs87VDksolX7LbbV+/ZnbN2bzaqNl86qjDbS5JK1essPmRRx1p8+NPOMHmK1b5/U8uXWZzSWo0RmyelXydX5gNrmNtW9iGTq9t85POONvm5dqQzR+463abD3odm0tSUvJ9stX1fV7BuAx2L0la8F1aT9DoffIlvgDUgj6XJPF5ZkGRKQU1phl8Pi9wvyrBc7cStGF01Pfr8VFfA+d8l5Mk5aMTNj//+FNtftRRR9t8tOHvZak+bHNJOvWU82x+3OFLbb5tg5/ffO/B68I2NJaN2nx8xg/O2Wk//yiX/BwpzeJXlGbXz0fzoNPOzizYvNeJO9Tu3b4NRcbuodYL5pqttr+XBS6TSsF8tFTybchzX1sGBdpQGWr4NtT83ECJb0Ov698zSz0/d5CkWtWPi9l5P3dIgveCctnX+UESPNcltXr+XraC5/bKFVM2f97Z54RtaM5N2/yeh++3eRq8ys7tnrF5t9v1O5AUvYElPX+to3lBK7rQkpJg3aJW4F3VWfxviAAAAAAAAFgUWEgCAAAAAABAISwkAQAAAAAAoBAWkgAAAAAAAFAIC0kAAAAAAAAohIUkAAAAAAAAFMJCEgAAAAAAAAopFd5y4OM0S2yeBbkklVPfnIWFts17neAYg37Yhizza2tJkC80mza/d91DNl+/aYvNJWnTrt023zi90+adsj+H4eUrbT42NW9zSTrzwpfYPJk42uZf/e5PbJ7nQYeUdNxxa21++OGH2/y7133X5lu3bbP50MiwzSVpfmbW5qU0s3k/uA7R5yUpyfy4S5J47B5qlZI/h0olKnXxOQ4GQZ8L4nJwiFLYRqnT9jVsy5atNp9t+hp69inPtPnzXvh8m0tSd2HB5qtXr7b5sSccb/Ph0RGblysVm0tSpd7wxxjyx6hUqjZvd/11lqTa9prNjzrmGJuPjE/avDHs688Dd9xqc0lamPe1vtnq2rwczQuUh21IghLW901YNGpBv4zqbJE6nOf+ekb7GG74caH4caJytWzz8VHfL2s138Ylk3WbD4/6sSlJ23bvsvnSoEYtW+vnFgvBs6A5Pec3kDQ6usLmtYavH+s2bLJ5qe7vkySdcupRNm+3ejbvdfx1zoNnalKgw9XKQ36DoMQM+r4NvU4rbEO37Z95na6/TotBcCulku9vaYGfS0gTf5A893lUv0pZ3F9GRn1/GRketfmg17F5UvIdrtyMx36j7GvYbM/PFXfM+ffQJUP+OpdqwZiSNDI+ZvNlZf8sefXLL7H5ccH7mSR974ZrbT6zw79fbd05bfNWMG67nXhc14NnajLw/Sl6ppcqcR3vtv0kaRC9vAT4iSQAAAAAAAAUwkISAAAAAAAACmEhCQAAAAAAAIWwkAQAAAAAAIBCWEgCAAAAAABAISwkAQAAAAAAoBAWkgAAAAAAAFAIC0kAAAAAAAAopFR0w/6g7zdIMx8P4mOcePKJNv/RjbfbfKG7YPNaOT7dQb9n8zT1a299JTYfX7LC5lmlYXNJWrVyic3f8JsvsfnRR66yeXNht81rS9fYXJJWHHOKzauTR9r8l1/8Mpvng3bYhtWrV9p8fGzc5r1+0Gkzf68vaj/Pf17St/7t32zebfrzrKRlm+cl30ZJUuL7dJ4XGLyHWKlU8RsElyG4BJKkeq1q8yz3n+/3Ov7zQX+SpIU5X+Pmp2dsvuywKZufe/45Nh8ejutTM8irw8M2bwyP2HxycmlwhLi/ZsG4if6KJcn8825oaDRsQ73hr0MWPDTzCX8vlk8ts/nMjug6Stvv8f2p3fb1qVby10nlIJdUTvzA6vb9uFos0qDPZMHcIkkK1PJAtI80823IglySajV/nksmfb9dstyPi5ExX+vHxnydlqTlh/m5gYbHbLxhp58jfeta/1y/7/6N/viSnv2sX7L5eeecZvPSmJ/ntXvdsA1Tq/x1OOlkPxdcmPfPq5nd/r0i7xV4MOe+lieDoI6mfkzkefBglzQYBOMqievcodZuztu8P/DXoRzVesU1sNfz71/Re2itEjzXJc3P+7G7bt2czddOTfo21IJ3SMXvLoOmf1etJb7GHT7l3zO3bfyJzTdu89dIkrLU1+lnnXK4zc879XSbP3jvA2EbHnzoYZs/vGW7zbcH9akfLJEkBfp8b+BrWLSmkAVjppTH84JSP6hhcYmz+IkkAAAAAAAAFMJCEgAAAAAAAAphIQkAAAAAAACFsJAEAAAAAACAQlhIAgAAAAAAQCEsJAEAAAAAAKAQFpIAAAAAAABQSKnohlkps3m317N5u9sPj7Fy5Uqbjzx70ub/9n+utXm33QrbkPnTVJYmwQZlG594yuk2X7XmGL9/SYNG2+ZTE/7zc7t32nzdJp+PTp3kDyCpVxm2eb3SsPkRRxxu84q/zJKkar1i86zq87zr+/SSZcts/uKXv9TmkjQ7N2vz73z72zbPSv5C5BqEbVBeYJtFLi37gRuN61KBSpgE1zJJ/Lp8JThItxfXyJlZ31/6eW7zcsX3+U7H15aFuQWbS9JRxxxn87XHHm3zsfFxmw8GHZtXS/4cpfg8oydFmvjnQL1RC9tQb/ga2G35e7198wafb3nY5kuWL7W5JM3ffrffIHjuDwfnuJDHfb6f+m0atWBwLxJZ6utDFhSpJJp7KK5BadCG6Aj1Ag/eFctGbT486vdRqfj7PT5Zt3ljNB57Q+O+jWOTfi46Pe3buOXhLTbfvOEhm0vSts1H2HxhYa3Ny3V/nRdavgZKUjuYAx2+eoXNB7nvUffdvdHm27bN2FyS2s2u36Dj25AEtXzgH6mSpDwa20+BKdaqCV+rOx3/3F1oNsNjpFk0Nv0cKQ9uxmAQX+hmy89hFtp+H9uCOj2yytenuV78Hpq0fRv7qR/bR0/596+50pjffxI/U4eHfRtOPdG/w7Vb8za/8977wzbc9cCDNt/W9MdYCNYl0tyP6yLDuhfM67Pgx3lKwXtDJZ4WKA/uZ79foMgZ/EQSAAAAAAAACmEhCQAAAAAAAIWwkAQAAAAAAIBCWEgCAAAAAABAISwkAQAAAAAAoBAWkgAAAAAAAFAIC0kAAAAAAAAopFR0w0SJzZcsXWbz7sJCeIzvfvc6m593xrNtfsQRR9j8/nvvCduQZZnfIPfxkmXLbX7W+efbfMXqY/0BJFWmJm2+c9PNNp8e+Hux/JjzbD66+nibS9IgWKMsl/x1LuU9m+/atTtsw6lrT7f5wry/Ds3mTpv3er6NIyMNm0vSLz3rl2x+803+XnZaLX8AP2wlSWnq70WWLf715iTr27wU9bdg2EtSPggGfzo4qDZ0ev4cJKnZ7voNSr6kTyxbavM09fd6fHTMH1/S6Oiwzfs932e7bT+2s0rZ5oMkvo67du2y+fSMrw31mh/bSR63YdCPtvH3cseOaZtvfniTzVcfeVRwfGnVypU2n9ngj9GoRgUonoJkuR83ST8Yl4tENLfIgrEbjU1JShJ/vQ82T9P4gTI3N2PzfjA+q8Mjvg2lUZu3O/Fcc8OGDTbfutnXh1p53OZrDzvcfz6J++xQ1efbtj5k8wcfutfmWerrqCSVy36b+flZmy80p21erfvrsGRZPIfauX3O5v086LN9P67C576kPPfbDBb/FEpTk/7ZPjPn7/VQNa7lLfkaONds2nyQ+XtZKjBXrdUqNm/12zbfvnPa5qum6jZv94I5nKRMvg2Jn2pq0PRj4uQT/btRdXlcQ6eW++uYZv48r/3B9Tb/xvV+PUCSHtjm5x+DUlDjen7c9jrBHC0Y95KUD3yfbff9deoF7wVpFo+7chK9/wQdKvAUKG8AAAAAAABYDFhIAgAAAAAAQCEsJAEAAAAAAKAQFpIAAAAAAABQCAtJAAAAAAAAKISFJAAAAAAAABTCQhIAAAAAAAAKKRXdMKv5TacOW+l30OyFx7jjpjts/i//8r9tXkmrNq/XfS5JSRJt4dfesiyz+bevuc7ma485LmqAzjnjRJvf8YMbbV5Ol9j8pFPOt3k/9ecoSXlwHaIlzJ0bNtl8dMlY2IZquWLzpOE/P71rh823b99u88ZQcABJRx19jM2POGK1ze+6806bl8vxvUqDPl+plMN9HGqp/EkkwcBOk3hNPSn7fWRpUBuCz/dmB2Ebej2/TS5/v9Oyr+PRdRoai/v05o0P2vzHN/txc9SRq2z+jGcea/NKMO4l6ce3/Njmt936E5uvWDFl81NP8TVakmoNfy3b8ve608uDvG/zRnB8STpq9RE2X3+rrz/91J9D+LiVNOj48ygncY1bDLKSH3vR3KGIaPyWgmNEn1eB50lp2J9nfcLfz+pIUKMy//lKJZ7nLcwv2Pxr//JFm5912nk2X33YiM1XTvrnviTVR4Zs3p1v2nznlp02r5Tj65Rmft4ezS/ygR//u3bttvns7vi9QQN/HuVg3A3k6+ggKdCGoJJlxV+1DpmZZsfnCz6v1erhMZKBH7ulYH7S6/o2lEpxfSpnwVwveNdtNVs237Hg9z9eq/njS8pKftx0O/4879/YtvnxK/zn68PxXHTp5LjNb7vzNpvfvu4mmz+wcWvYBiXB2G35sZv1fV4N+kI/mGNJ0iDo872uv9blzLeh3fb3WlLwViBlwTEi/EQSAAAAAAAACmEhCQAAAAAAAIWwkAQAAAAAAIBCWEgCAAAAAABAISwkAQAAAAAAoBAWkgAAAAAAAFAIC0kAAAAAAAAopFR4w1pm84Vm0+bLGkvDYzSqIzavZDWbz8/M2LxaqoRtSKI88Wtv23dst/k3/+3bNj/11LOCFkgnHneMzeea/jwr5bLNk6xu85Fhn0tSeWjI5rs2bbb5HTfdavN/f9lvhm1oVKs2T/Lc5pOj4za/5+57bZ73bSxJWrnyMJufeabvDw/c/4DNg1tdSKXyBOzkSVYq+/qUpv5ey3/8kWOUgusQLMsPNPB57nNJand9pxodH7f55NLl/vMTEzZfvWa1zSXpJ3f/xOZf+dq/2fy8s061+aojDrd5VooH3sMPb7X57bf5sb19+7zNh4b9s0qSnnnCiTbvB/Wp0mjYfNlKf51GRsdsLklzM7ttPrHU95fN23cERwjGpaQs89skSbyPxSBNfYGI8iKyYB9Z5gtdEny+UvfPVEnq5V2bz861bD458P26VPJjq1yK21hq+Knv9h0P2fzb1/r6ceIxJ9h86eQym0tSte/r2NRKX4uPOc7n9z70g7AN0RxpxYoVNm8tBH1hxp9jOfOfl6Ru08/aB62ez5MgH8TjsteP9hE/2w+1XdO+1kf6g7gOtzp+7JfL/t0lD+b0nW7cX9KgBlaCY0RanY7NG5P+PVeS1Pfzi+gsm23fH2fm/b1atnRNcARpdmbO5ps3T9t895w/xyI/5hINq+h9PUl87eh22nEjApWKf14liX8WdTv+XpZL8TJOtxfUp348bhx+IgkAAAAAAACFsJAEAAAAAACAQlhIAgAAAAAAQCEsJAEAAAAAAKAQFpIAAAAAAABQCAtJAAAAAAAAKISFJAAAAAAAABTCQhIAAAAAAAAKKRXdsFLym27a8LDNd2tneIxjjz3O5qefcobN/9eX/6fN281m2AYpD9KBzRuNqs3H68M273ZaNpek733vBpvfduttNj/11FNsvmnzVpsfe+IJNpek4UHZ5v9yxVdtXqn5/nbMyXEb2v2OzWdnZ21eq9eD3N/roWF/ryVpbGzM5meddZbNr/vOd2y+a3pb2IZyKQtyfy8Xg2olamPfpkmWhMdIo22iZfmBv87ttq89ktRs92y+amTE54evtvnIiO+Pw8NDNpeklctX+H0E46ZS9Xl9aNzmu6dnbC5JjYa/Tg9v3m7zhzb6fHKiEbbhsJWH2bxa8TVwaGjUf354ic2bXT8mJGk0qE8TS/x13LndX6dSqRK2oSo/bjrxsFkU0tQXiCzIkyCXpDTxNSpqQ5oF17rdDdvQa87bvD7s51A7ty/YfKjh9z8+Hk9ra/VgbI3558n4qJ8bDNI5m++a8XMTSVro7rL51jk/5773wQdsnqbxwBkM/L3avHmzzbOyv84T4+M2X5jbbXNJGnR9G9NgauA/HV8DScqCcdPvx7X2UOv3/Xlmma8draYft5LUy/38Jeov5WCeF9UvqUCNDPKoDd2gRtZr/rktSfMz/l11MPD14/A1fg42MbHS5uMr/TxRkqa33Gfzo49/hs0fmv6hzQsMO5WCdYnofT5J/Ljs9fznez3fnyVpMIi28f1tkPs2xNdASoOxG1fBYP8H9WkAAAAAAAA8bbCQBAAAAAAAgEJYSAIAAAAAAEAhLCQBAAAAAACgEBaSAAAAAAAAUAgLSQAAAAAAACiEhSQAAAAAAAAUUiq6YWeh6TcY+DWpbdu2hsd43nnPs/n55/+Sza/5t6ttvnlhIWxDGiytVaplmzdbLZsvdDo2/9//+q++AZK+821/25YuHbN5mvrPj45N2Xxl05+DJH3nqqt8/q/fsPkl/+H1Np9YMRm2YWZ6xub9Xs/m3V7X5o36kM3Hx/19kKRqpWLzw1evtvmaNWtsPje3O2xDpeL7dJIm4T4OtSTzeZ74c8gyfw0kKUv9QZKSz3P5fGE+rpG9Xm7zVs+Pzcaw77O7ZuZsfvPNt9hckkbqvr48/6Kzbb7yiCODI/h7maoffF5q1P24W736MJtv2bLd5kcf6cetJC2ZHLX57O5Zm1cqVZuXK3W//7m2zSWpmg58G6oNmw98iVWex/eqlPn7nT9F/j4sCyYXWebrQxrkUjQypCSog2nQxrQUPwsq2YjNy2Xfp6qVcZtnybBvQB7X8okJP3/oDnwd7Lb8XPKu+26z+fjwuM0laZD7e/FwMKcelH1/aVRrYRvyvr9XM7O+Rm3ZtMPmC/P++KUCz+Ve8MwrB8/ttOSfV3nun7lFton3cOh12v55UAquUzl4N5KkSsk/d5OglucKakfV71+SWsE7Wjn151HO/DH6/eCZFozrR/g+WyoF+0h9G5KyP4dW8J4qSaWa7w/1JJgb5P5eFjEY+POMhm70zK1U/Dm2gzEjSb3gPbPfD565wTO7P4ivY7nsz6PXi9dGnKfGDAwAAAAAAACHHAtJAAAAAAAAKISFJAAAAAAAABTCQhIAAAAAAAAKYSEJAAAAAAAAhbCQBAAAAAAAgEJYSAIAAAAAAEAhpaIbJrnPK2W/q2SoER7jBz/4oc2XLZ3ybahUbN7vD8I2NOo1m5cr/jznW02bb922zeYPP7zJ5pJ0wdnn2vw1r3mNzb/8/7vS5v/j8/+Pzb921TdtLkn33vQjmz//gmfZ/KIXXWTzhW4nbEO9Vrd5qVy2+e6ZGZs3Gr5Pj4+P2VySspLvT+Ojozafmlph87t+Eq8Vp5nfptfrhfs45LLExkni73Ul83kR+SCoL2lm42otbkMp8efZnluweRY0sdf3fWHdunV+B5JGfAlVvTZi80ZtyObbtuy0+fz8Lt8ASSuW+2fJc579Szafndlt89NOPSlsQyr/UN28+WGbZ4nvT8uWL7N5a87XN0lqzc7bvDHq72U/8c/kVqcdtqFc8X2+Foz9xSJN/dgK82DsS1JSYJuDOkYSP0+yNJgL5r4I9TpRDfJzpKXLfP2QpFrD19qs7ts4Pzdr80476tfx2Ov1fX3YPTdn827uP19etiRsw3DDX8voXs/P+Xnatq1+PpwP4v7caPh5Xr/p5y9p0Kfz4DpK0iB49h/87OLJVwrmouVq1eb14D48chD/zGq2/PwlH/h7kRSoT7Wan6BE74mlUjBfHvRtfv8DG2wuScuX+msdnUM9mEv2gzbOLPj6JklrVvr6Mbt5s81bbX+vB4P4vSMN6k85WJc42GdypeLvkyR1gjlOqxXUp+Aci7yf9Xpdmw/yg3vH4yeSAAAAAAAAUAgLSQAAAAAAACiEhSQAAAAAAAAUwkISAAAAAAAACmEhCQAAAAAAAIWwkAQAAAAAAIBCWEgCAAAAAABAIaWiGyZB3ppv+QP14zWrjRvW2/z/+eIX/Q76uY2HhxphG2r1ss2zzH9+cnLc5v3ct3F6es4fQNL45BKbL1u2wuZTK1fa/Kr//U2btzs9m0vSaaecbPMX/7v/j82Tsr/QlUHUI6VOPrB5s+X7bLvdtvnGhzfa/Pbb7rC5JC2/aLnNK9WqzysVmyfhyJUGfX+dfI9dHLKSL2Vp4utPHoxLSSplQbkMjpGV/ecnJkfDNqQ1Py7m5+dtfvtdt9l8+eFH+gZ0pn0uaWpyyOazla7NN+28xeaNmq/jy1css7kknXTKGpsfnft72e/42qA07k/bd261eSs4xuyCP0a1PmLzvF+zuSTNTfu81fVtXGj5vNX2fUGSynnwLKgVnsYcUknia3Ga+j4X5UWOEeZZ8Lwo0K/T1N+vasXXh107Fmw+0KzNjz/+cJtLUqPhr+WmrVtsXq36sTMInprNtp97SNLI2ITNSzN+rjjo+uf6UM3fB0kqJX5sbdq6zeYPP+jzpO/33237c5CkUur3Ua74OX0+8McYDPphG5JgDpU+Bf7OPq0Hz4NgXLd6cS1X3787JMEcqlTx+dBQ3KejGtgJ5v29nj+H4eFhm2/f7eubJFUbvn4ctsI/25OgTLea/hyyAt01K/vz3Drnr/MgutcFnjXBlFrBrVY3uJe93sG//fT7vn5UKv4kovpTKzD/aTb92Oy2goWNwOKvbgAAAAAAAFgUWEgCAAAAAABAISwkAQAAAAAAoBAWkgAAAAAAAFAIC0kAAAAAAAAohIUkAAAAAAAAFMJCEgAAAAAAAAopFd0w72Y2b083/ef71fAYw42GzXdu3WzzkZERm4+NjoZtyIKltZK/DKqU/SWtTS23+dKxMX8ASZMTwTblmo3Pe/azbf7c5z3H5mk5vpeHHzZl86kVS20+35y3+ciIv46SND83bfPm3ILNu+22zW+75Vabb9u22+aSdPbZ59o81cDmSTmxeaNSCduQp77T56k/xqKQ+HMol/11SP1lliRVK+VgC18cmu2Ob0M5XtdvDPkamfZ7Nt+y8SF/gOA6NaJLIKkytczm6x7eYfMbv3+bzY895iib/9qlr7S5JKWZr2Erp1bYfG7Gn8POnT5/ZJtdNt81PWPzBzdst/na40+0eXOhZXNJmp2ZtflCUEOzxD8PR6txbakHfbLQ4F0E0qDOHmwuSVnJX+8kqJPRIfIC1zoNnhedTt/mvb7//NLl/tm/ZKmfW0hSnvv5RWvOn+fYkJ+DZcO+UJYL1PpqxdeoaL481PDz3easn7NLUiv37ewu5DbPVLd5Kfi77HLFf16S8tw/dwe5b+MgCfp0MGYkKYn24ZuwKERNbHf9/KUS1WlJpZIf28PDwzaP7mURaXJw89n+wNevtO9r8CCY00vSlu1+/rBqaonNd+32z231t9i4NubffSRpZql/z5yd93PRVsv3pyKDJrqVtZqvoVnP145u0OcHgyJt9I2s1XyNm53188C5ueBeK54X5Dq4McFPJAEAAAAAAKAQFpIAAAAAAABQCAtJAAAAAAAAKISFJAAAAAAAABTCQhIAAAAAAAAKYSEJAAAAAAAAhbCQBAAAAAAAgEJYSAIAAAAAAEAhpaIb9ls9mw+V6jZPk/hQ/a4/xpLJMZtXKjXfhgLLZkni8zTxOwk+rlLQhuFGNdiDtH3HFpvPzTdt/swTT7R5e2GnzSeXLbe5JE2Oj9i8OTdj807HX8lOpxu2odlcsHmr5a/T+vXrbH7H7bfZfPfMvM0laWb3tM2XLB23eaVStnlaysI2lCsVm3cG/XAfh1ol8+eQRWvmBWpDp+evQ7fTtnk/yW0+GtQ3SVq2dMLmCzu227w7M2fzbRs22vyYow+zuSQNjfixf9ddP7L57bffZ/O5WT9uX/byX7G5JI2O+mudqWPzbtdfx17Pt1GS8r7vD7Mz0zbvBP1NAx/3+nENnV+YtfnOndM2L2e+EWnur4Ekqe/vRZ7GNW4xSIMJSBJMPqJckvI8uN7Btcoy38Y8yCUpCeZIpczPBet1/0wbGRq2+cJ80PElrRxbafMs8XPRH/1wnc2f8cwjbb5i+RKbS9L99/3E5qXgub1suZ+nNWeC+iGp7y+DNjw0fVCfr1X9vRz04/eGJPF9utfzjej3/XO90LgrsM1iF51npez7Wzt6Hkk6gFfO/YrqW1LgPbPVatk86i9Z+Lzxz7RKgUuwMOev5Y5pn4+M+LzVXGfzE6dOs7kkTW9/2OZ33vZjm2dZ0N9K/n1ekvrBu0ka9Oly2T9rioz9yMKCfw+M3lOHh32NnJv1c1GpyNzj4OZQ/EQSAAAAAAAACmEhCQAAAAAAAIWwkAQAAAAAAIBCWEgCAAAAAABAISwkAQAAAAAAoBAWkgAAAAAAAFAIC0kAAAAAAAAopFR0w0F3YPNapWbzXqsfHqNSqdp8aKhu8zTNbJ5l8bpZmvi8FORJ5jcoZf6SZ6X4lnR7bZvv2LHd5kni78X0todtvrZnY0lSJbhO5eA6DXL/+V6vE7ZhdnbG5tPTu2x+zbXX2Ly5MGfzh9bda3NJ+u6137L5r73yYpsnwXUqZX5MSFKl5LfJe8FBFoE89/2p3e7avN/3uSRVa77G1YL6FApqgyQdtnqFzXclfnCmfX8vF+ZbNh/EZVxpydfZJUsnbJ5lZZsPj4zYfGxi3OaS1Bj2z5o8KC9pEj1r4nGXJL7Pzs/6exE9Lxdmp20+O+ProyS1274/5X0/LyhX/b3Me/G4G8gfIzjEohHd7yh/YtoQbnEQ6SOivp8Gk6xKtWLzemPU5ju3+/mRJJ1y0rE2f7Ds97Fx/e02L5c3+wbk8Vy00/Ede+XU4TZ/8H7fhrHhybANSyb886ZW3WrzUubHd5L4cyyX48HdD55JaeqfeeG468UT3uixmAx8DVsMSsG7R5T3ClyndsePq+npaZvXG36OlSTxuOoHk5joPCtV/9yN3iHTWlxFR4eHbb5zzl/r2pg/hx1bN9j8h9/fbXNJarWaNt+2dYvN6zU/trPgvUSSFHS5csUfox+9aAaKzPPm5vx7YrO5YPPhoC80gjEhSTNBG/KD/JkifiIJAAAAAAAAhbCQBAAAAAAAgEJYSAIAAAAAAEAhLCQBAAAAAACgEBaSAAAAAAAAUAgLSQAAAAAAACiEhSQAAAAAAAAUUiq64Wh92ObdVs/mjaFqeIzhIX+MJPHrXmma2TzL4nWzNInyPMj9DtICbYgcfvhKm59wwnE237Zth82brY7N77r9dptL0o7NG2y+epU/h+HJ5TYvV7phG2Zmdtn8zjv9eaxf/6DNj1p7uM07nb7NJel7111r83POOtvm5VLZ5iMjjbANee77dPkJ6LNPtlbH99lKydeGSqkSHiPL/NiulKP64+9Vv8C6/sSSUd8G+Tq86+HtNh8dqtt8dmbW5pKU5L7fn3HaMTZf98BGm59++gk2X7HUP0ckSV3fXzrtOZvPzU7bfNfObWETgmGnUnXI5rNzCzZ/6MEHbL4wN+8bIGl22t/vZt/3t+leOzxGZLjipylpcB0XiyScG/g8SXx9KXKMSJoGc6xSXKOSYBKVBfuIzmHXTj82R4bj8T+1/Bk2P+Xkms3vvvsem9ervo62/NCVJJ1/zvNtPrXSzz8+ceMnbZ6tmgjbMFQd2LzT9oOvVgvuRe77dD6I+9ug7583UX+K3itKpfg1KQ3aEM2xFoM0uA7VavQOF59jnvtxFZWvVqtl837f91ep2P10orMsV/w8b3zYXwNJyvv+2V9qjNt8rr3b5g9vvN/mC3NNm0vS8hVTNq8F1yEL70Pcn6J7GY3tLA36S7D/hYV4DpXncZ90ZoI5dyUcl9Ig2EcWLXwEFv8bIgAAAAAAABYFFpIAAAAAAABQCAtJAAAAAAAAKISFJAAAAAAAABTCQhIAAAAAAAAKYSEJAAAAAAAAhbCQBAAAAAAAgEJKRTesJGWbJ8GehkeGw2NkmT9GKThImvk8y5KwDWm0yaBv41wDmyeJX7vrdjtBA6RS2e9j2YplNq/Vhmx+/TXfsvmKZZM2l6R62V/Ie+Zm/DEO99fhmNG4Db1e2+Z3/eQOm08umbD50iDvdro2l6Rtmzfb/OYffN/mxxx1tM3vuuPmsA3zs7M2r1Uq4T4OtVrDtzGqDb7yPKKUZTaP6kuW+XGbJX7/klSvVW2ejo7YvN/x9WvV0UfYfG73tM0laWbXDpsP1fy9uuC8E2y+dPkSm2/Z8BObS1LWn/N52d+L2ZmdPp/1+5ck9f0xKsG463d9DZ3Ztcvmc/N+3EvS7mAfI8FzPRqXu+cWwjb0u/6ZOrvg6/xikQb1IwnGf5LE85domyxoQ1TjonN4ZCMfl8q+FpdSX41zX8K0dHLKbyBp7ZHH23xuxo+toYafQyV5cBEGvo5L0tojT7R5p537Q3QbNt+yeTpsw87tvka0Wv5mVMp1m/eDe9kf+HOU4vlwFtyLQTCnHwx8/ZGkXpCX8vg8DrVS7mtHv+3ns42q72+S1JffR3OhafNez1/pej1uw9CQH7vlsq8/rVbL5lnqa2S15udokjQ756/TSPBcrTbGbb4jeHeZWrHC5lJ8nZpN/w6Xpv45kMfDLnyeKffH6PX93GF+3s/jms14/pIHYz86h07Ht3FQpEaW/DFa3aiCefxEEgAAAAAAAAphIQkAAAAAAACFsJAEAAAAAACAQlhIAgAAAAAAQCEsJAEAAAAAAKAQFpIAAAAAAABQCAtJAAAAAAAAKISFJAAAAAAAABRSKrpha6Fp81q9avOsFK9ZZYnfplTyzc0ynydJErch89vkPf/5/sB/PmpDlsa3ZNAfBHlu827Xn8Q3vvFNm69aNWVzSfqVl73Q5r3gVgSnqGqtFrahPwh20vfXYXiobvNut2XzzB9dklQq+612T++2+THHHmfzfOD7giTVq/5aZorHzaFWrvt7FVWfUtBVJEl5MO4GfZtXyj5Ps7jHDGoVv4/+kM3bI74Nxx7n+9P09m02l6Rdu2b9Bv22jVcuGbd5rezH7Zb19/jjS5rf8bDNR5f4GtcJClSW+fv0/25k437PX6d+v2vzrdt32nxhfs7mktRtLdj8xNVrbL5s6ajN59u+hkpSs+P77Mysv06LRTQ/SdMiTwwvTX2ly4I8/HyBv3tMg3lcWWWfB9epWvFzzeOOXWtzSaoG06yd27b7z2cNm0fz5fpyPy4kaXJ0pc03rF9v80bZX6deMA+UpH7Xj71yFs/DnDx4piaVeP4yCOZ5g2BOnuc+j8aEJGVRLe/767gYlIN3k1rNz7GycvzuMrPga3WS+jZMTEzavBHMAyWp0/XPzegdrVr146pU8vVtbiEedwP5fr9lsx/7nba/ziPDvv5MjI/bXJJm5/z8odnq2LzXiybd8bir1fy9iN6Vo3GZBv2xXC4wzwsMCryjOQXKkxRMs7q9eB5m23BQnwYAAAAAAMDTBgtJAAAAAAAAKISFJAAAAAAAABTCQhIAAAAAAAAKYSEJAAAAAAAAhbCQBAAAAAAAgEJYSAIAAAAAAEAhpaIblst+03q9YfNMWXiMJMhbrZbNa7WazUul+HTz3OdJVva5BuEx7PGLfD6p2LhU8vnNt9xs807XX+ebbr3V5pJ0z70P2HzViqU2f8krXmbz0571S2Eb2m1/HmPDIzbv9Ns2z4IOWwrGjCQ1Kn5cDE+M+nx02LdBvi9IUhL0lyxb/OvN/b7Pg8ustNAp+uJQTn1tKKW+Eb1eJ2xBteb7bL/j2zg7M2fzUtm38Ygj19hckqZ37bJ5v+/Ps9rw/bFc8Xm707T5I9vM2nyh5zvE6Pikzes1Py4lqdoYsnlW8fVjYcHfy2jcLsz6z0vSyJDfx9Il4zav1/05VoJ5gyRNBPmKpQf3zF0s0mJF6KD2kSQ+Hwx8/cjiaZyyYKMk8Q/ONJgJloN5XK8b19Hvfe96m9/yo1tsngRtbAT9fumS5TYvcoxyyT9vKkGd7DfjcRP3J99f8mBCnea9sA2RqD9FbSgHk4N+L25jdIxoTCwG1WHfZ6P3imhcSvE7WmfGz7k77WBOXuA65wPf77Nq1eaNet3ms3P+uTo05K+zFF+n6F04etetBudY5F05kqR+XFYyf4x+P65PeVA/ds/O2Hw+mENVgjlYpeKvoyT1gvoRXetKxdf5djAmJKlS9WN3vBa/JzqL/w0RAAAAAAAAiwILSQAAAAAAACiEhSQAAAAAAAAUwkISAAAAAAAACmEhCQAAAAAAAIWwkAQAAAAAAIBCWEgCAAAAAABAIaXCG5Yym3fbbZt3Wq3wGHnu816/54/Rrth8bGw0bEO5Wrd5Eiy9ZWkSHCHI83htr1bz5znod21+6y0327zeqNp8zfiIzSVpy8bNNv/Rj3wbnnnaqTYPL7OkXTt32HwQ9KdapewPENyqSin4vKRB4sdVdK+lgW9DJR7ig4HfR5Yu/vXm3lzT5vUVE8Ee+uExgu6iQVDAev4yKyn5cSdJh68+yua7t++y+X133GvzhblZmy9ZGl1HqdfxtX7ZCn8O1XrD5o2az+dm/TWQpE7XP6/6Qb582UqbD4JnmSRFm6w9yl+nmR1b/P5bu22eTcV1fPkyf7+HRvy9iB53JcU1Ms/9wCmVoxr5i6Fcimt5kvgLnga1vFLx1zLL/PPqkTb4Y0T7iM6h2/Xzmx/d/CObS9Ktt95m81bTP08i0XXessWPXUm6+aabbD47N3dAbfpZ5fLB96do7pAHz8Q09eO/1wseuo/sxMZRny50jLAJvg3JU2AOpWCu2ev6OVLih2WxJtRqNu8PfBuKzFVrDf/MKgV1Ng3qV6Xs+3QejBlJ6nY64TYHIzrHmVk/D5TisV0N3p/SzLeh246vQRo8jsZGh2ye6+DGfpHasbAwb/NBMFnMMt+n5+cXwjZkwf0eGQ3mcYGnQHUDAAAAAADAYsBCEgAAAAAAAAphIQkAAAAAAACFsJAEAAAAAACAQlhIAgAAAAAAQCEsJAEAAAAAAKAQFpIAAAAAAABQSKnohnm3b/OOfD5Urxc5ik0rWWLzUsmvi1WyLGxBveq3GQwGNs99rCRqQvB5SRqqlf0GecfGleDjjarvFtVa3G0mjllt8+6RR9j8hGceb/NBdKElPbzxIZtnwcWulSr+AKnvj1kaXGhJSdBnx0ZqvgmpP4dKJe7z3bYfu1nhKnHodFo9v0Hur3O5UmBNfeCvU7nk73e35z9/2Eo/ZiRpavky34bU3+/aWNXmGzf4MbNi+XKbS1K/4+tPv9O2+fgKf4zhxpDNoxouSf2e7y+zs7M2by74vF7341aS+n3f545YeZj//Ikn2XzpiL/XI6NLbC5Js62mzXfs2GDz0XHfBsnfS0lS39fhndu3x/tYBEolX0jTxD9P+sHcQ5IqZV+DksT3uTz3c7AsOAdJKpf9Nlnq25AF87QkuE7Npu+zkpQGbSgH1zGSlfw57J6ZCfdxzbXX2jy+Vwd3HSWpF9TJaB/Rvex2uzaP7pMklYJt2sHz6Ino84quU7yHQ266GTzT8uC5Ooifu1nVX4lK1T8vOt1gbhHcy0f24e/V0JB/JjXbfv4SSQr06XqjYfOF+XmbR+dYCs6hE4xLSaoG96oavGhGx6hW4zlUt+PPMw/WFKJ52vy8f5Z0g/74yDH82ker1bJ59DwrFXhBi8aNFg7uZ4r4iSQAAAAAAAAUwkISAAAAAAAACmEhCQAAAAAAAIWwkAQAAAAAAIBCWEgCAAAAAABAISwkAQAAAAAAoBAWkgAAAAAAAFBIqeiGaZL4PPh8lsZrVtWqb86SJZP+GCX/+Vq1GrahFOxjkHdtnshfp1y5339/YHNJGqoFbey3bL5yaonNN0yM2DxJezaXpLTvr0M/qdj8yKPW2HxhbjZsQ3thzub1atnmWdBlsyyzeVpgnbYS9Mk079u8tTBt82rFn6Mk9Xodm1cK7ONQ86NKmp3x/WV0LD7HUtn32UrF38s88bWjWvZjRpKmt260+ez0wzavp74/Vcv+HIIu/8gxan6jbsvfi4V5P24V1FgFY0aS+j1fZ5dM+GdNp7tg8243rpGVypDN2wv+OjUqvj+uWX2kzUt1f3xJGmzbZvMtG/zn54Nb0U/9dZSk6Z27bF5vxOfxVBDNPYrIc18JKxV/jOiZFlfaeK4YPjeDuWJ0jvE5xPvo9fz4LZeDuUN28Pey1/XPi8hg4GtclEvxdYry6BjRdez341rePcjrFI27qC8UUaRPHmqd4N2jkfl7VeQ6Re9og+DZ3QjmWEXqU7Xk60ul4u/Vwpx/vyoH88Qi5uZmbN5c8M/NRr1+UMcvci+jcZMP/HOgEtbQeMw0F5o2b7XaNi+Vojm9P8c0jefsjUbD5kni+2Oz6e91WqC0JH1/jHbH9+kIP5EEAAAAAACAQlhIAgAAAAAAQCEsJAEAAAAAAKAQFpIAAAAAAABQCAtJAAAAAAAAKISFJAAAAAAAABTCQhIAAAAAAAAKYSEJAAAAAAAAhZSKblgrVfyOSmX/+WotPMboSN3m1VLmd5D4OFUetiFT3+b1qj/PLGhjqeQv+WAwsLkkrVg+afNaxR9jxbIlB7n/4EJL0sBvk5aHbX7YYYfZfOu2zWETRoaGbD4+OmrzTr9t8zT11znJfV+RpEbVj6sd27fYfPfMDptn5fhelSt+PTlN43FzqI2MN2w+N7dg89HJpeExShV/r/LEX8ck9fciC8qbJGW575PdhV0273Q7Nq/V/HU8bOUqm0tSu73b5jM7p20+u9OfQ5b4cVepxM+aajDu+gP/HOh0fZ2uVKphG0rBs6LT9Pc6y/y4LI+M2Hx61o8JSZqfmbV5VF02Prze5qPj/lkkSctXrPAbPE3+Oqxcjp8nSeLvSJinQQ0Lapwk9fp+7GRBoUuDNuS57/dF5lDRtYzaEB0jyivBs0SKz7PT9vUhutfRfSgiauPB9sciontVSYM62+0efBuia9nrHfQxnmzR3GCQ+WdanvtxL0ndVjQ2g3ETHGNy3D/zJCkqYYMFP39ZPubfKxrD/t1m807/TJWk6Zk5m2epv05jE/5ejY4ss/nOHdM2l6T5+Xmbtzu+PyWpn6e1O62wDdG6w4oV4zYfBPVr29atNk9Kcf3Kov4WzDWfCFnw7tHtx89M52kyBQMAAAAAAMDBYiEJAAAAAAAAhbCQBAAAAAAAgEJYSAIAAAAAAEAhLCQBAAAAAACgEBaSAAAAAAAAUAgLSQAAAAAAACikVHTD0bFhm1cqFZvX6rXwGFkps3kefD5JfD7IB2EbegN/lLzTsXmWB5c0qfr9F2jjxMS4zRsjkzavNEZsnspfyPhOSr3gZlWD/lAp++s4N707bMP09E5/jErZ5uXEtyFP/XVKCgyvft6z+Z133G7zNGhDKfPjUpKyzLczCY6xGDQavj81F5o2by/0w2PUq74+9Qddm5dL/jp2er4vSNIg6C9KGzZOqkM237Jli823bt3mjy9p+ZSvP6OTvr+1F9o2n5/eZfOFAn1+dMmEzcuZv9dRjVQ/7k+91oLPe/5ZUx3y97rd89dx1y5fHyVpw4aHbF6v+Rp62JGrbT4366+BJCVZcK3TX4y/DxsM/LO/V6A+RPOwJJgkDcJ+G89PSiVfi6Pz7ARzrGrVz6GiayDF17IfXIdqzZ9jFtSPIvcyule1et3m7VbroNuQBmMryqPrGPWFUimeQ0XbtNu+DmZR/Sj5GifF1zKPXl4WgTTos508uJd9P/+RpDS4lmlwnbrB+1mr7WuHJJXK/n6XU9/GyaVLbN7t+etUpD7Vg/ejrOSvQ1Q7mk0/Hy4y5x8EnboanGcejP0ol+I+G9Wf+YVoDubHdXR8SZqf98cI30PLPo/upSS1O8G7STnuk84vxgwMAAAAAAAATzoWkgAAAAAAAFAIC0kAAAAAAAAohIUkAAAAAAAAFMJCEgAAAAAAAAphIQkAAAAAAACFsJAEAAAAAACAQkpFN6wP12yeZZnNEx8/Is2D3K97pSV/OmnQRklSMrDxIFh6S3J/Dr3c77/f7foDSOr1en6D1F+HJK0E+/dt6PT9OUhSP/FtGKqUbT4yMmzzrdsfDtswNzfrNwi6W7nsr1NaidZhgwNIygeJzTtdf60blYY/QJE+H8gH8XkcaknJn+fwsL9Oc7NBX5FUH/b9oZT4e1mu123ejsa1pJ6C/jC+3OYnnODbcMdtP7H5zT+8yeaSdMbZp9h8ZHjU5qWKv87tZtPm5QJ/PTK/MOPbkAWPxn7fxskgHnedbsfmvdz3h3KpavN+17exVPI1WJJWTK3yGwTPy2heUOTvsmam/b0aXbIk3MdTQRLUj37Q5ySp0/F9qlr1faYcjL2giZLidpaDeVq57PvlYOD7XHQNJKkSnGcpaEO/78dmHswDo3Msso9uUD+i61QK7oMU38toLhqN/yiPzkGSusGcObiMShJfgwaD+LncDfrcIGrEIjAYBPc6qPVpw48pScpKfh5WLfs+mcnfi16pQIEKbsXI0IjN55r+Xnc7vj9G76mSNDk5afN6w9ePbrdl8x07dtq834v7a1THo/ftVsu3cWhoKGxDJxj709PT4T6c6HmYF6hPUYdrNts2j+pTJ+hvRfQL1DiHn0gCAAAAAABAISwkAQAAAAAAoBAWkgAAAAAAAFAIC0kAAAAAAAAohIUkAAAAAAAAFMJCEgAAAAAAAAphIQkAAAAAAACFlApvmGUHlWdZfKjE70KJcpun6vsd5EnYhlLZr62Vy76RaXASaer3n5bi67T54YdtfvP3r7f5D274jm9DcJ0VXANJGiT+PEcnx/whqv4Yg343bMPocMPm3cG8zfPEX4ck7E7BdZSUVvx1qteG/A6CRgwU36s8aOYgGleLQB5c66GxEZvv3NIKj9Fpdmxebvj+lncH/gD9IJeUlCo+T3z9WLp0mc2nVs3afP2DG2wuSSeccqLNK5W2zTttP7b7PZ9X6nWbS3H9aHf9ve63fT7fLzBmgoGXlKIHoh/7edCdsqCvSFK94etPp9e0ea/rr3NjKKhvkjodfy3nZ+bCfSwG3Y7vM9HcoFrxY1+SkqBP9Hq9g/p8rcDYKmUH9/eTg4HvuOVy2ebRORQ5RtRvs2CeFt3LfpH6EEjTYE5e8vWlSBui61TkWjtRfyzSxqgNURPbneh55PMiBk/A/X6ytVp+DpQG73ijI35OL0kjY37+UQmOsTAzbfNWL75X40N+njY0Mm7z6ekZm3eD/pRWqjaXpFbLP1fbHT+2SyVff7Lg/SwtxeO6GfSXajU+T2d+3r+fSVI5fCb68xzkflwOBXP6nbt2BMeXej1fQ0vBsyQP5onRuJWkXMHzLtyDx08kAQAAAAAAoBAWkgAAAAAAAFAIC0kAAAAAAAAohIUkAAAAAAAAFMJCEgAAAAAAAAphIQkAAAAAAACFsJAEAAAAAACAQlhIAgAAAAAAQCGlohvWSn7NqVwu2zzJkvAYifJgA7+PSqli81I5Pt1yObN5FlyHJGij5PM0i9u4af1DNv/C5f9fm5eCezVRq/oGxLdStaq/FxMTozZ/4L67bJ6qH7ahUffn0Ww2bd7pdm3e6/RsXg+ugST1en4fSgc2TjJ/L/PEf16S8mDYZQX65KEWtbFc8feiNtQIjzE7u2DzkZERmyeZry39+Fap127bvJR0gjb467ByaoXNZ3fvtrkkbdu2xR9jxYk2r1X92O71/IUKx5SkXVu327w78GO/3fT3oR3cJ0las3q1zWvloNCm/jxHhn1/nJmd8/uXNNfy9yIr+T6t4JmeK/q8NLF0mc23b/P3crHIg0Lb7/trHT2PJKkSPNvT9OD+7nAwiJ+7gzSY4wTXYTDw4zu6TtFcVIrnQP2ghkTXIbrO0TlKUp4Hz/4kmIsG9yEZFJiTh/NZr8h5OqVSPPeI+kM3uJfRuCxyDaJnzsFeh5+HtOJrcdRdkmo87gZBn1U01yz5Y3R68XM3z3wb2t3gXgWf7wcvSJ1Wy+9fUqnsjzE355/dY2PDNm93/HUaHh6zuSTVG3WbzwXzi2iOlBYYd8PD/jzTUZ/vnpmxefTeUOTdKM99bYjm/e12MBctMNdMo3ePAu+Jdv8H9WkAAAAAAAA8bbCQBAAAAAAAgEJYSAIAAAAAAEAhLCQBAAAAAACgEBaSAAAAAAAAUAgLSQAAAAAAACiEhSQAAAAAAAAUUiq6YaNWsXmaJv5A5XLcmCwL9hHkJX86aRqvm/mzkPLo84nfQ5RnBdoYXada0Mp6vWbzNInaUKSN/n7v2rzJ5g8H/U1ZdKekesVfp/rYmM13Tu+0eb/XtXmaRr1FKgWbJMG9jLpLlvhrIElJgT636AXn2R/4e1WtV8NDzM7M2bzZ8ccoVf0x+oO4v2jQ9/soBfe737FxqeTH7cpVq/z+Jc3snrX57KzPR8dGbF4f9vmuHbtsLknrN663efSsqQ/VbZ5V4jE1Mj5q82rN34t6xT/vKpVhm9d2+/omSYOdvk8m6cE9s3u9An0+8+c5Prk03sciMBgMbJ7n/lr0+37sS9IgmBtkQR7pBzWuiDSapwVzpH6n5z8fzuKkrBLMR4Nndy+4DoOev9fVmq8fkhRcBnXaLZv3+/46RWNXkrJg7HW7/nkS9dly8F4QzZclqdfz59kL2hiJxqUkdYPzHBTYx6HW6jRtXi37+UvWj8+x19pt83YveK4GfXYQzX8ktYP60Wy1bZ4H7z8FLkMoS/y4a9T8u0u75ftjlvh72Q2ukSQtWemfu92u708LPlatErwDSlLPj+2Rmr9XlcS/C3e6vsYun5y0uSRt3LzF5s2mvxBRjVyyZDxsQ7Plz2Nm3vf5yC/AGyQAAAAAAAB+HlhIAgAAAAAAQCEsJAEAAAAAAKAQFpIAAAAAAABQCAtJAAAAAAAAKISFJAAAAAAAABTCQhIAAAAAAAAKSfI8zw91IwAAAAAAALD48RNJAAAAAAAAKISFJAAAAAAAABTCQhIAAAAAAAAKYSEJAAAAAAAAhbCQBAAAAAAAgEJYSAIAAAAAAEAhLCQBAAAAAACgEBaSAAAAAAAAUAgLSQAAAAAAACjk/w9ZkgtfrJ+C4gAAAABJRU5ErkJggg==",
       "text/plain": [
        "<Figure size 1200x300 with 4 Axes>"
       ]

--- a/src/hyrax/config_utils.py
+++ b/src/hyrax/config_utils.py
@@ -201,13 +201,13 @@ class ConfigManager:
         runtime_config_filepath: Optional[Union[Path, str]] = None,
         default_config_filepath: Union[Path, str] = DEFAULT_CONFIG_FILEPATH,
     ):
-        self.hyrax_default_config: TOMLDocument = ConfigManager._read_runtime_config(default_config_filepath)
+        self.hyrax_default_config: TOMLDocument = ConfigManager.read_runtime_config(default_config_filepath)
 
         self.runtime_config_filepath = ConfigManager.resolve_runtime_config(runtime_config_filepath)
         if self.runtime_config_filepath is DEFAULT_CONFIG_FILEPATH:
             self.user_specific_config = TOMLDocument()
         else:
-            self.user_specific_config = ConfigManager._read_runtime_config(self.runtime_config_filepath)
+            self.user_specific_config = ConfigManager.read_runtime_config(self.runtime_config_filepath)
 
         self.external_library_config_paths = ConfigManager._find_external_library_default_config_paths(
             self.user_specific_config
@@ -222,7 +222,7 @@ class ConfigManager:
             ConfigManager._validate_runtime_config(self.config, self.overall_default_config)
 
     @staticmethod
-    def _read_runtime_config(config_filepath: Union[Path, str] = DEFAULT_CONFIG_FILEPATH) -> TOMLDocument:
+    def read_runtime_config(config_filepath: Union[Path, str] = DEFAULT_CONFIG_FILEPATH) -> TOMLDocument:
         """Read a single toml file and return a ConfigDict
 
         Parameters
@@ -293,7 +293,7 @@ class ConfigManager:
 
         # Merge all external library default configurations first
         for path in self.external_library_config_paths:
-            external_library_config = self._read_runtime_config(path)
+            external_library_config = self.read_runtime_config(path)
             self.overall_default_config = self.merge_configs(
                 self.overall_default_config, external_library_config
             )

--- a/src/hyrax/vector_dbs/chromadb_impl.py
+++ b/src/hyrax/vector_dbs/chromadb_impl.py
@@ -190,7 +190,9 @@ class ChromaDB(VectorDB):
             multiprocessing.set_start_method("spawn", force=True)
             with ProcessPoolExecutor() as executor:
                 futures = {
-                    executor.submit(_query_for_id, self.context["results_dir"], shard.name, id): shard
+                    executor.submit(
+                        _query_for_id, self.context["results_dir"], shard.name, id, ["embeddings"]
+                    ): shard
                     for shard in shards
                 }
                 for future in as_completed(futures):

--- a/src/hyrax/vector_dbs/chromadb_impl.py
+++ b/src/hyrax/vector_dbs/chromadb_impl.py
@@ -142,7 +142,7 @@ class ChromaDB(VectorDB):
         Returns
         -------
         dict[int, list[Union[str, int]]]
-            Dictionary with input id index as the key and the ids of the k
+            Dictionary with input id as the key and the ids of the k
             nearest neighbors as the value. Because this function accepts only 1
             id, the key will always be 0. i.e. {0: [id1, id2, ...]}
 
@@ -203,7 +203,8 @@ class ChromaDB(VectorDB):
         else:
             query_results = self.search_by_vector(vectors, k=k)
 
-        return query_results
+        # Return the dictionary as {id: neighbor_ids}
+        return {id: query_results[0]}
 
     def search_by_vector(
         self, vectors: Union[np.ndarray, list[np.ndarray]], k: int = 1

--- a/src/hyrax/vector_dbs/chromadb_impl.py
+++ b/src/hyrax/vector_dbs/chromadb_impl.py
@@ -1,5 +1,5 @@
 from concurrent.futures import ProcessPoolExecutor, as_completed
-from typing import Union
+from typing import Optional, Union
 
 import chromadb
 import numpy as np
@@ -35,7 +35,7 @@ def _query_for_nn(results_dir: str, shard_name: str, vectors: list[np.ndarray], 
     return collection.query(query_embeddings=vectors, n_results=k)
 
 
-def _query_for_id(results_dir: str, shard_name: str, id: Union[str, list[str]]):
+def _query_for_id(results_dir: str, shard_name: str, id: Union[str, list[str]], include: Optional[list[str]]):
     """The query function for the ProcessPoolExecutor to query a shard for the
     vector associated with a given id.
 
@@ -47,6 +47,8 @@ def _query_for_id(results_dir: str, shard_name: str, id: Union[str, list[str]]):
         The name of the ChromaDB shard to load and query
     id : Union[str, list[str]]
         One or more ids of vectors in the database shard we are trying to retrieve
+    include : list[str], optional
+        The fields to include in the results.
 
     Returns
     -------
@@ -55,7 +57,9 @@ def _query_for_id(results_dir: str, shard_name: str, id: Union[str, list[str]]):
     """
     chromadb_client = chromadb.PersistentClient(path=str(results_dir))
     collection = chromadb_client.get_collection(name=shard_name)
-    return collection.get(id, include=["embeddings"])
+    if not include:
+        include = ["embeddings"]
+    return collection.get(id, include=include)
 
 
 class ChromaDB(VectorDB):
@@ -117,6 +121,18 @@ class ChromaDB(VectorDB):
         vectors : list[np.ndarray]
             The vectors to insert into the database
         """
+
+        # Check to see if the ids we're about to insert are already in the database
+        pre_existing_ids = self._get_ids(ids=ids)
+
+        # create a mask, so that we don't insert vectors that are already present in the database
+        mask = [i for i in range(len(ids)) if ids[i] not in pre_existing_ids]
+        ids = [ids[i] for i in mask]
+        vectors = [vectors[i] for i in mask]
+
+        if len(ids) == 0:
+            # no new vectors to insert
+            return
 
         # increment counter, if exceeds shard limit, create a new collection
         self.shard_size += len(ids)
@@ -307,7 +323,9 @@ class ChromaDB(VectorDB):
             multiprocessing.set_start_method("spawn", force=True)
             with ProcessPoolExecutor() as executor:
                 futures = {
-                    executor.submit(_query_for_id, self.context["results_dir"], shard.name, ids): shard
+                    executor.submit(
+                        _query_for_id, self.context["results_dir"], shard.name, ids, ["embeddings"]
+                    ): shard
                     for shard in shards
                 }
                 for future in as_completed(futures):
@@ -324,3 +342,48 @@ class ChromaDB(VectorDB):
                     vectors[result_id] = results["embeddings"][indx]
 
         return vectors
+
+    def _get_ids(self, ids: list[Union[str, int]]) -> set[str]:
+        """For the given list of ids, return the ids that are already in the database.
+
+        Parameters
+        ----------
+        ids : list[Union[str, int]]
+            The ids of the vectors to retrieve. For ChromaDB instances, these should
+            always be strings.
+
+        Returns
+        -------
+        set(str)
+            Set of ids that are already in the database.
+        """
+
+        # create the database connection
+        if self.chromadb_client is None:
+            self.connect()
+
+        shards = self.chromadb_client.list_collections()
+        found_ids = set()
+
+        if len(shards) > self.min_shards_for_parallelization:
+            import multiprocessing
+
+            multiprocessing.set_start_method("spawn", force=True)
+            with ProcessPoolExecutor() as executor:
+                futures = {
+                    executor.submit(
+                        _query_for_id, self.context["results_dir"], shard.name, ids, include=[]
+                    ): shard
+                    for shard in shards
+                }
+                for future in as_completed(futures):
+                    results = future.result()
+                    found_ids.update(results["ids"])
+
+        else:
+            for shard in shards:
+                collection = self.chromadb_client.get_collection(shard.name)
+                results = collection.get(ids, include=[])
+                found_ids.update(results["ids"])
+
+        return found_ids

--- a/src/hyrax/verbs/__init__.py
+++ b/src/hyrax/verbs/__init__.py
@@ -1,11 +1,12 @@
 # Remove import sorting, these are imported in the order written so that
 # autoapi docs are generated with ordering controlled below.
 # ruff: noqa: I001
+from hyrax.verbs.database_connection import DatabaseConnection
 from hyrax.verbs.umap import Umap
 from hyrax.verbs.infer import Infer
 from hyrax.verbs.visualize import Visualize
 from hyrax.verbs.lookup import Lookup
-from hyrax.verbs.vdb_index import Index
+from hyrax.verbs.save_to_database import SaveToDatabase
 from hyrax.verbs.verb_registry import Verb
 from hyrax.verbs.verb_registry import all_class_verbs, all_verbs, fetch_verb_class, is_verb_class
 
@@ -19,6 +20,7 @@ __all__ = [
     "Umap",
     "Visualize",
     "Infer",
-    "Index",
+    "SaveToDatabase",
     "Verb",
+    "DatabaseConnection",
 ]

--- a/src/hyrax/verbs/database_connection.py
+++ b/src/hyrax/verbs/database_connection.py
@@ -63,7 +63,10 @@ class DatabaseConnection(Verb):
 
         vector_db_path = Path(vector_db_dir).resolve()
         if not vector_db_path.is_dir():
-            raise RuntimeError(f"Database directory {str(vector_db_path)} does not exist.")
+            raise RuntimeError(
+                f"Database directory {str(vector_db_path)} does not exist. \
+                    Have you run `hyrax.save_to_database(output_dir={vector_db_path})`?"
+            )
 
         # Get the flavor of database (i.e. Chroma, Qdrant, etc) from the config
         # file saved in `vector_db_path`. This ensures that we will use the correct

--- a/src/hyrax/verbs/database_connection.py
+++ b/src/hyrax/verbs/database_connection.py
@@ -1,0 +1,100 @@
+import logging
+from argparse import ArgumentParser, Namespace
+from pathlib import Path
+from typing import Optional, Union
+
+from .verb_registry import Verb, hyrax_verb
+
+logger = logging.getLogger(__name__)
+
+
+@hyrax_verb
+class DatabaseConnection(Verb):
+    """Verb to insert inference results into a vector database index for fast
+    similarity search."""
+
+    cli_name = "database_connection"
+    add_parser_kwargs = {}
+
+    @staticmethod
+    def setup_parser(parser: ArgumentParser):
+        """Stub of parser setup"""
+
+        parser.add_argument(
+            "-d",
+            "--database-dir",
+            type=str,
+            required=False,
+            help="Directory of existing vector database.",
+        )
+
+    def run_cli(self, args: Optional[Namespace] = None):
+        """Stub CLI implementation"""
+        logger.error("Database connection is not supported from the command line.")
+
+    def run(self, database_dir: Optional[Union[Path, str]] = None):
+        """Create a connection to the vector database for interactive queries.
+
+        Parameters
+        ----------
+        database_dir : str or Path, Optional
+            The directory containing the database that will be connected to.
+            If None, attempt to connect to the most recently created `...-vector-db-...`
+            directory. If specified, it can point to either an empty directory
+            or a directory containing an existing vector database. If the latter, the
+            database will be updated with the new vectors.
+        """
+        from hyrax.config_utils import find_most_recent_results_dir
+        from hyrax.vector_dbs.vector_db_factory import vector_db_factory
+
+        config = self.config
+
+        # Attempt to find the directory containing the vector database. Check for
+        # the database_dir argument first, then check the config file for
+        # vector_db.vector_db_dir, and finally check for the most recently
+        # created vector-db directory.
+        vector_db_dir = None
+        if database_dir is not None:
+            vector_db_dir = database_dir
+        elif config["vector_db"]["vector_db_dir"]:
+            vector_db_dir = config["vector_db"]["vector_db_dir"]
+        else:
+            vector_db_dir = find_most_recent_results_dir(config, "vector-db")
+
+        vector_db_path = Path(vector_db_dir).resolve()
+        if not vector_db_path.is_dir():
+            raise RuntimeError(f"Database directory {str(vector_db_path)} does not exist.")
+
+        # Get the flavor of database (i.e. Chroma, Qdrant, etc) from the config
+        # file saved in `vector_db_path`. This ensures that we will use the correct
+        # database class when creating the connection.
+        db_type = self._get_database_type_from_config(vector_db_path)
+        config["vector_db"]["name"] = db_type
+
+        # Create an instance of the vector database class for the connection
+        self.vector_db = vector_db_factory(config, context={"results_dir": vector_db_path})
+        if self.vector_db is None:
+            raise RuntimeError(f"Unable to conenct to the {db_type} database in directory {vector_db_path}")
+
+        return self.vector_db
+
+    def _get_database_type_from_config(self, database_dir: Path):
+        """Internal function that will read a config file from a directory and
+        return the name of the vector database from it. i.e. "chromadb", "qdrant".
+
+        Parameters
+        ----------
+        database_dir : Path
+            The directory containing the vector database and the config file that
+            be used as reference.
+
+        Returns
+        -------
+        str
+            The config value for ["vector_db"]["name"] in the reference config.
+        """
+        from hyrax.config_utils import ConfigManager
+
+        config_file = database_dir / "runtime_config.toml"
+        reference_config = ConfigManager.read_runtime_config(config_filepath=config_file)
+        return reference_config["vector_db"]["name"]

--- a/src/hyrax/verbs/save_to_database.py
+++ b/src/hyrax/verbs/save_to_database.py
@@ -112,7 +112,7 @@ class SaveToDatabase(Verb):
             raise RuntimeError(f"Database directory {str(vector_db_path)} does not exist.")
 
         # Create an instance of the vector database to insert into
-        vector_db = vector_db_factory(config, context={"results_dir": vector_db_dir})
+        vector_db = vector_db_factory(config, context={"results_dir": str(vector_db_path)})
         if vector_db:
             vector_db.create()
         else:
@@ -124,8 +124,8 @@ class SaveToDatabase(Verb):
 
         # Log the config with updated values for the input and output directories.
         config["vector_db"]["infer_results_dir"] = str(inference_results_path)
-        config["vector_db"]["vector_db_dir"] = str(vector_db_dir)
-        log_runtime_config(config, vector_db_dir)
+        config["vector_db"]["vector_db_dir"] = str(vector_db_path)
+        log_runtime_config(config, vector_db_path)
 
         # Use the batch_index to get the list of batches.
         batches = np.unique(inference_data_set.batch_index["batch_num"])

--- a/src/hyrax/verbs/save_to_database.py
+++ b/src/hyrax/verbs/save_to_database.py
@@ -5,22 +5,17 @@ from typing import Optional, Union
 
 import numpy as np
 
-from hyrax.config_utils import (
-    create_results_dir,
-    find_most_recent_results_dir,
-)
-
 from .verb_registry import Verb, hyrax_verb
 
 logger = logging.getLogger(__name__)
 
 
 @hyrax_verb
-class Index(Verb):
+class SaveToDatabase(Verb):
     """Verb to insert inference results into a vector database index for fast
     similarity search."""
 
-    cli_name = "index"
+    cli_name = "save_to_database"
     add_parser_kwargs = {}
 
     @staticmethod
@@ -66,15 +61,22 @@ class Index(Verb):
             or a directory containing an existing vector database. If the latter, the
             database will be updated with the new vectors.
         """
+        from copy import deepcopy
+
         from tqdm import tqdm
 
+        from hyrax.config_utils import (
+            create_results_dir,
+            find_most_recent_results_dir,
+            log_runtime_config,
+        )
         from hyrax.data_sets.inference_dataset import InferenceDataSet
         from hyrax.vector_dbs.vector_db_factory import vector_db_factory
 
-        config = self.config
+        config = deepcopy(self.config)
 
         # Attempt to find the directory containing inference results. Check for
-        # the input_dir argument first, then check the config file for
+        # the --input-dir argument first, then check the config file for
         # vector_db.infer_results_dir, and finally check for the most recent
         # results directory.
         infer_results_dir = None
@@ -88,22 +90,26 @@ class Index(Verb):
         if infer_results_dir is None:
             raise RuntimeError("Must define infer_results_dir in the [vector_db] section of hyrax config.")
 
-        inference_results_path = Path(infer_results_dir)
+        inference_results_path = Path(infer_results_dir).resolve()
         if not inference_results_path.is_dir():
-            raise RuntimeError(f"Input directory {input_dir} does not exist.")
+            raise RuntimeError(f"Input directory {inference_results_path} does not exist.")
 
         # Create an instance of the InferenceDataSet
         inference_data_set = InferenceDataSet(config, inference_results_path)
 
-        # Get the vector db output directory by using the input parameter or
+        # Get the vector db output directory by using the --output-dir parameter or
         # config value or creating a new directory, in that order.
-        vector_db_dir = None
+        vector_db_dir = Path()
         if output_dir is not None:
             vector_db_dir = output_dir
         elif config["vector_db"]["vector_db_dir"]:
             vector_db_dir = config["vector_db"]["vector_db_dir"]
         else:
-            vector_db_dir = create_results_dir(config, "index")
+            vector_db_dir = create_results_dir(config, "vector-db")
+
+        vector_db_path = Path(vector_db_dir).resolve()
+        if not vector_db_path.is_dir():
+            raise RuntimeError(f"Database directory {str(vector_db_path)} does not exist.")
 
         # Create an instance of the vector database to insert into
         vector_db = vector_db_factory(config, context={"results_dir": vector_db_dir})
@@ -115,6 +121,11 @@ class Index(Verb):
                 "Please specify a supported vector db in the ['vector_db']['name'] "
                 "section of the hyrax config."
             )
+
+        # Log the config with updated values for the input and output directories.
+        config["vector_db"]["infer_results_dir"] = str(inference_results_path)
+        config["vector_db"]["vector_db_dir"] = str(vector_db_dir)
+        log_runtime_config(config, vector_db_dir)
 
         # Use the batch_index to get the list of batches.
         batches = np.unique(inference_data_set.batch_index["batch_num"])

--- a/tests/hyrax/test_chromadb_impl.py
+++ b/tests/hyrax/test_chromadb_impl.py
@@ -85,23 +85,23 @@ def test_search_by_id(chromadb_instance):
 
     # Search by single vector should return the id1 and id2 in that order
     result = chromadb_instance.search_by_id("id1", k=2)
-    assert len(result[0]) == 2
-    assert np.all(result[0] == ["id1", "id2"])
+    assert len(result["id1"]) == 2
+    assert np.all(result["id1"] == ["id1", "id2"])
 
     # Search should return all ids when k is larger than the number of ids
     result = chromadb_instance.search_by_id("id1", k=5)
-    assert len(result[0]) == 2
-    assert np.all(result[0] == ["id1", "id2"])
+    assert len(result["id1"]) == 2
+    assert np.all(result["id1"] == ["id1", "id2"])
 
     # Search should return 1 id when k is 1
     result = chromadb_instance.search_by_id("id1", k=1)
-    assert len(result[0]) == 1
-    assert np.all(result[0] == ["id1"])
+    assert len(result["id1"]) == 1
+    assert np.all(result["id1"] == ["id1"])
 
     # Search by another vector should return the id2 and id1 in that order
     result = chromadb_instance.search_by_id("id2", k=2)
-    assert len(result[0]) == 2
-    assert np.all(result[0] == ["id2", "id1"])
+    assert len(result["id2"]) == 2
+    assert np.all(result["id2"] == ["id2", "id1"])
 
 
 def test_search_by_id_many_shards(chromadb_instance, random_vector_generator):
@@ -129,8 +129,8 @@ def test_search_by_id_many_shards(chromadb_instance, random_vector_generator):
 
     # Search should return 1 id when k is 1
     result = chromadb_instance.search_by_id("id1", k=1)
-    assert len(result[0]) == 1
-    assert np.all(result[0] == ["id1"])
+    assert len(result["id1"]) == 1
+    assert np.all(result["id1"] == ["id1"])
 
 
 def test_search_by_vector(chromadb_instance):

--- a/tests/hyrax/test_save_to_database.py
+++ b/tests/hyrax/test_save_to_database.py
@@ -1,9 +1,7 @@
 import numpy as np
 
-from hyrax.vector_dbs.chromadb_impl import ChromaDB
 
-
-def test_vdb_index(loopback_inferred_hyrax):
+def test_save_to_database(loopback_inferred_hyrax):
     """Test that the data inserted into the vector database is not corrupted. i.e.
     that we can match ids to input vectors for all values."""
 
@@ -15,14 +13,14 @@ def test_vdb_index(loopback_inferred_hyrax):
 
     # Populate the vector database with the results of inference
     vdb_path = h.config["general"]["results_dir"]
-    h.index(output_dir=vdb_path)
+    h.save_to_database(output_dir=vdb_path)
 
-    chromadb_instance = ChromaDB({}, {"results_dir": vdb_path})
-    chromadb_instance.connect()
+    # Get a connection to the database that was just created.
+    db_connection = h.database_connection(database_dir=vdb_path)
 
     # Verify that every inserted vector id matches the original vector
     for indx, id in enumerate(inference_result_ids):
         assert id == original_dataset_ids[indx]
-        result = chromadb_instance.get_by_id(id)
+        result = db_connection.get_by_id(id)
         original_value = dataset[indx]
         assert np.all(result[id] == original_value.numpy())


### PR DESCRIPTION
- Cleaning up vector database UX.
  - Now it's `h.save_to_database()` instead of `h.index()`.
  - Connect to database without needing to know the database type with `h.database_connection`.
  - Ensure that a user cannot insert duplicate ids into chromadb.
- Added `database_connection` verb
- Renamed `index` to `save_to_database`
- Created a new example notebook.
- Updated tests
- Modified ConfigManager - made the private static method, `read_runtime_config` public so that we can quickly read a config from a result directory without having to invoke the entire ConfigManager machinery (which is really slow now :() 
