### PR TITLE
Basic NaN handling using a quantile-based system

### DIFF
--- a/docs/external_libraries.rst
+++ b/docs/external_libraries.rst
@@ -150,6 +150,30 @@ it's ``x`` input. See the example below, which stacks the g, r, and i fluxes int
 Note that ``to_tensor`` must be defined with ``@staticmethod`` as in the example. The function does not have
 access to the model's data members through the typical ``self`` argument in python.
 
+Another possible use of ``to_tensor`` is to remove or otherwise adjust the input data of your model in ways 
+that are not easily done with a ``torch.transform``. Below is an example ``to_tensor`` function which removes 
+NaN values from input data, replacing them with the value zero. 
+
+.. code-block:: python
+
+    from hyrax.models import hyrax_model
+
+    @hyrax_model
+    class MyModel:
+
+        @staticmethod
+        def to_tensor(batch_dict):
+            """
+            Accepts a batch of tensors which may contain NaN values. Replaces those values with zero.
+            """
+            from torch import any, isnan, nan_to_num
+            if any(isnan(batch)):
+                batch = nan_to_num(batch, 0.0)
+            return batch
+
+Some NaN handling is available automatically in hyrax, via ``config['data_set']['nan_mode']``, but if a 
+customized strategy is desired, the approach above may be preferable.
+
 .. _custom-dataset-instructions:
 
 Defining a dataset class

--- a/src/hyrax/hyrax_default_config.toml
+++ b/src/hyrax/hyrax_default_config.toml
@@ -204,6 +204,12 @@ filter_column_name = false
 # Override the name of the filename column for FitsImageDataset and HSCDataset
 filename_column_name = false
 
+# Replace NaN in input data with a value, modes are false for no replacement or "quantile"
+nan_mode = "quantile"
+
+# When replacing NaN values with a quantile, which quantile in the non-nan tensor
+nan_quantile = 0.05
+
 [data_loader]
 # The number of data points to load at once.
 batch_size = 512

--- a/src/hyrax/hyrax_default_config.toml
+++ b/src/hyrax/hyrax_default_config.toml
@@ -204,10 +204,11 @@ filter_column_name = false
 # Override the name of the filename column for FitsImageDataset and HSCDataset
 filename_column_name = false
 
-# Replace NaN in input data with a value, modes are false for no replacement or "quantile"
-nan_mode = "quantile"
+# Replace NaN in input data with a value, modes are false for no replacement or "quantile" to replace with a 
+# defined quantile of the non-NaN data, see nan_quantile.
+nan_mode = false
 
-# When replacing NaN values with a quantile, which quantile in the non-nan tensor
+# When replacing NaN values with a quantile, which quantile in the non-nan tensor should be used.
 nan_quantile = 0.05
 
 [data_loader]

--- a/src/hyrax/pytorch_ignite.py
+++ b/src/hyrax/pytorch_ignite.py
@@ -274,7 +274,14 @@ def create_splits(data_set: Dataset, config: ConfigDict):
 
 
 def _handle_nans(batch, config):
+    from torch import any, isnan
+
     if config["data_set"]["nan_mode"] is False:
+        if any(isnan(batch)):
+            msg = "Input data contains NaN values. This may mean your model output is all NaNs."
+            msg += "Consider setting config['data_set']['nan_mode'] = 'quantile', or writing a to_tensor()"
+            msg += "function for your model. Search hyrax readthedocs for 'to_tensor' to get started. "
+            logger.warning(msg)
         return batch
 
     if config["data_set"]["nan_mode"] == "quantile":

--- a/src/hyrax/pytorch_ignite.py
+++ b/src/hyrax/pytorch_ignite.py
@@ -273,7 +273,55 @@ def create_splits(data_set: Dataset, config: ConfigDict):
     return split_inds
 
 
-def create_engine(funcname: str, device: torch.device, model: torch.nn.Module) -> Engine:
+def _handle_nans(batch, config):
+    if config["data_set"]["nan_mode"] is False:
+        return batch
+
+    if config["data_set"]["nan_mode"] == "quantile":
+        quantile = config["data_set"]["nan_quantile"]
+        if quantile < 0.0 or quantile > 1.0:
+            raise RuntimeError('set config["data_set"]["nan_quantile"] to a value between 0 and 1')
+        return _handle_nan_quantile(batch, quantile)
+    else:
+        msg = f"nan mode was set to '{config['data_set']['nan_mode']}' which is unsupported."
+        msg += "The only supported mode is 'quantile' "
+        raise NotImplementedError(msg)
+
+
+def _handle_nan_quantile(batch, quantile):
+    from torch import any, isnan
+
+    if any(isnan(batch)):
+        flat_batch = torch.reshape(batch, (batch.shape[0], -1))
+        batch_quantile = torch.nanquantile(flat_batch, q=quantile, dim=-1)
+        for i, val in enumerate(batch_quantile):
+            batch[i] = torch.nan_to_num(batch[i], val)
+
+    return batch
+
+
+def _inner_loop(func, to_tensor, device, config, engine, batch):
+    """This wraps a model-specific function (func) to move data to the appropriate device."""
+    # If we have a dict of lists, we need to decode the dict
+    # This will give us either a tensor of the whole batch or a tuple
+    if isinstance(batch, dict):
+        batch = to_tensor(batch)
+
+    batch = _handle_nans(batch, config)
+
+    # Send the batch to the device
+    batch = batch.to(device) if isinstance(batch, torch.Tensor) else tuple(i.to(device) for i in batch)
+    return func(batch)
+
+
+def _create_process_func(funcname, device, model, config):
+    inner_step = extract_model_method(model, funcname)
+    to_tensor = extract_model_method(model, "to_tensor")
+    inner_loop = functools.partial(_inner_loop, inner_step, to_tensor, device, config)
+    return inner_loop
+
+
+def create_engine(funcname: str, device: torch.device, model: torch.nn.Module, config: ConfigDict) -> Engine:
     """Unified creation of the pytorch engine object for either an evaluator or trainer.
 
     This function will automatically unwrap a distributed model to find the necessary function, and construct
@@ -289,26 +337,10 @@ def create_engine(funcname: str, device: torch.device, model: torch.nn.Module) -
         The device the engine will run the model on
     model : torch.nn.Module
         The Model the engine will be using
+    config : ConfigDict
+        The runtime config in use
     """
-
-    # This wraps a model-specific function (func) to move data to the appropriate device.
-    def _inner_loop(func, to_tensor, device, engine, batch):
-        # If we have a dict of lists, we need to decode the dict
-        # This will give us either a tensor of the whole batch or a tuple
-        if isinstance(batch, dict):
-            batch = to_tensor(batch)
-
-        # Send the batch to the device
-        batch = batch.to(device) if isinstance(batch, torch.Tensor) else tuple(i.to(device) for i in batch)
-        return func(batch)
-
-    def _create_process_func(funcname, device, model):
-        inner_step = extract_model_method(model, funcname)
-        to_tensor = extract_model_method(model, "to_tensor")
-        inner_loop = functools.partial(_inner_loop, inner_step, to_tensor, device)
-        return inner_loop
-
-    return Engine(_create_process_func(funcname, device, model))
+    return Engine(_create_process_func(funcname, device, model, config))
 
 
 def extract_model_method(model, method_name):
@@ -333,7 +365,7 @@ def extract_model_method(model, method_name):
 
 
 def create_evaluator(
-    model: torch.nn.Module, save_function: Callable[[torch.Tensor, torch.Tensor], Any]
+    model: torch.nn.Module, save_function: Callable[[torch.Tensor, torch.Tensor], Any], config: ConfigDict
 ) -> Engine:
     """Creates an evaluator engine
     Primary purpose of this function is to attach the appropriate handlers to an evaluator engine
@@ -347,6 +379,9 @@ def create_evaluator(
         A function which will receive Engine.state.output at the end of each iteration. The intent
         is for the results of evaluation to be saved.
 
+    config : ConfigDict
+        The runtime config in use
+
     Returns
     -------
     pytorch-ignite.Engine
@@ -355,7 +390,7 @@ def create_evaluator(
     device = idist.device()
     model.eval()
     model = idist.auto_model(model)
-    evaluator = create_engine("forward", device, model)
+    evaluator = create_engine("forward", device, model, config)
 
     @evaluator.on(Events.STARTED)
     def log_eval_start(evaluator):
@@ -415,7 +450,7 @@ def create_validator(
     device = idist.device()
     model = idist.auto_model(model)
 
-    validator = create_engine("train_step", device, model)
+    validator = create_engine("train_step", device, model, config)
     fixup_engine(validator)
 
     @validator.on(Events.STARTED)
@@ -472,7 +507,7 @@ def create_trainer(
     device = idist.device()
     model.train()
     model = idist.auto_model(model)
-    trainer = create_engine("train_step", device, model)
+    trainer = create_engine("train_step", device, model, config)
     fixup_engine(trainer)
 
     optimizer = extract_model_method(model, "optimizer")

--- a/src/hyrax/verbs/infer.py
+++ b/src/hyrax/verbs/infer.py
@@ -127,7 +127,7 @@ class Infer(Verb):
             write_index += batch_len
 
         # Run inference
-        evaluator = create_evaluator(model, _save_batch)
+        evaluator = create_evaluator(model, _save_batch, config)
         evaluator.run(data_loader)
 
         # Write out a dictionary to map IDs->Batch

--- a/tests/hyrax/test_nan.py
+++ b/tests/hyrax/test_nan.py
@@ -78,6 +78,7 @@ def test_nan_handling(loopback_hyrax_nan):
     Test that default nan handling removes nans
     """
     h, dataset = loopback_hyrax_nan
+    h.config["data_set"]["nan_mode"] = "quantile"
 
     inference_results = h.infer()
 

--- a/tests/hyrax/test_nan.py
+++ b/tests/hyrax/test_nan.py
@@ -1,0 +1,104 @@
+import numpy as np
+import pytest
+from torch import any, from_numpy, isnan, tensor
+from torch.utils.data import Dataset
+
+import hyrax
+from hyrax.data_sets import HyraxDataset
+
+
+class RandomNaNDataset(HyraxDataset, Dataset):
+    """Dataset yielding pairs of random numbers. Requires a seed to emulate
+    static data on the filesystem between instantiations"""
+
+    def __init__(self, config):
+        size = config["data_set"]["size"]
+        seed = config["data_set"]["seed"]
+        rng = np.random.default_rng(seed)
+        self.data = rng.random((size, 20), np.float32)
+
+        num_nans = 40
+        nan_index_i = rng.integers(0, size, num_nans)
+        nan_index_j = rng.integers(0, 20, num_nans)
+        for i, j in zip(nan_index_i, nan_index_j):
+            self.data[i][j] = np.nan
+
+        # Start our IDs at a random integer between 0 and 100
+        id_start = rng.integers(100)
+        self.id_list = list(range(id_start, id_start + size))
+
+        super().__init__(config)
+
+    def __getitem__(self, idx):
+        return from_numpy(self.data[idx])
+
+    def __len__(self):
+        return len(self.data)
+
+    def ids(self):
+        """Yield IDs for the dataset"""
+        for id_item in self.id_list:
+            yield str(id_item)
+
+
+@pytest.fixture(scope="function")
+def loopback_hyrax_nan(tmp_path_factory):
+    """This generates a loopback hyrax instance
+    which is configured to use the loopback model
+    and a simple dataset yielding random numbers
+    """
+    results_dir = tmp_path_factory.mktemp("loopback_hyrax_nan")
+
+    h = hyrax.Hyrax()
+    h.config["model"]["name"] = "LoopbackModel"
+    h.config["train"]["epochs"] = 1
+    h.config["data_loader"]["batch_size"] = 5
+    h.config["general"]["results_dir"] = str(results_dir)
+
+    h.config["general"]["dev_mode"] = True
+    h.config["data_set"]["name"] = "RandomNaNDataset"
+    h.config["data_set"]["size"] = 20
+    h.config["data_set"]["seed"] = 0
+
+    h.config["data_set"]["validate_size"] = 0.2
+    h.config["data_set"]["test_size"] = 0.2
+    h.config["data_set"]["train_size"] = 0.6
+
+    weights_file = results_dir / "fakeweights"
+    with open(weights_file, "a"):
+        pass
+    h.config["infer"]["model_weights_file"] = str(weights_file)
+
+    dataset = h.prepare()
+    return h, dataset
+
+
+def test_nan_handling(loopback_hyrax_nan):
+    """
+    Test that default nan handling removes nans
+    """
+    h, dataset = loopback_hyrax_nan
+
+    inference_results = h.infer()
+
+    original_nans = tensor([any(isnan(item)) for item in dataset])
+    assert any(original_nans)
+
+    for result in inference_results:
+        assert not any(isnan(result))
+
+
+def test_nan_handling_off(loopback_hyrax_nan):
+    """
+    Test that when nan handling is off nans appear in output
+    """
+    h, dataset = loopback_hyrax_nan
+
+    h.config["data_set"]["nan_mode"] = False
+    inference_results = h.infer()
+
+    original_nans = tensor([any(isnan(item)) for item in dataset])
+    assert any(original_nans)
+
+    result_nans = tensor([any(isnan(item)) for item in inference_results])
+    assert any(result_nans)


### PR DESCRIPTION
This is our first run at image based handling of NaN values.

The basic algorithm is that it looks at every image in the batch and replaces NaNs in the image with the 5th percentile value from that same image. The percentile is configurable, and we can add other methods over time.

This is intended as a precursor to having LSST visit images as inputs to hyrax models, but could be immediately usable by anyone with NaNs in their data.