### PR TITLE
Read the original config file from results directory for InferenceDataset

### DIFF
--- a/src/hyrax/data_sets/inference_dataset.py
+++ b/src/hyrax/data_sets/inference_dataset.py
@@ -53,9 +53,9 @@ class InferenceDataSet(HyraxDataset, Dataset):
 
         # Initialize the original dataset using the old config, so we have it
         # around for metadata calls
-        self._original_dataset_config = ConfigManager(
+        self._original_dataset_config = ConfigManager().read_runtime_config(
             self.results_dir / ORIGINAL_DATASET_CONFIG_FILENAME
-        ).config
+        )
 
         # Disable cache preloading on this dataset because it will only be used for its metadata
         # TODO: May want to add some sort of metadata_only optional arg to dataset constructor


### PR DESCRIPTION
Just read the config in the results directory instead of hydrating the entire config.

Probably not a huge time savings, but I don't think it's necessary to rehydrate the config file from scratch in this case, since I believe all we want to do is use some values from it to properly instantiate the dataset.