### PR TITLE
New Features for LSST X Hyrax

### DIFF
--- a/docs/pre_executed/hyrax_hats_cutouts.ipynb
+++ b/docs/pre_executed/hyrax_hats_cutouts.ipynb
@@ -46,11 +46,11 @@
    "id": "ab7c0163-5b56-47dd-a19f-c1e5604c0ac2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-04-23T00:16:50.912226Z",
-     "iopub.status.busy": "2025-04-23T00:16:50.911905Z",
-     "iopub.status.idle": "2025-04-23T00:16:50.915794Z",
-     "shell.execute_reply": "2025-04-23T00:16:50.915367Z",
-     "shell.execute_reply.started": "2025-04-23T00:16:50.912206Z"
+     "iopub.execute_input": "2025-05-26T07:50:34.665977Z",
+     "iopub.status.busy": "2025-05-26T07:50:34.665377Z",
+     "iopub.status.idle": "2025-05-26T07:50:34.668812Z",
+     "shell.execute_reply": "2025-05-26T07:50:34.668333Z",
+     "shell.execute_reply.started": "2025-05-26T07:50:34.665958Z"
     }
    },
    "outputs": [],
@@ -65,6 +65,38 @@
     "    \"config\": \"/repo/main\",\n",
     "    \"collections\": \"LSSTComCam/runs/DRP/DP1/v29_0_0_rc5/DM-49865\",\n",
     "}\n",
+    "sky_config = {\n",
+    "    \"skymap\": \"lsst_cells_v1\",\n",
+    "    \"tract\": 5063,\n",
+    "    \"patch\": 4,\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "15d6cb96-2d8e-4670-a12a-8acc1cb6ad29",
+   "metadata": {},
+   "source": [
+    "# Route 1 -- Create a Hats catalog with objects of interest\n",
+    "\n",
+    "In order that this is compatible with DP1 ComCam data, we will pick a tract/patch where there is a deep field, cone search in hats slightly smaller than the patch to avoid edge-of-patch/edge-of-tract cutouts which are not yet handled by LSSTCutout, and then save the catalog file"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "1317a8a4-26dd-4d90-a9b8-50c23988efa6",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-05-26T07:50:27.155109Z",
+     "iopub.status.busy": "2025-05-26T07:50:27.154876Z",
+     "iopub.status.idle": "2025-05-26T07:50:27.158156Z",
+     "shell.execute_reply": "2025-05-26T07:50:27.157706Z",
+     "shell.execute_reply.started": "2025-05-26T07:50:27.155092Z"
+    }
+   },
+   "outputs": [],
+   "source": [
     "lsdb_config = {\n",
     "    \"path\": \"/sdf/data/rubin/shared/lsdb_commissioning/hats/v29_0_0_rc5/object_lc\",\n",
     "    \"margin_cache\": \"/sdf/data/rubin/shared/lsdb_commissioning/hats/v29_0_0_rc5/object_lc_5arcs\",\n",
@@ -79,22 +111,7 @@
     "        \"shape_yy\",\n",
     "        \"shape_xy\",\n",
     "    ],\n",
-    "}\n",
-    "sky_config = {\n",
-    "    \"skymap\": \"lsst_cells_v1\",\n",
-    "    \"tract\": 5063,\n",
-    "    \"patch\": 4,\n",
     "}"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "15d6cb96-2d8e-4670-a12a-8acc1cb6ad29",
-   "metadata": {},
-   "source": [
-    "# Create a Hats catalog with objects of interest\n",
-    "\n",
-    "In order that this is compatible with DP1 ComCam data, we will pick a tract/patch where there is a deep field, cone search in hats slightly smaller than the patch to avoid edge-of-patch/edge-of-tract cutouts which are not yet handled by LSSTCutout, and then save the catalog file"
    ]
   },
   {
@@ -282,7 +299,7 @@
    "id": "77b6cbea-b9e7-495c-97b9-603b3245bf80",
    "metadata": {},
    "source": [
-    "# Setup Hyrax to use the hats catalog\n",
+    "## Setup Hyrax to use the hats catalog\n",
     "Configure hyrax to use the hats catalog "
    ]
   },
@@ -394,13 +411,332 @@
    "source": [
     "a[3].shape"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dac3d274-adc4-4c0d-885e-30c72507778f",
+   "metadata": {},
+   "source": [
+    "# Route 2 -- Use Butler to Download Catalog "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "3cd02f96-63a7-4ee9-9cac-cc31569bfddd",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-05-26T07:52:23.266789Z",
+     "iopub.status.busy": "2025-05-26T07:52:23.266435Z",
+     "iopub.status.idle": "2025-05-26T07:52:23.871030Z",
+     "shell.execute_reply": "2025-05-26T07:52:23.870466Z",
+     "shell.execute_reply.started": "2025-05-26T07:52:23.266761Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "butler = Butler(**butler_config)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "decb6d5f-b94c-47dc-8c64-f441929a3434",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-05-26T07:52:23.266789Z",
+     "iopub.status.busy": "2025-05-26T07:52:23.266435Z",
+     "iopub.status.idle": "2025-05-26T07:52:23.871030Z",
+     "shell.execute_reply": "2025-05-26T07:52:23.870466Z",
+     "shell.execute_reply.started": "2025-05-26T07:52:23.266761Z"
+    }
+   },
+   "source": [
+    "Let's specify the columns we want to downloda"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "f0bf7034-7186-46bc-af3e-89d5155ea276",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-05-26T07:53:51.609164Z",
+     "iopub.status.busy": "2025-05-26T07:53:51.608935Z",
+     "iopub.status.idle": "2025-05-26T07:53:51.612082Z",
+     "shell.execute_reply": "2025-05-26T07:53:51.611631Z",
+     "shell.execute_reply.started": "2025-05-26T07:53:51.609147Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "INCOLS = [\n",
+    "    \"objectId\",\n",
+    "    \"coord_ra\",\n",
+    "    \"coord_dec\",\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2d08e370-c469-43aa-bbeb-40bb1211bf8f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-05-26T07:53:51.609164Z",
+     "iopub.status.busy": "2025-05-26T07:53:51.608935Z",
+     "iopub.status.idle": "2025-05-26T07:53:51.612082Z",
+     "shell.execute_reply": "2025-05-26T07:53:51.611631Z",
+     "shell.execute_reply.started": "2025-05-26T07:53:51.609147Z"
+    }
+   },
+   "source": [
+    "Now, let's download the data using the butler. We use the `sky_config` we had specified earlier"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "43884efc-4959-47ce-8ac7-84011e931158",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-05-26T08:00:41.606305Z",
+     "iopub.status.busy": "2025-05-26T08:00:41.605968Z",
+     "iopub.status.idle": "2025-05-26T08:00:42.521933Z",
+     "shell.execute_reply": "2025-05-26T08:00:42.521465Z",
+     "shell.execute_reply.started": "2025-05-26T08:00:41.606278Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "object_table = butler.get(\"object\", dataId=sky_config, parameters={\"columns\": INCOLS})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0ff37bd6-496f-46a8-b73c-4c2ada428ba1",
+   "metadata": {},
+   "source": [
+    "The butler returns an Astropy table"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "793b368c-836c-4f4f-a807-2a267b7713fb",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-05-26T08:00:50.362153Z",
+     "iopub.status.busy": "2025-05-26T08:00:50.361792Z",
+     "iopub.status.idle": "2025-05-26T08:00:50.366402Z",
+     "shell.execute_reply": "2025-05-26T08:00:50.366019Z",
+     "shell.execute_reply.started": "2025-05-26T08:00:50.362125Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div><i>Table length=330140</i>\n",
+       "<table id=\"table139969023099872\" class=\"table-striped table-bordered table-condensed\">\n",
+       "<thead><tr><th>objectId</th><th>coord_ra</th><th>coord_dec</th></tr></thead>\n",
+       "<thead><tr><th>int64</th><th>float64</th><th>float64</th></tr></thead>\n",
+       "<tr><td>2226730948571955231</td><td>53.84420370780718</td><td>-28.240337522632426</td></tr>\n",
+       "<tr><td>2226730948571955234</td><td>53.858131730585136</td><td>-28.238685401609477</td></tr>\n",
+       "<tr><td>2226730948571955235</td><td>53.85369296384201</td><td>-28.237595175872777</td></tr>\n",
+       "<tr><td>2226730948571955236</td><td>53.85497966971418</td><td>-28.23732718026425</td></tr>\n",
+       "<tr><td>2226730948571955237</td><td>53.85206728015377</td><td>-28.23398234737432</td></tr>\n",
+       "<tr><td>2226730948571955238</td><td>53.86660564441939</td><td>-28.233416496002043</td></tr>\n",
+       "<tr><td>2226730948571955240</td><td>53.86916441028787</td><td>-28.232749888804847</td></tr>\n",
+       "<tr><td>2226730948571955241</td><td>53.86609497158882</td><td>-28.232530683870277</td></tr>\n",
+       "<tr><td>2226730948571955242</td><td>53.86861432865251</td><td>-28.231339170865187</td></tr>\n",
+       "<tr><td>...</td><td>...</td><td>...</td></tr>\n",
+       "<tr><td>2226977239176579401</td><td>52.80923955437342</td><td>-27.490619588860596</td></tr>\n",
+       "<tr><td>2226977239176579402</td><td>52.80899342409366</td><td>-27.48975412387232</td></tr>\n",
+       "<tr><td>2226977239176579405</td><td>52.78375248803146</td><td>-27.490286784137727</td></tr>\n",
+       "<tr><td>2226977239176579406</td><td>52.78438293057994</td><td>-27.490388265176712</td></tr>\n",
+       "<tr><td>2226977239176579407</td><td>52.84074658730358</td><td>-27.490221262062125</td></tr>\n",
+       "<tr><td>2226977239176579408</td><td>52.84028570775721</td><td>-27.48967661686162</td></tr>\n",
+       "<tr><td>2226977239176579410</td><td>52.829380591411926</td><td>-27.489168431131656</td></tr>\n",
+       "<tr><td>2226977239176579411</td><td>52.830521086290894</td><td>-27.489912601216663</td></tr>\n",
+       "<tr><td>2226981637223088139</td><td>52.70677004240624</td><td>-27.51892952118405</td></tr>\n",
+       "<tr><td>2226981637223088140</td><td>52.70315846142726</td><td>-27.51825689185434</td></tr>\n",
+       "</table></div>"
+      ],
+      "text/plain": [
+       "<Table length=330140>\n",
+       "      objectId           coord_ra           coord_dec     \n",
+       "       int64             float64             float64      \n",
+       "------------------- ------------------ -------------------\n",
+       "2226730948571955231  53.84420370780718 -28.240337522632426\n",
+       "2226730948571955234 53.858131730585136 -28.238685401609477\n",
+       "2226730948571955235  53.85369296384201 -28.237595175872777\n",
+       "2226730948571955236  53.85497966971418  -28.23732718026425\n",
+       "2226730948571955237  53.85206728015377  -28.23398234737432\n",
+       "2226730948571955238  53.86660564441939 -28.233416496002043\n",
+       "2226730948571955240  53.86916441028787 -28.232749888804847\n",
+       "2226730948571955241  53.86609497158882 -28.232530683870277\n",
+       "2226730948571955242  53.86861432865251 -28.231339170865187\n",
+       "                ...                ...                 ...\n",
+       "2226977239176579401  52.80923955437342 -27.490619588860596\n",
+       "2226977239176579402  52.80899342409366  -27.48975412387232\n",
+       "2226977239176579405  52.78375248803146 -27.490286784137727\n",
+       "2226977239176579406  52.78438293057994 -27.490388265176712\n",
+       "2226977239176579407  52.84074658730358 -27.490221262062125\n",
+       "2226977239176579408  52.84028570775721  -27.48967661686162\n",
+       "2226977239176579410 52.829380591411926 -27.489168431131656\n",
+       "2226977239176579411 52.830521086290894 -27.489912601216663\n",
+       "2226981637223088139  52.70677004240624  -27.51892952118405\n",
+       "2226981637223088140  52.70315846142726  -27.51825689185434"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "object_table"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "53191e08-b1f4-4779-8a4a-b84dfb74533f",
+   "metadata": {},
+   "source": [
+    "Let's save the first 10,000 images as a pickle file (faster i/o compared to fits)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "9e8265e0-7de5-4735-9411-df086c0e4473",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-05-26T08:06:18.760429Z",
+     "iopub.status.busy": "2025-05-26T08:06:18.760221Z",
+     "iopub.status.idle": "2025-05-26T08:06:18.765841Z",
+     "shell.execute_reply": "2025-05-26T08:06:18.765432Z",
+     "shell.execute_reply.started": "2025-05-26T08:06:18.760414Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import pickle\n",
+    "\n",
+    "with open(\"./test_catalog_10k.pkl\", \"wb\") as f:\n",
+    "    pickle.dump(object_table[:10000], f)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5fcd568c-6f7d-4488-93de-31c83e86b155",
+   "metadata": {},
+   "source": [
+    "## Setup Hyrax to use the astropy catalog\n",
+    "Configure hyrax to use the astropy catalog. Note that instead of saving the astropy table as a pickle file, you can save it any format that is supported by Astropy"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "628c8667-d48f-418c-a699-f1ee43837ff8",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-05-26T08:07:05.648623Z",
+     "iopub.status.busy": "2025-05-26T08:07:05.648290Z",
+     "iopub.status.idle": "2025-05-26T08:07:05.690332Z",
+     "shell.execute_reply": "2025-05-26T08:07:05.689920Z",
+     "shell.execute_reply.started": "2025-05-26T08:07:05.648598Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[2025-05-26 01:07:05,687 hyrax:INFO] Runtime Config read from: /sdf/data/rubin/user/aritrag/hyrax/src/hyrax/hyrax_default_config.toml\n"
+     ]
+    }
+   ],
+   "source": [
+    "h = hyrax.Hyrax()\n",
+    "h.config[\"data_set\"][\"name\"] = \"LSSTDataset\"\n",
+    "h.config[\"data_set\"][\"astropy_table\"] = \"./test_catalog_10k.pkl\"\n",
+    "h.config[\"data_set\"][\"butler_repo\"] = butler_config[\"config\"]\n",
+    "h.config[\"data_set\"][\"butler_collection\"] = butler_config[\"collections\"]\n",
+    "h.config[\"data_set\"][\"skymap\"] = sky_config[\"skymap\"]\n",
+    "h.config[\"data_set\"][\"semi_width_deg\"] = (20 * u.arcsec).to(u.deg).value\n",
+    "h.config[\"data_set\"][\"semi_height_deg\"] = (20 * u.arcsec).to(u.deg).value"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "e568b4d0-9501-4eb4-a945-65510824ad6a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-05-26T08:09:23.155948Z",
+     "iopub.status.busy": "2025-05-26T08:09:23.155209Z",
+     "iopub.status.idle": "2025-05-26T08:09:23.957462Z",
+     "shell.execute_reply": "2025-05-26T08:09:23.956918Z",
+     "shell.execute_reply.started": "2025-05-26T08:09:23.155930Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[2025-05-26 01:09:23,954 hyrax.prepare:INFO] Finished Prepare\n"
+     ]
+    }
+   ],
+   "source": [
+    "a = h.prepare()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "c54d995d-f5b7-4347-b82b-902d95fc6c83",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-05-26T08:09:33.101098Z",
+     "iopub.status.busy": "2025-05-26T08:09:33.100744Z",
+     "iopub.status.idle": "2025-05-26T08:09:52.227634Z",
+     "shell.execute_reply": "2025-05-26T08:09:52.227089Z",
+     "shell.execute_reply.started": "2025-05-26T08:09:33.101071Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "torch.Size([3, 203, 199])"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "a[1].shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "62fb7bbe-db69-4284-9f3f-bcbfc64891a9",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "LSST",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "lsst"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {

--- a/src/hyrax/data_sets/__init__.py
+++ b/src/hyrax/data_sets/__init__.py
@@ -13,6 +13,11 @@ where `LSST Pipeline <https://pipelines.lsst.io/>`_ tools and a
 `data butler <https://pipelines.lsst.io/modules/lsst.daf.butler/index.html>`_ with the appropriate images
 are available.
 
+:doc:`DownloadedLSSTDataset <downloaded_lsst_dataset/index>` is a subclass of LSSTDataset that generates
+cutouts from the butler and saves them as ``.pt`` files on first access. On subsequent access,
+it loads the cutouts directly from these files, which can significantly speed up data loading times.
+It inherits from LSSTDataset to access the data butler and catalog functionality.
+
 :doc:`HSCDataSet <hsc_data_set/index>` Works similarly to FitsImageDataSet, but is specialized to
 `Hyper Suprime-Cam (HSC) <https://hsc-release.mtk.nao.ac.jp/doc/index.php/data/>`_ cutout images downloaded
 with the hyrax ``download`` verb. It contains additional integrity checks and is tightly integrated with
@@ -48,6 +53,7 @@ functionality to make custom datasets easier to write. See the
 # ruff: noqa: I001
 from .fits_image_dataset import FitsImageDataSet
 from .lsst_dataset import LSSTDataset
+from .downloaded_lsst_dataset import DownloadedLSSTDataset
 from .hsc_data_set import HSCDataSet
 from .hyrax_cifar_data_set import HyraxCifarDataSet, HyraxCifarIterableDataSet
 from .inference_dataset import InferenceDataSet
@@ -62,5 +68,6 @@ __all__ = [
     "InferenceDataSet",
     "HyraxDataset",
     "LSSTDataset",
+    "DownloadedLSSTDataset",
     "HyraxCifarBase",
 ]

--- a/src/hyrax/data_sets/downloaded_lsst_dataset.py
+++ b/src/hyrax/data_sets/downloaded_lsst_dataset.py
@@ -1,0 +1,223 @@
+import functools
+import logging
+from pathlib import Path
+
+import torch
+from astropy.table import Table
+from tqdm import tqdm
+
+from .lsst_dataset import LSSTDataset
+
+logger = logging.getLogger(__name__)
+
+
+class DownloadedLSSTDataset(LSSTDataset):
+    """
+    DownloadedLSSTDataset: A dataset that inherits from LSSTDataset and
+    downloads cutouts from the LSST butler and saves them as `.pt` files
+    during the first access.On subsequent accesses, it loads the cutouts 
+    directly from these files.
+    """
+
+    def __init__(self, config):
+
+        self.download_dir = Path(config["general"]["data_dir"])
+        self.download_dir.mkdir(exist_ok=True)
+
+        super().__init__(config)
+
+        # Store config for thread-local Butler creation
+        self._butler_config = {
+            'repo': config["data_set"]["butler_repo"],
+            'collections': config["data_set"]["butler_collection"],
+            'skymap': config["data_set"]["skymap"]
+        }
+
+        # Determine naming strategy
+        self._setup_naming_strategy()
+
+    def _setup_naming_strategy(self):
+        """Setup file naming strategy based on catalog columns."""
+        catalog_columns = self.catalog.colnames if hasattr(self.catalog, 'colnames') else self.catalog.columns
+
+        self.use_object_id = False
+        if 'object_id' in catalog_columns:
+            self.use_object_id = True
+            self.object_id_column = 'object_id'
+        elif 'objectId' in catalog_columns:
+            self.use_object_id = True
+            self.object_id_column = 'objectId'
+        else:
+            self.object_id_column = 'objectId'
+
+        if not self.use_object_id:
+            dataset_length = len(self.catalog)
+            self.padding_length = max(4, len(str(dataset_length)))
+
+    def _get_cutout_path(self, idx):
+        """Generate cutout file path for a given index."""
+        if self.use_object_id:
+            if isinstance(self.catalog, Table):
+                object_id = self.catalog[idx][self.object_id_column]
+            else:
+                object_id = self.catalog.iloc[idx][self.object_id_column]
+            return self.download_dir / f"cutout_{object_id}.pt"
+        else:
+            return self.download_dir / f"cutout_{idx:0{self.padding_length}d}.pt"
+
+
+    @staticmethod
+    @functools.lru_cache(maxsize=128)
+    def _request_patch_cached(tract_index, patch_index, butler_repo, butler_collections, skymap_name, bands_tuple):
+        """
+        Cached patch fetching using static method.
+
+        Static method means no 'self' in cache key, making it truly global.
+        Thread-safe because each call creates its own Butler instance.
+        """
+        try:
+            import lsst.daf.butler as butler
+
+            # Create fresh Butler instance for this call
+            thread_butler = butler.Butler(butler_repo, collections=butler_collections)
+            #thread_skymap = thread_butler.get("skyMap", {"skymap": skymap_name})
+
+            data = []
+            for band in bands_tuple:  # bands_tuple is hashable for cache key
+                butler_dict = {
+                    "tract": tract_index,
+                    "patch": patch_index,
+                    "skymap": skymap_name,
+                    "band": band,
+                }
+                image = thread_butler.get("deep_coadd", butler_dict)
+                data.append(image.getImage())
+
+            logger.debug(f"Fetched patch {tract_index}-{patch_index} from Butler")
+            return data
+
+        except Exception as e:
+            logger.error(f"Failed to fetch patch {tract_index}-{patch_index}: {e}")
+            raise
+
+    def _fetch_single_cutout(self, row, idx=None):
+        """Fetch cutout, using saved cutout if available."""
+        if idx is not None:
+            cutout_path = self._get_cutout_path(idx)
+            if cutout_path.exists():
+                return torch.load(cutout_path, map_location='cpu', weights_only=True)
+
+        # For main thread, use parent's method (original caching)
+        import threading
+        if threading.current_thread() is threading.main_thread():
+            cutout = super()._fetch_single_cutout(row)
+        else:
+            # For worker threads, use our cached method
+            cutout = self._fetch_cutout_with_cache(row)
+
+        # Save cutout if idx provided
+        if idx is not None:
+            cutout_path = self._get_cutout_path(idx)
+            torch.save(cutout, cutout_path)
+
+        return cutout
+
+    def _fetch_cutout_with_cache(self, row):
+        """Generate cutout using cached patch fetching."""
+        import numpy as np
+        from torch import from_numpy
+
+        # Get tract and patch info (using parent's methods)
+        tract_info, patch_info = self._get_tract_patch(row)
+        box_i = self._parse_box(patch_info, row)
+
+        # Use cached patch fetching - convert bands list to tuple for hashability
+        bands_tuple = tuple(self.BANDS)
+
+        patch_images = self._request_patch_cached(
+            tract_info.getId(),
+            patch_info.sequential_index,
+            self._butler_config['repo'],
+            self._butler_config['collections'], 
+            self._butler_config['skymap'],
+            bands_tuple
+        )
+
+        # Extract cutout from patch images
+        cutout_data = [image[box_i].getArray() for image in patch_images]
+        data_np = np.array(cutout_data)
+        data_torch = from_numpy(data_np.astype(np.float32))
+
+        return data_torch
+
+    def __getitem__(self, idxs):
+        """Modified to pass index for saving cutouts."""
+        # Handle single index
+        if isinstance(idxs, int):
+            row = self.catalog[idxs] if isinstance(self.catalog, Table) else self.catalog.iloc[idxs]
+            return self._fetch_single_cutout(row, idx=idxs)
+
+        # Handle multiple indices
+        cutouts = []
+        for idx in idxs:
+            row = self.catalog[idx] if isinstance(self.catalog, Table) else self.catalog.iloc[idx]
+            cutouts.append(self._fetch_single_cutout(row, idx=idx))
+
+        return cutouts
+
+    def download_cutouts(self, indices=None):
+        """Download cutouts using multiple threads with caching."""
+        from concurrent.futures import ThreadPoolExecutor, as_completed
+
+        if indices is None:
+            indices = range(len(self))
+
+        indices_to_download = [idx for idx in indices if not self._get_cutout_path(idx).exists()]
+
+        if not indices_to_download:
+            print("All cutouts already downloaded")
+            return
+
+        logger.info(f"Downloading {len(indices_to_download)} cutouts using "
+                   f"{self._determine_numprocs_download()} threads.")
+
+        with ThreadPoolExecutor(max_workers=self._determine_numprocs_download()) as executor:
+            futures = {executor.submit(self._download_single_cutout, idx): idx for idx in indices_to_download}
+
+            with tqdm(total=len(indices_to_download), desc="Downloading cutouts") as pbar:
+                for future in as_completed(futures):
+                    try:
+                        future.result()
+                        pbar.update(1)
+                    except Exception as e:
+                        idx = futures[future]
+                        logger.error(f"Failed to download cutout {idx}: {e}")
+                        pbar.update(1)
+
+        # Log cache stats
+        cache_info = self._request_patch_cached.cache_info()
+        logger.info(f"Download complete. Cache stats: {cache_info}")
+
+    def _download_single_cutout(self, idx):
+        """Helper method to download a single cutout."""
+        cutout_path = self._get_cutout_path(idx)
+        if cutout_path.exists():
+            return
+
+        row = self.catalog[idx] if isinstance(self.catalog, Table) else self.catalog.iloc[idx]
+        cutout = self._fetch_cutout_with_cache(row)
+        torch.save(cutout, cutout_path)
+
+    def get_cache_info(self):
+        """Get cache statistics."""
+        return self._request_patch_cached.cache_info()
+
+    def clear_cache(self):
+        """Clear the LRU cache."""
+        self._request_patch_cached.cache_clear()
+        logger.info("Cleared patch cache")
+
+    @staticmethod
+    def _determine_numprocs_download():
+        """Determine number of threads for downloading."""
+        return 1

--- a/src/hyrax/data_sets/downloaded_lsst_dataset.py
+++ b/src/hyrax/data_sets/downloaded_lsst_dataset.py
@@ -80,6 +80,9 @@ class DownloadedLSSTDataset(LSSTDataset):
         self.download_dir = Path(config["general"]["data_dir"])
         self.download_dir.mkdir(exist_ok=True)
 
+        self.config = config
+
+        # Initialize parent class with config
         super().__init__(config)
 
         # Store config for thread-local Butler creation
@@ -103,7 +106,10 @@ class DownloadedLSSTDataset(LSSTDataset):
         catalog_columns = self.catalog.colnames if hasattr(self.catalog, "colnames") else self.catalog.columns
 
         self.use_object_id = False
-        if "object_id" in catalog_columns:
+        if self.config["data_set"]["object_id_column_name"]:
+            self.use_object_id = True
+            self.object_id_column = self.config["data_set"]["object_id_column_name"]
+        elif "object_id" in catalog_columns:
             self.use_object_id = True
             self.object_id_column = "object_id"
         elif "objectId" in catalog_columns:

--- a/src/hyrax/hyrax_default_config.toml
+++ b/src/hyrax/hyrax_default_config.toml
@@ -195,7 +195,7 @@ use_cache = true
 # Warning: Only suitable for situations where the entire dataset fits in system memory
 preload_cache = true
 
-# Override the name of the object_id column for FitsImageDataset and HSCDataset
+# Override the name of the object_id column for FitsImageDataset, HSCDataset and DownloadedLSSTDataset
 object_id_column_name = false
 
 # Override the name of the filter column for FitsImageDataset and HSCDataset


### PR DESCRIPTION
1. LSSTDataset: Updates the LSSTDataset to add support for Astropy Tables (i.e., any file format that is supported by `astropy`) 

2. Updates the demo notebook to show the above feature

3. Introduces a new dataset called `DownloadedLSSTDataset` that inherits from `LSSTDataset`
     - This dataset downloads tensors and saves them as `.pt` files for rapid access
     - Uses the same LRU caching strategy as LSSTDataset; but multi-threads it 
     - Creates and updates a manifest file during download, similar to `HSCDataset` 
     - Provides some convenience functions to monitor / help during donwload. 
     

Notes:- 
- Tested that this works on the RSP
- @mtauraso & @drewoldag : If either you think this code will benefit from refactoring or other major structural changes; please feel free to push directly to this branch/PR. 