### PR TITLE
Flatten vectors and check for tuples

### DIFF
--- a/src/hyrax/pytorch_ignite.py
+++ b/src/hyrax/pytorch_ignite.py
@@ -276,6 +276,10 @@ def create_splits(data_set: Dataset, config: ConfigDict):
 def _handle_nans(batch, config):
     from torch import any, isnan
 
+    # If `batch` is a tuple, assume the first element is a tensor.
+    if isinstance(batch, tuple):
+        batch = batch[0]
+
     if config["data_set"]["nan_mode"] is False:
         if any(isnan(batch)):
             msg = "Input data contains NaN values. This may mean your model output is all NaNs."

--- a/src/hyrax/verbs/save_to_database.py
+++ b/src/hyrax/verbs/save_to_database.py
@@ -140,6 +140,9 @@ class SaveToDatabase(Verb):
 
             # Retrieve the vectors from the batch file using the ids. We use the
             # ids here so that we only have to open one file to get the vectors.
-            vectors = inference_data_set._load_from_batch_file(batch, ids)
+            inference_data = inference_data_set._load_from_batch_file(batch, ids)
 
-            vector_db.insert(ids=list(vectors["id"]), vectors=list(vectors["tensor"]))
+            # Flatten the vectors and turn them into a list of np.arrays.
+            vectors = list(inference_data["tensor"].reshape(len(inference_data["tensor"]), -1))
+
+            vector_db.insert(ids=list(inference_data["id"]), vectors=vectors)

--- a/tests/hyrax/conftest.py
+++ b/tests/hyrax/conftest.py
@@ -52,10 +52,11 @@ class RandomDataset(HyraxDataset, Dataset):
 
         print(f"Initialized dataset with dim 1: {dim_1_length}, dim 2: {dim_2_length}")
 
-        if dim_2_length > 0:
-            self.data = rng.random((size, dim_1_length, dim_2_length), np.float32)
-        else:
-            self.data = rng.random((size, dim_1_length), np.float32)
+        self.data = rng.random((size, 2, 3), np.float32)
+        # if dim_2_length > 0:
+        #     self.data = rng.random((size, dim_1_length, dim_2_length), np.float32)
+        # else:
+        #     self.data = rng.random((size, dim_1_length), np.float32)
 
         # Start our IDs at a random integer between 0 and 100
         id_start = rng.integers(100)

--- a/tests/hyrax/conftest.py
+++ b/tests/hyrax/conftest.py
@@ -46,13 +46,11 @@ class RandomDataset(HyraxDataset, Dataset):
     def __init__(self, config):
         size = config["data_set"]["size"]
         dim_1_length = config["data_set"]["dimension_1_length"]
-
-        dim_2_length = (
-            config["data_set"]["dimension_2_length"] if config["data_set"]["dimension_2_length"] else 0
-        )
-
+        dim_2_length = config["data_set"]["dimension_2_length"]
         seed = config["data_set"]["seed"]
         rng = np.random.default_rng(seed)
+
+        print(f"Initialized dataset with dim 1: {dim_1_length}, dim 2: {dim_2_length}")
 
         if dim_2_length > 0:
             self.data = rng.random((size, dim_1_length, dim_2_length), np.float32)

--- a/tests/hyrax/conftest.py
+++ b/tests/hyrax/conftest.py
@@ -45,9 +45,19 @@ class RandomDataset(HyraxDataset, Dataset):
 
     def __init__(self, config):
         size = config["data_set"]["size"]
+        dim_1_length = config["data_set"]["dimension_1_length"]
+
+        dim_2_length = (
+            config["data_set"]["dimension_2_length"] if config["data_set"]["dimenstion_2_length"] else 0
+        )
+
         seed = config["data_set"]["seed"]
         rng = np.random.default_rng(seed)
-        self.data = rng.random((size, 2), np.float32)
+
+        if dim_2_length > 0:
+            self.data = rng.random((size, dim_1_length, dim_2_length), np.float32)
+        else:
+            self.data = rng.random((size, dim_1_length), np.float32)
 
         # Start our IDs at a random integer between 0 and 100
         id_start = rng.integers(100)
@@ -93,6 +103,8 @@ def loopback_hyrax(tmp_path_factory, request):
     h.config["data_set"]["name"] = request.param
     h.config["data_set"]["size"] = 20
     h.config["data_set"]["seed"] = 0
+    h.config["data_set"]["dimension_1_length"] = 2
+    h.config["data_set"]["dimension_2_length"] = 3
 
     h.config["data_set"]["validate_size"] = 0.2
     h.config["data_set"]["test_size"] = 0.2

--- a/tests/hyrax/conftest.py
+++ b/tests/hyrax/conftest.py
@@ -48,7 +48,7 @@ class RandomDataset(HyraxDataset, Dataset):
         dim_1_length = config["data_set"]["dimension_1_length"]
 
         dim_2_length = (
-            config["data_set"]["dimension_2_length"] if config["data_set"]["dimenstion_2_length"] else 0
+            config["data_set"]["dimension_2_length"] if config["data_set"]["dimension_2_length"] else 0
         )
 
         seed = config["data_set"]["seed"]

--- a/tests/hyrax/test_infer.py
+++ b/tests/hyrax/test_infer.py
@@ -1,40 +1,6 @@
 import numpy as np
 import pytest
 
-import hyrax
-
-
-@pytest.fixture(scope="function", params=["RandomDataset", "RandomIterableDataset"])
-def loopback_hyrax(tmp_path_factory, request):
-    """This generates a loopback hyrax instance
-    which is configured to use the loopback model
-    and a simple dataset yielding random numbers
-    """
-    results_dir = tmp_path_factory.mktemp(f"loopback_hyrax_{request.param}")
-
-    h = hyrax.Hyrax()
-    h.config["model"]["name"] = "LoopbackModel"
-    h.config["train"]["epochs"] = 1
-    h.config["data_loader"]["batch_size"] = 5
-    h.config["general"]["results_dir"] = str(results_dir)
-
-    h.config["general"]["dev_mode"] = True
-    h.config["data_set"]["name"] = request.param
-    h.config["data_set"]["size"] = 20
-    h.config["data_set"]["seed"] = 0
-
-    h.config["data_set"]["validate_size"] = 0.2
-    h.config["data_set"]["test_size"] = 0.2
-    h.config["data_set"]["train_size"] = 0.6
-
-    weights_file = results_dir / "fakeweights"
-    with open(weights_file, "a"):
-        pass
-    h.config["infer"]["model_weights_file"] = str(weights_file)
-
-    dataset = h.prepare()
-    return h, dataset
-
 
 @pytest.mark.parametrize("shuffle", [True, False])
 @pytest.mark.parametrize("split", ["test", "train", "validate", None])
@@ -61,4 +27,4 @@ def test_infer_order(loopback_hyrax, split, shuffle):
 
         print(f"orig idx: {dataset_idx}, infer idx: {idx}")
         print(f"orig data: {dataset[dataset_idx]}, infer data: {inference_results[idx]}")
-        assert all(np.isclose(dataset[dataset_idx], inference_results[idx]))
+        assert np.all(np.isclose(dataset[dataset_idx], inference_results[idx]))

--- a/tests/hyrax/test_inference_dataset.py
+++ b/tests/hyrax/test_inference_dataset.py
@@ -1,42 +1,8 @@
 import numpy as np
 import pytest
-from astropy.table import Table
-from torch import from_numpy
-from torch.utils.data import Dataset
 
 import hyrax
-from hyrax.data_sets import HyraxDataset
 from hyrax.data_sets.inference_dataset import InferenceDataSet, InferenceDataSetWriter
-
-
-class RandomDataset(HyraxDataset, Dataset):
-    """Dataset yielding pairs of random numbers. Requires a seed to emulate
-    static data on the filesystem between instantiations"""
-
-    def __init__(self, config):
-        size = config["data_set"]["size"]
-        seed = config["data_set"]["seed"]
-        rng = np.random.default_rng(seed)
-        self.data = rng.random((size, 2), np.float32)
-
-        # Start our IDs at a random integer between 0 and 100
-        id_start = rng.integers(100)
-        self.id_list = list(range(id_start, id_start + size))
-
-        metadata_table = Table({"object_id": np.array(list(self.ids()))})
-
-        super().__init__(config, metadata_table)
-
-    def __getitem__(self, idx):
-        return from_numpy(self.data[idx])
-
-    def __len__(self):
-        return len(self.data)
-
-    def ids(self):
-        """Yield IDs for the dataset"""
-        for id_item in self.id_list:
-            yield str(id_item)
 
 
 @pytest.fixture(scope="session", params=[1, 2, 3, 4, 5])
@@ -105,7 +71,7 @@ def test_order(inference_dataset):
     # Check all data is the correct data for that ID
     for result_i in range(20):
         for orig_i in range(20):
-            if all(orig[orig_i].numpy() == result[result_i].numpy()):
+            if np.all(orig[orig_i].numpy() == result[result_i].numpy()):
                 try:
                     assert orig_ids[orig_i] == result_ids[result_i]
                     assert orig_meta_ids[orig_i] == result_meta_ids[result_i]

--- a/tests/hyrax/test_save_to_database.py
+++ b/tests/hyrax/test_save_to_database.py
@@ -10,7 +10,8 @@ def test_save_to_database(loopback_inferred_hyrax):
     original_dataset_ids = list(dataset.ids())
 
     h.config["vector_db"]["name"] = "chromadb"
-
+    dim_1_length = h.config["data_set"]["dimension_1_length"]
+    dim_2_length = h.config["data_set"]["dimension_2_length"]
     # Populate the vector database with the results of inference
     vdb_path = h.config["general"]["results_dir"]
     h.save_to_database(output_dir=vdb_path)
@@ -22,5 +23,6 @@ def test_save_to_database(loopback_inferred_hyrax):
     for indx, id in enumerate(inference_result_ids):
         assert id == original_dataset_ids[indx]
         result = db_connection.get_by_id(id)
+        saved_value = result[id].reshape(dim_1_length, dim_2_length)
         original_value = dataset[indx]
-        assert np.all(result[id] == original_value.numpy())
+        assert np.all(saved_value == original_value.numpy())

--- a/tests/hyrax/test_umap.py
+++ b/tests/hyrax/test_umap.py
@@ -44,6 +44,9 @@ def test_umap_order(loopback_inferred_hyrax):
     umap_result_ids = list(umap_results.ids())
     original_dataset_ids = list(dataset.ids())
 
+    dim_1_length = h.config["data_set"]["dimension_1_length"]
+    dim_2_length = h.config["data_set"]["dimension_2_length"]
+
     for idx, result_id in enumerate(umap_result_ids):
         dataset_idx = None
         for i, orig_id in enumerate(original_dataset_ids):
@@ -53,6 +56,8 @@ def test_umap_order(loopback_inferred_hyrax):
         else:
             raise AssertionError("Failed to find a corresponding ID")
 
+        umap_result = umap_results[idx].cpu().numpy().reshape(dim_1_length, dim_2_length)
+
         print(f"orig idx: {dataset_idx}, umap idx: {idx}")
-        print(f"orig data: {dataset[dataset_idx]}, umap data: {umap_results[idx]}")
-        assert all(np.isclose(dataset[dataset_idx], umap_results[idx]))
+        print(f"orig data: {dataset[dataset_idx]}, umap data: {umap_result}")
+        assert np.all(np.isclose(dataset[dataset_idx], umap_result))


### PR DESCRIPTION
Flattening vectors before inserting into vector db, checking if batch is tuple before de-NaN-ifying.


- The verb `save_to_database` was not flattening the vectors before attempting to insert them into the database, now it does.

- Additionally, in the `_handle_nan` function, if a batch is provided that is a tuple, the `torch.any(torch.isnan(batch))` logic would fail, complaining that the batch wasn't a tensor. I added a little type check-and-convert with the assumption that getting to a working solution is better for now, even if it's not the idealized solution. 

