### PR TITLE
Fixing bug in `_handle_nans` treatment of tuple inputs

### DIFF
--- a/tests/hyrax/conftest.py
+++ b/tests/hyrax/conftest.py
@@ -33,6 +33,8 @@ class LoopbackModel(nn.Module):
 
     def forward(self, x):
         """We simply return our input"""
+        if isinstance(x, tuple):
+            x, label = x
         return x
 
     def train_step(self, batch):

--- a/tests/hyrax/test_nan.py
+++ b/tests/hyrax/test_nan.py
@@ -126,7 +126,7 @@ def test_nan_handling_off(loopback_hyrax_nan):
     assert any(result_nans)
 
 
-def test_non_handling_off_returns_input(loopback_hyrax_nan):
+def test_nan_handling_off_returns_input(loopback_hyrax_nan):
     """Ensure that when nan_mode is False, that the original values passed to
     _handle_nans are returned unchanged."""
 


### PR DESCRIPTION
Implementing single dispatch for nan-handling. Might be over doing it but it makes nice separation. Added and updated tests.

The root cause was that I was overriding the value of `batch` with `batch[0]` when the input type of `batch` was a tuple. Thus, when batch was returned, it had lost all the other elements of the tuple. 

This is fixed now. The singledispatch approach allows slightly cleaner treatment of logic necessary. This is mostly to address the case of recombining the values from `_handle_nan_quantile` and any future nan handling approaches taken. Really I just didn't want to have piles of `if isinstance(batch, tuple)` all over the place. 

Also added a test to make sure this is working as expected for our dataset types, and updated the HyraxLoopback model to handle tuples appropriately. (It's starting to make me wonder more if HyraxLoopback should be a real model just to help people get their pipelines set up - @mtauraso originally pitched that idea IIRC)