### PR TITLE
Adding chromadb shard size and vector size configs

### DIFF
--- a/src/hyrax/hyrax_default_config.toml
+++ b/src/hyrax/hyrax_default_config.toml
@@ -246,8 +246,8 @@ infer_results_dir = false
 # value will decrease insert times while increasing search times.
 shard_size_limit = 65536
 
-# Inserting vectors with a total number of elements >= this value will log a warning
-# message. ChromaDB performance degrades when working vectors of this size or larger.
+# Inserting vectors with more than this many elements logs a warning message. ChromaDB
+# performance degrades with vectors of this size. Set to "false" to disable warning.
 vector_size_warning = 10000
 
 

--- a/src/hyrax/hyrax_default_config.toml
+++ b/src/hyrax/hyrax_default_config.toml
@@ -240,6 +240,17 @@ vector_db_dir = false
 # inference results.
 infer_results_dir = false
 
+
+["vector_db.chromadb"]
+# The approximate maximum size of a shard before creating a new one. A smaller
+# value will decrease insert times while increasing search times.
+shard_size_limit = 65536
+
+# Inserting vectors with a total number of elements >= this value will log a warning
+# message. ChromaDB performance degrades when working vectors of this size or larger.
+vector_size_warning = 10000
+
+
 [results]
 # Path to inference results to use for visualization and lookups. Uses latest inference run if none provided.
 inference_dir = false

--- a/src/hyrax/vector_dbs/chromadb_impl.py
+++ b/src/hyrax/vector_dbs/chromadb_impl.py
@@ -79,6 +79,9 @@ class ChromaDB(VectorDB):
         # The approximate maximum size of a shard before a new one is created
         self.shard_size_limit = self.config["vector_db.chromadb"]["shard_size_limit"]
 
+        # If set, inserting a vector with number of elements >= this logs a warning.
+        self.vector_size_limit = self.config["vector_db.chromadb"]["vector_size_warning"]
+
         # Min number of shards before using multiprocess to parallelize the search
         self.min_shards_for_parallelization = MIN_SHARDS_FOR_PARALLELIZATION
 
@@ -137,7 +140,7 @@ class ChromaDB(VectorDB):
             # no new vectors to insert
             return
 
-        if len(vectors[0]) >= self.config["vector_db.chromadb"]["vector_size_warning"]:
+        if self.vector_size_limit and len(vectors[0]) >= self.vector_size_limit:
             logger.warning(
                 f"Attempting to insert vectors with length: {len(vectors[0])}.\
                            Chroma DB often has poor performance when working with vectors\

--- a/src/hyrax/vector_dbs/chromadb_impl.py
+++ b/src/hyrax/vector_dbs/chromadb_impl.py
@@ -1,3 +1,4 @@
+import logging
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from typing import Optional, Union
 
@@ -7,6 +8,8 @@ import numpy as np
 from hyrax.vector_dbs.vector_db_interface import VectorDB
 
 MIN_SHARDS_FOR_PARALLELIZATION = 50
+
+logger = logging.getLogger()
 
 
 def _query_for_nn(results_dir: str, shard_name: str, vectors: list[np.ndarray], k: int):
@@ -74,7 +77,7 @@ class ChromaDB(VectorDB):
         self.shard_size = 0  # The number of vectors in the current shard
 
         # The approximate maximum size of a shard before a new one is created
-        self.shard_size_limit = 65_536
+        self.shard_size_limit = self.config["vector_db.chromadb"]["shard_size_limit"]
 
         # Min number of shards before using multiprocess to parallelize the search
         self.min_shards_for_parallelization = MIN_SHARDS_FOR_PARALLELIZATION
@@ -133,6 +136,13 @@ class ChromaDB(VectorDB):
         if len(ids) == 0:
             # no new vectors to insert
             return
+
+        if len(vectors[0]) >= self.config["vector_db.chromadb"]["vector_size_warning"]:
+            logger.warning(
+                f"Attempting to insert vectors with length: {len(vectors[0])}.\
+                           Chroma DB often has poor performance when working with vectors\
+                           larger than {self.config['vector_db.chromadb']['vector_size_warning']}"
+            )
 
         # increment counter, if exceeds shard limit, create a new collection
         self.shard_size += len(ids)

--- a/tests/hyrax/test_chromadb_impl.py
+++ b/tests/hyrax/test_chromadb_impl.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 
+from hyrax import Hyrax
 from hyrax.vector_dbs.chromadb_impl import ChromaDB
 
 
@@ -19,7 +20,8 @@ def random_vector_generator(batch_size=1):
 @pytest.fixture()
 def chromadb_instance(tmp_path):
     """Create a ChromaDB instance for testing"""
-    chromadb_instance = ChromaDB({}, {"results_dir": tmp_path})
+    h = Hyrax()
+    chromadb_instance = ChromaDB(h.config, {"results_dir": tmp_path})
     chromadb_instance.connect()
     chromadb_instance.create()
     return chromadb_instance
@@ -27,7 +29,8 @@ def chromadb_instance(tmp_path):
 
 def test_connect(tmp_path):
     """Test that we can create a connections to the database"""
-    chromadb_instance = ChromaDB({}, {"results_dir": tmp_path})
+    h = Hyrax()
+    chromadb_instance = ChromaDB(h.config, {"results_dir": tmp_path})
     chromadb_instance.connect()
 
     assert chromadb_instance.chromadb_client is not None


### PR DESCRIPTION
Adding configuration for shard size and warning for large vectors to chromadb_impl.

The user now has easier control over the shard size of the chromadb vector database. Additionally, a warning is emitted if the user is trying to insert vectors with >= 10k elements. And the 10k value is configurable in the config as well so they can easily turn off the warnings by setting this to false.