### PR TITLE
Fixed logging for fits_image_dataset

### DIFF
--- a/src/hyrax/data_sets/fits_image_dataset.py
+++ b/src/hyrax/data_sets/fits_image_dataset.py
@@ -436,11 +436,11 @@ class FitsImageDataSet(HyraxDataset, Dataset):
         log = log_every is not None and isinstance(log_every, int)
         for index, object_id in enumerate(self.files):
             if log and index != 0 and index % log_every == 0:
-                logger.info(f"Processed {index+1} objects")
+                logger.info(f"Processed {index + 1} objects")
             yield str(object_id)
         else:
             if log:
-                logger.info(f"Processed {index+1} objects")
+                logger.info(f"Processed {index + 1} objects")
 
     def _all_files(self):
         """

--- a/src/hyrax/data_sets/fits_image_dataset.py
+++ b/src/hyrax/data_sets/fits_image_dataset.py
@@ -436,11 +436,11 @@ class FitsImageDataSet(HyraxDataset, Dataset):
         log = log_every is not None and isinstance(log_every, int)
         for index, object_id in enumerate(self.files):
             if log and index != 0 and index % log_every == 0:
-                logger.info(f"Processed {index} objects")
+                logger.info(f"Processed {index+1} objects")
             yield str(object_id)
         else:
             if log:
-                logger.info(f"Processed {index} objects")
+                logger.info(f"Processed {index+1} objects")
 
     def _all_files(self):
         """


### PR DESCRIPTION
<!-- 
Thank you for your contribution to the repo :)

Pull Request (PR) Instructions:
Provide a general summary of your changes in the Title above. Fill out each section of the template, and replace the space with an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! Once you are satisfied with the pull request, click the "Create pull request" button to submit it for review.

Before submitting this PR, please ensure that your input and responses are entered in the designated space provided below each section to keep all project-related information organized and easily accessible.
 
How to link to a PR:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue 
-->

## Change Description
<!--- 
Describe your changes in detail. In your description, you should answer questions like "Why is this change required? What problem does it solve?".

If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged.
-->
- [ ] My PR includes a link to the issue that I am addressing



## Solution Description
<!-- Please explain the technical solution that I have provided and how it addresses the issue or feature being implemented -->
As you can see below, `FitsImageDataSet` has 5 objects, but it would say that it only processed 4.


<img width="944" height="537" alt="Screenshot 2025-07-10 at 12 35 45 PM" src="https://github.com/user-attachments/assets/26f31139-ca9c-4541-8d29-8a2613f1052d" />


The logging would print the {index} amount of objects, which start from 0 and is always 1 off from the true number of objects processed. Now it is {index+1}.
