### PR TITLE
Read inference_dir as `None` if it's `false` in the config

### DIFF
--- a/src/hyrax/verbs/visualize.py
+++ b/src/hyrax/verbs/visualize.py
@@ -95,7 +95,9 @@ class Visualize(Verb):
         # If no input directory is specified, read from config.
         if input_dir is None:
             logger.info("UMAP directory not specified at runtime. Reading from config values.")
-            input_dir = self.config["results"]["inference_dir"]
+            input_dir = (
+                self.config["results"]["inference_dir"] if self.config["results"]["inference_dir"] else None
+            )
 
         # Get the umap data and put it in a kdtree for indexing.
         self.umap_results = InferenceDataSet(self.config, results_dir=input_dir, verb="umap")


### PR DESCRIPTION
The run method of visualize was taking the `inference_dir` value directly from the config (it defaults to `False`) and passing that to instantiate the InferenceDataset. 

InferenceDataset expects a Path or str (or None) as the data types for `result_dir`. 

The change here will set `input_dir` to `None` if it is `false` in the config.