### PR TITLE
WIP - Investigating use of parquet as output format for InferenceDataset

### DIFF
--- a/docs/pre_executed/random_parquet.ipynb
+++ b/docs/pre_executed/random_parquet.ipynb
@@ -49,6 +49,16 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "845aa3da",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "h.save_to_database()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "d7f79cb1",
    "metadata": {},
    "outputs": [],

--- a/docs/pre_executed/random_parquet.ipynb
+++ b/docs/pre_executed/random_parquet.ipynb
@@ -1,0 +1,363 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "a72367cd",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[2025-08-18 16:26:09,122 hyrax:INFO] Runtime Config read from: /Users/drew/code/hyrax/src/hyrax/hyrax_default_config.toml\n"
+     ]
+    }
+   ],
+   "source": [
+    "from hyrax import Hyrax\n",
+    "h = Hyrax()\n",
+    "# h.config['data_set']['name'] = 'HyraxRandomDataset'\n",
+    "# h.config['data_set']['random_dataset']['size'] = 10_000\n",
+    "# h.config['data_set']['random_dataset']['shape'] = (3, 41, 41)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "47f647b1",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[2025-08-18 16:26:15,390 hyrax.models.model_registry:INFO] Using criterion: torch.nn.CrossEntropyLoss with default arguments.\n",
+      "2025-08-18 16:26:15,405 ignite.distributed.auto.auto_dataloader INFO: Use data loader kwargs for dataset '<hyrax.data_sets.hyr': \n",
+      "\t{'sampler': <hyrax.pytorch_ignite.SubsetSequentialSampler object at 0x16b0263c0>, 'batch_size': 512, 'shuffle': False, 'pin_memory': False}\n",
+      "2025-08-18 16:26:15,406 ignite.distributed.auto.auto_dataloader INFO: Use data loader kwargs for dataset '<hyrax.data_sets.hyr': \n",
+      "\t{'sampler': <hyrax.pytorch_ignite.SubsetSequentialSampler object at 0x16b027740>, 'batch_size': 512, 'shuffle': False, 'pin_memory': False}\n",
+      "/Users/drew/opt/miniconda3/envs/hyrax/lib/python3.12/site-packages/ignite/handlers/tqdm_logger.py:127: TqdmExperimentalWarning: Using `tqdm.autonotebook.tqdm` in notebook mode. Use `tqdm.tqdm` instead to force console mode (e.g. in jupyter console)\n",
+      "  from tqdm.autonotebook import tqdm\n",
+      "2025/08/18 16:26:15 INFO mlflow.system_metrics.system_metrics_monitor: Skip logging GPU metrics. Set logger level to DEBUG for more details.\n",
+      "2025/08/18 16:26:15 INFO mlflow.system_metrics.system_metrics_monitor: Started monitoring system metrics.\n",
+      "[2025-08-18 16:26:15,531 hyrax.pytorch_ignite:INFO] Training model on device: mps\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "62c9ca58d34c4291b87566b2a6211e4e",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  2%|1         | 1/59 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[2025-08-18 16:26:21,129 hyrax.pytorch_ignite:INFO] Total training time: 5.60[s]\n",
+      "[2025-08-18 16:26:21,130 hyrax.pytorch_ignite:INFO] Latest checkpoint saved as: /Users/drew/code/hyrax/docs/pre_executed/results/20250818-162611-train-KDT0/checkpoint_epoch_1.pt\n",
+      "[2025-08-18 16:26:21,130 hyrax.pytorch_ignite:INFO] Best metric checkpoint saved as: /Users/drew/code/hyrax/docs/pre_executed/results/20250818-162611-train-KDT0/checkpoint_1_loss=-357.3800.pt\n",
+      "2025/08/18 16:26:21 INFO mlflow.system_metrics.system_metrics_monitor: Stopping system metrics monitoring...\n",
+      "2025/08/18 16:26:21 INFO mlflow.system_metrics.system_metrics_monitor: Successfully terminated system metrics monitoring!\n",
+      "[2025-08-18 16:26:21,145 hyrax.verbs.train:INFO] Finished Training\n",
+      "[2025-08-18 16:26:21,642 hyrax.model_exporters:INFO] Exported model to ONNX format: /Users/drew/code/hyrax/docs/pre_executed/results/20250818-162611-train-KDT0/example_model_opset_20.onnx\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "HyraxAutoencoder(\n",
+       "  (encoder): Sequential(\n",
+       "    (0): Conv2d(3, 32, kernel_size=(3, 3), stride=(2, 2), padding=(1, 1))\n",
+       "    (1): GELU(approximate='none')\n",
+       "    (2): Conv2d(32, 32, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))\n",
+       "    (3): GELU(approximate='none')\n",
+       "    (4): Conv2d(32, 64, kernel_size=(3, 3), stride=(2, 2), padding=(1, 1))\n",
+       "    (5): GELU(approximate='none')\n",
+       "    (6): Conv2d(64, 64, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))\n",
+       "    (7): GELU(approximate='none')\n",
+       "    (8): Conv2d(64, 64, kernel_size=(3, 3), stride=(2, 2), padding=(1, 1))\n",
+       "    (9): GELU(approximate='none')\n",
+       "    (10): Flatten(start_dim=1, end_dim=-1)\n",
+       "    (11): Linear(in_features=1024, out_features=64, bias=True)\n",
+       "  )\n",
+       "  (dec_linear): Sequential(\n",
+       "    (0): Linear(in_features=64, out_features=1024, bias=True)\n",
+       "    (1): GELU(approximate='none')\n",
+       "  )\n",
+       "  (decoder): Sequential(\n",
+       "    (0): ConvTranspose2d(64, 64, kernel_size=(3, 3), stride=(2, 2), padding=(1, 1), output_padding=(1, 1))\n",
+       "    (1): GELU(approximate='none')\n",
+       "    (2): Conv2d(64, 64, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))\n",
+       "    (3): GELU(approximate='none')\n",
+       "    (4): ConvTranspose2d(64, 32, kernel_size=(3, 3), stride=(2, 2), padding=(1, 1), output_padding=(1, 1))\n",
+       "    (5): GELU(approximate='none')\n",
+       "    (6): Conv2d(32, 32, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))\n",
+       "    (7): GELU(approximate='none')\n",
+       "    (8): ConvTranspose2d(32, 3, kernel_size=(3, 3), stride=(2, 2), padding=(1, 1), output_padding=(1, 1))\n",
+       "    (9): Tanh()\n",
+       "  )\n",
+       "  (criterion): CrossEntropyLoss()\n",
+       ")"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "h.config['train']['epochs'] = 1\n",
+    "# h.config['model']['name'] = 'HyraxCNN'\n",
+    "# h.config['model']['hyrax_cnn']['output_classes'] = 3\n",
+    "\n",
+    "h.train()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "bb0311a0",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[2025-08-18 16:26:25,268 hyrax.models.model_registry:INFO] Using criterion: torch.nn.CrossEntropyLoss with default arguments.\n",
+      "[2025-08-18 16:26:25,269 hyrax.verbs.infer:INFO] data set has length 50000\n",
+      "2025-08-18 16:26:25,270 ignite.distributed.auto.auto_dataloader INFO: Use data loader kwargs for dataset '<hyrax.data_sets.hyr': \n",
+      "\t{'sampler': None, 'batch_size': 512, 'shuffle': False, 'pin_memory': False}\n",
+      "[2025-08-18 16:26:25,280 hyrax.verbs.infer:INFO] Saving inference results at: /Users/drew/code/hyrax/docs/pre_executed/results/20250818-162621-infer-zk3O\n",
+      "[2025-08-18 16:26:25,467 hyrax.pytorch_ignite:INFO] Evaluating model on device: mps\n",
+      "[2025-08-18 16:26:25,468 hyrax.pytorch_ignite:INFO] Total epochs: 1\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "916cae80d2e148219374ee579c725964",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  1%|1         | 1/98 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[2025-08-18 16:26:30,388 hyrax.pytorch_ignite:INFO] Total evaluation time: 4.92[s]\n",
+      "[2025-08-18 16:26:30,443 hyrax.verbs.infer:INFO] Inference Complete.\n"
+     ]
+    }
+   ],
+   "source": [
+    "ds = h.infer()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "4c936fd1",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "tensor([[ 8.2588e-01,  1.8817e+00, -8.6632e-02, -2.6173e-01,  1.6635e+00,\n",
+       "          3.0351e-01,  8.5987e-01,  1.3563e+00,  7.2110e-01, -9.2282e-01,\n",
+       "          1.7628e-01,  9.0702e-01, -5.5977e-01,  7.7089e-01,  5.0296e-01,\n",
+       "         -1.1167e+00,  8.3786e-01, -7.5270e-01,  2.3004e+00,  1.1066e+00,\n",
+       "          8.6355e-01,  1.0416e+00,  2.0365e-01, -1.8310e+00, -1.2457e+00,\n",
+       "         -1.4892e+00, -2.5756e-01, -1.5162e+00, -2.7329e+00, -3.9386e-01,\n",
+       "          1.6330e+00,  4.9924e-03, -5.7766e-02, -1.2319e-01, -6.4349e-02,\n",
+       "         -4.5615e-01, -1.1544e+00, -1.4566e+00,  1.0005e+00, -1.2052e+00,\n",
+       "          1.6361e+00,  2.9691e+00, -6.5868e-01, -8.4884e-01,  8.8773e-01,\n",
+       "          1.0800e-01, -4.1050e-02, -3.5328e+00,  1.9987e+00,  6.2507e-02,\n",
+       "          5.1641e-01,  5.1441e-01,  1.5979e+00,  6.1225e-01, -7.3815e-01,\n",
+       "         -2.8229e+00, -1.1311e+00, -1.7349e+00, -8.8074e-01,  5.8053e-01,\n",
+       "          2.0290e+00,  1.4515e+00, -5.7942e-01, -2.2863e+00],\n",
+       "        [-1.8638e+00,  1.6474e+00,  1.2942e+00,  2.6285e+00, -5.3237e-01,\n",
+       "         -9.1890e-01,  1.4413e+00, -2.2368e+00,  3.2656e+00,  1.7891e+00,\n",
+       "          1.2822e+00, -8.5861e-01, -2.4984e+00, -5.9200e-01, -3.2084e+00,\n",
+       "          2.7060e+00, -1.8733e+00,  1.6886e+00,  9.7744e-01,  6.7465e-01,\n",
+       "          1.8386e+00,  1.4043e+00, -1.9525e+00, -3.3646e+00, -1.2194e+00,\n",
+       "         -3.7596e+00,  2.4909e-01, -4.3790e+00, -2.8164e+00, -1.2411e+00,\n",
+       "         -1.4035e+00, -3.9871e+00,  1.3360e+00,  1.0409e+00, -3.2809e-01,\n",
+       "         -4.3863e-01, -4.7392e-01,  1.8710e+00,  2.2132e+00, -4.2567e+00,\n",
+       "          1.4478e+00,  6.5822e-01, -1.1808e+00, -1.4641e+00,  1.1896e+00,\n",
+       "          3.7631e+00, -1.0718e+00, -3.6106e+00,  2.7578e+00,  3.0404e-01,\n",
+       "          1.2880e+00, -3.0260e-01, -6.4776e-01,  1.3154e-01, -2.1639e+00,\n",
+       "         -1.8378e+00,  1.7767e+00, -4.1950e+00, -3.3926e+00, -2.5583e+00,\n",
+       "         -7.4612e-01,  1.5366e+00, -4.9807e-01, -3.2541e+00],\n",
+       "        [ 9.1252e+00,  2.6852e+00, -5.0103e-01, -3.1083e+00,  2.6907e+00,\n",
+       "          3.0270e-01,  7.3212e+00, -1.3294e+00, -4.4973e+00, -9.0405e-01,\n",
+       "          2.2374e-01, -1.0708e+00,  6.1727e+00,  4.2572e+00,  2.6065e+00,\n",
+       "         -1.2101e+00,  2.1371e+00, -3.1564e+00,  8.3735e+00, -7.8278e+00,\n",
+       "         -3.9114e+00, -3.1876e+00,  1.7429e+00, -7.0203e-02,  3.4703e+00,\n",
+       "          3.5852e+00,  8.1255e+00,  1.3436e+00,  1.5095e+00,  5.5257e-01,\n",
+       "          1.6718e+00,  8.4553e+00,  1.8557e+00, -2.8962e-01,  4.5964e+00,\n",
+       "          3.9063e+00,  1.6253e+00, -2.4102e+00, -1.7235e+00,  2.9188e+00,\n",
+       "          8.2193e-01,  5.3422e+00,  5.8919e+00, -1.5443e+00,  4.6577e+00,\n",
+       "         -2.4533e+00, -8.9942e+00,  1.2615e+00,  1.1246e-01,  1.2246e+00,\n",
+       "         -2.0967e+00, -5.1056e+00,  8.2227e+00, -1.4352e+00,  2.2767e+00,\n",
+       "          9.8109e+00,  5.8141e+00,  2.8233e+00,  2.8774e+00,  2.8049e-01,\n",
+       "         -1.3116e+00, -6.9024e-01, -3.3581e+00,  3.7914e+00],\n",
+       "        [ 2.4166e+00,  4.5367e+00,  3.4935e+00, -4.0383e+00,  3.3331e+00,\n",
+       "          2.1223e+00,  7.8645e+00,  1.8972e+00, -7.4950e-01, -8.2478e+00,\n",
+       "          4.4108e-01, -4.7144e+00,  5.1176e+00,  1.9898e+00,  7.3030e+00,\n",
+       "         -6.3822e+00,  7.9458e+00, -4.3932e+00,  5.6662e+00, -4.3106e+00,\n",
+       "         -1.4209e+00,  9.1675e-02, -2.8994e+00,  4.1698e+00,  4.6921e+00,\n",
+       "         -4.9870e-02,  6.8865e+00, -7.4052e+00, -2.6820e+00,  1.4404e+00,\n",
+       "          5.7161e+00,  2.3878e+00,  8.5746e+00, -3.3502e-02,  2.4380e+00,\n",
+       "          1.6036e+00, -1.9574e+00, -4.4522e+00,  4.3862e+00,  3.3441e-01,\n",
+       "         -1.6480e-02,  3.6642e+00,  8.5626e-01,  3.3176e+00,  1.8293e+00,\n",
+       "          7.8217e+00, -3.5750e+00,  5.5294e+00,  2.3035e+00,  1.7096e+00,\n",
+       "          1.3585e+00, -1.1679e-02,  2.9931e+00, -5.6309e+00, -4.6791e-01,\n",
+       "          1.0019e+01,  6.0152e+00, -1.6427e+00,  1.1137e+00,  1.4178e+00,\n",
+       "          3.6636e+00, -3.7802e+00, -2.9396e+00,  6.0465e+00],\n",
+       "        [-1.5818e-01,  1.3229e+00, -1.0622e+00,  1.4643e+00, -1.4856e+00,\n",
+       "         -2.6712e+00,  2.7149e+00, -2.5642e+00,  2.5741e+00,  7.8925e+00,\n",
+       "          1.9215e+00, -3.2695e+00, -2.2950e+00, -2.5061e+00, -1.8414e+00,\n",
+       "          3.9399e+00, -4.8842e+00,  3.3730e+00,  2.9689e+00,  9.5659e-01,\n",
+       "          2.9752e+00, -8.7886e-01, -3.1244e+00, -2.3654e+00, -4.8565e-02,\n",
+       "         -2.9762e+00,  1.9463e+00, -3.8066e+00,  2.5787e+00, -3.3243e+00,\n",
+       "         -2.6758e+00, -6.1210e+00, -2.2495e+00, -8.3281e-01, -2.1874e+00,\n",
+       "         -4.2828e+00,  7.2333e-01,  1.3418e+00, -7.6968e-02, -4.5636e+00,\n",
+       "          1.3869e+00, -6.8981e-01, -1.7643e+00, -4.5380e+00,  2.3339e+00,\n",
+       "          4.0303e+00, -2.1139e-01, -3.2028e+00,  8.4711e-01,  2.4759e+00,\n",
+       "          1.2761e+00, -5.1419e-01, -3.3388e+00,  2.9619e+00, -5.7594e+00,\n",
+       "         -2.3335e-02,  6.2894e-01, -2.4124e+00, -4.1536e+00, -3.4111e+00,\n",
+       "         -2.3175e+00,  2.6906e+00,  2.4537e+00, -4.5308e+00],\n",
+       "        [ 4.2673e-01,  2.7005e+00, -5.0971e+00,  8.2673e-01,  4.9469e+00,\n",
+       "         -2.0567e-01,  1.1178e+00, -1.8069e+00,  1.4646e+00,  5.0213e+00,\n",
+       "         -4.3606e+00, -2.0435e-01, -4.4604e+00, -4.1957e+00, -1.9744e+00,\n",
+       "          6.1316e+00, -1.7559e+00,  8.8842e-01,  7.5145e-01,  4.1948e+00,\n",
+       "          2.5245e+00, -3.1448e+00, -3.2607e+00, -1.3012e+00,  2.2925e-01,\n",
+       "         -3.0305e+00,  1.0251e+00, -1.7528e+00, -1.9203e+00, -2.0169e+00,\n",
+       "         -4.2167e+00, -4.8239e+00, -2.2842e+00,  2.9594e+00, -4.5036e-01,\n",
+       "         -4.0305e+00,  3.2684e+00,  4.9443e+00,  1.0798e-02, -3.0544e+00,\n",
+       "          4.8183e+00,  1.7831e+00, -6.3177e-01, -1.7021e+00,  1.0998e+00,\n",
+       "         -2.1260e+00,  2.5136e+00, -5.9918e+00,  3.0932e+00,  8.8470e+00,\n",
+       "          2.1150e+00, -2.2601e+00, -3.4305e+00,  4.4904e-01, -3.8352e+00,\n",
+       "         -2.1336e+00,  9.7216e-01, -1.7431e+00, -4.2880e+00, -8.5726e+00,\n",
+       "         -3.9721e+00, -1.3394e+00, -2.5868e+00, -5.6204e+00]])"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ds[[0,1,2,4,5,6]]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d7f79cb1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "\n",
+    "tensors = [np.random.rand(3,4,5) for _ in range(512)]\n",
+    "ids = np.arange(512)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e0726059",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "import pyarrow as pa\n",
+    "import pyarrow.parquet as pq\n",
+    "\n",
+    "_shape = json.dumps(tensors[0].shape)\n",
+    "flattened_tensors = [tensor.flatten() for tensor in tensors]\n",
+    "table = pa.Table.from_arrays([ids, flattened_tensors], names=['id', 'tensor'])\n",
+    "table = table.replace_schema_metadata({'shape': _shape})\n",
+    "\n",
+    "pq.write_table(table, './output.parquet')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "87e57a7f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "table = pq.read_table('./output.parquet')\n",
+    "retrieved_metadata_bytes = table.schema.metadata.get(b'shape')\n",
+    "reshape_dims = json.loads(retrieved_metadata_bytes)\n",
+    "df = table.to_pandas()\n",
+    "df['tensor'][0].reshape(reshape_dims)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bc4942fb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pyarrow.parquet as pq\n",
+    "\n",
+    "table = pq.read_table('/Users/drew/code/hyrax/docs/pre_executed/results/20250818-160645-infer-Bcjm/output.parquet')\n",
+    "\n",
+    "tensor_shape = table.schema.metadata.get(b'tensor_shape')\n",
+    "df = table.to_pandas()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ec26afc9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "a = df[0:10]\n",
+    "len(a['tensor'][0])"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "hyrax",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/pre_executed/random_parquet.ipynb
+++ b/docs/pre_executed/random_parquet.ipynb
@@ -8,6 +8,7 @@
    "outputs": [],
    "source": [
     "from hyrax import Hyrax\n",
+    "\n",
     "h = Hyrax()"
    ]
   },
@@ -18,7 +19,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "h.config['train']['epochs'] = 1\n",
+    "h.config[\"train\"][\"epochs\"] = 1\n",
     "h.train()"
    ]
   },
@@ -42,8 +43,18 @@
     "# Access patterns for the resulting InferenceDataset\n",
     "aa = ds[100]  # Retrieve a single index\n",
     "bb = ds[0:10:2]  # A slice of indices\n",
-    "cc = ds[[0,2,4,6,8]]  # Or provide a list of indices to return\n",
-    "dd = ds['asdf']  # Iterable \"index\", results in an error message and returns None"
+    "# cc = ds[[0, 2, 4, 6, 8]]  # Or provide a list of indices to return\n",
+    "dd = ds[\"asdf\"]  # Iterable \"index\", results in an error message and returns None"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c00a3f10",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds.get_id([10])"
    ]
   },
   {
@@ -68,78 +79,147 @@
     "import pyarrow as pa\n",
     "import pyarrow.parquet as pq\n",
     "\n",
+    "tensors_0 = [np.random.rand(3, 4, 5) for _ in range(512)]\n",
+    "tensor_shape = tensors_0[0].shape\n",
+    "ids_0 = np.arange(512).astype(str)\n",
     "\n",
-    "tensors = [np.random.rand(3,4,5) for _ in range(512)]\n",
-    "tensor_shape = tensors[0].shape\n",
-    "ids = np.arange(512)"
+    "tensors_1 = [np.random.rand(3, 4, 5) for _ in range(512)]\n",
+    "ids_1 = np.arange(512).astype(str)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a67e52d5",
+   "id": "506293cf",
    "metadata": {},
    "outputs": [],
    "source": [
-    "pa.parquet.write_table(table, './output.parquet')\n",
-    "new_table = pa.parquet.read_table('./output.parquet')\n",
-    "assert table == new_table"
+    "### Current implementation in Inference dataset\n",
+    "\n",
+    "buffer = {}\n",
+    "# _shape = json.dumps(tensors_0[0].shape)\n",
+    "\n",
+    "flattened_model_output = [o.flatten() for o in tensors_0]\n",
+    "\n",
+    "buffer[\"id\"] = buffer.get(\"id\", []) + list(ids_0)\n",
+    "buffer[\"model_output\"] = buffer.get(\"model_output\", []) + flattened_model_output\n",
+    "\n",
+    "table = pa.Table.from_arrays([buffer[\"id\"], buffer[\"model_output\"]], names=[\"id\", \"model_output\"])\n",
+    "\n",
+    "pq.write_to_dataset(table, root_path=\"./output\")\n",
+    "\n",
+    "for k in buffer.keys():\n",
+    "    buffer[k] = []"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e0726059",
+   "id": "256cb82a",
    "metadata": {},
    "outputs": [],
    "source": [
+    "### New experimental implementation that doesn't require unflattening the numpy arrays\n",
     "\n",
-    "_shape = json.dumps(tensors[0].shape)\n",
-    "flattened_tensors = [tensor.flatten() for tensor in tensors]\n",
-    "table = pa.Table.from_arrays([ids, flattened_tensors], names=['id', 'tensor'])\n",
-    "table = table.replace_schema_metadata({'shape': _shape})\n",
+    "buffer = {}\n",
+    "shape = tensors_0[0].shape\n",
     "\n",
-    "pq.write_table(table, './output.parquet')"
+    "tensors_pa = pa.FixedSizeListArray.from_arrays(np.array(tensors_0).flatten(), np.prod(shape))\n",
+    "ty = pa.fixed_shape_tensor(pa.float64(), shape=shape)\n",
+    "arr = pa.FixedShapeTensorArray.from_storage(ty, tensors_pa)\n",
+    "# table = pa.table({\"tensor\": arr})\n",
+    "\n",
+    "# flattened_model_output = [o.flatten() for o in tensors_0]\n",
+    "\n",
+    "buffer[\"id\"] = buffer.get(\"id\", []) + list(ids_0)\n",
+    "buffer[\"model_output\"] = buffer.get(\"model_output\", []) + flattened_model_output\n",
+    "\n",
+    "table = pa.Table.from_arrays([buffer[\"id\"], arr], names=[\"id\", \"model_output\"])\n",
+    "\n",
+    "pq.write_to_dataset(table, root_path=\"./output\")\n",
+    "\n",
+    "for k in buffer.keys():\n",
+    "    buffer[k] = []"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "87e57a7f",
+   "id": "58fba7a7",
    "metadata": {},
    "outputs": [],
    "source": [
-    "table = pq.read_table('./output.parquet')\n",
-    "retrieved_metadata_bytes = table.schema.metadata.get(b'shape')\n",
-    "reshape_dims = json.loads(retrieved_metadata_bytes)\n",
-    "df = table.to_pandas()\n",
-    "df['tensor'][0].reshape(reshape_dims)"
+    "data = pq.read_table(\n",
+    "    \"/home/drew/code/hyrax/docs/pre_executed/output/7fd0474d170d4d9fb5518653f414f8d8-0.parquet\"\n",
+    ")\n",
+    "\n",
+    "data[\"model_output\"][0]"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bc4942fb",
+   "id": "f9cc2131",
    "metadata": {},
    "outputs": [],
    "source": [
-    "import pyarrow.parquet as pq\n",
+    "buffer = {}\n",
+    "shape = tensors_0[0].shape\n",
     "\n",
-    "table = pq.read_table('/Users/drew/code/hyrax/docs/pre_executed/results/20250818-160645-infer-Bcjm/output.parquet')\n",
+    "# tensors_pa = pa.FixedSizeListArray.from_arrays(np.array(tensors_0).flatten(), np.prod(shape))\n",
+    "# ty = pa.fixed_shape_tensor(pa.float64(), shape=shape)\n",
+    "arr = pa.FixedShapeTensorArray.from_numpy_ndarray(np.array(tensors_0))\n",
+    "arr2 = pa.FixedShapeTensorArray.from_numpy_ndarray(np.array(tensors_1))\n",
+    "# table = pa.table({\"tensor\": arr})\n",
     "\n",
-    "tensor_shape = table.schema.metadata.get(b'tensor_shape')\n",
-    "df = table.to_pandas()"
+    "# flattened_model_output = [o.flatten() for o in tensors_0]\n",
+    "\n",
+    "buffer[\"id\"] = buffer.get(\"id\", []) + list(ids_0)\n",
+    "\n",
+    "table = pa.Table.from_arrays([buffer[\"id\"], arr], names=[\"id\", \"model_output\"])\n",
+    "\n",
+    "pq.write_to_dataset(table, root_path=\"./output\")\n",
+    "\n",
+    "for k in buffer.keys():\n",
+    "    buffer[k] = []"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ec26afc9",
+   "id": "4955834e",
    "metadata": {},
    "outputs": [],
    "source": [
-    "a = df[0:10]\n",
-    "len(a['tensor'][0])"
+    "data = pq.read_table(\n",
+    "    \"/home/drew/code/hyrax/docs/pre_executed/output/acc93f5f5b594cee8281b81c97352b89-0.parquet\"\n",
+    ")\n",
+    "test = data[\"model_output\"][3]\n",
+    "\n",
+    "for i in test:\n",
+    "    print(i.to_numpy().shape)\n",
+    "    print(i.to_numpy().ndim)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "868573f0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "np.array([str(i) for i in data[\"id\"][0]])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "015daf78",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pddata = data.to_pandas()\n",
+    "pddata[\"model_output\"].iloc[0]"
    ]
   }
  ],

--- a/docs/pre_executed/random_parquet.ipynb
+++ b/docs/pre_executed/random_parquet.ipynb
@@ -2,268 +2,48 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "a72367cd",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "[2025-08-18 16:26:09,122 hyrax:INFO] Runtime Config read from: /Users/drew/code/hyrax/src/hyrax/hyrax_default_config.toml\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from hyrax import Hyrax\n",
-    "h = Hyrax()\n",
-    "# h.config['data_set']['name'] = 'HyraxRandomDataset'\n",
-    "# h.config['data_set']['random_dataset']['size'] = 10_000\n",
-    "# h.config['data_set']['random_dataset']['shape'] = (3, 41, 41)"
+    "h = Hyrax()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "47f647b1",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "[2025-08-18 16:26:15,390 hyrax.models.model_registry:INFO] Using criterion: torch.nn.CrossEntropyLoss with default arguments.\n",
-      "2025-08-18 16:26:15,405 ignite.distributed.auto.auto_dataloader INFO: Use data loader kwargs for dataset '<hyrax.data_sets.hyr': \n",
-      "\t{'sampler': <hyrax.pytorch_ignite.SubsetSequentialSampler object at 0x16b0263c0>, 'batch_size': 512, 'shuffle': False, 'pin_memory': False}\n",
-      "2025-08-18 16:26:15,406 ignite.distributed.auto.auto_dataloader INFO: Use data loader kwargs for dataset '<hyrax.data_sets.hyr': \n",
-      "\t{'sampler': <hyrax.pytorch_ignite.SubsetSequentialSampler object at 0x16b027740>, 'batch_size': 512, 'shuffle': False, 'pin_memory': False}\n",
-      "/Users/drew/opt/miniconda3/envs/hyrax/lib/python3.12/site-packages/ignite/handlers/tqdm_logger.py:127: TqdmExperimentalWarning: Using `tqdm.autonotebook.tqdm` in notebook mode. Use `tqdm.tqdm` instead to force console mode (e.g. in jupyter console)\n",
-      "  from tqdm.autonotebook import tqdm\n",
-      "2025/08/18 16:26:15 INFO mlflow.system_metrics.system_metrics_monitor: Skip logging GPU metrics. Set logger level to DEBUG for more details.\n",
-      "2025/08/18 16:26:15 INFO mlflow.system_metrics.system_metrics_monitor: Started monitoring system metrics.\n",
-      "[2025-08-18 16:26:15,531 hyrax.pytorch_ignite:INFO] Training model on device: mps\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "62c9ca58d34c4291b87566b2a6211e4e",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "  2%|1         | 1/59 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "[2025-08-18 16:26:21,129 hyrax.pytorch_ignite:INFO] Total training time: 5.60[s]\n",
-      "[2025-08-18 16:26:21,130 hyrax.pytorch_ignite:INFO] Latest checkpoint saved as: /Users/drew/code/hyrax/docs/pre_executed/results/20250818-162611-train-KDT0/checkpoint_epoch_1.pt\n",
-      "[2025-08-18 16:26:21,130 hyrax.pytorch_ignite:INFO] Best metric checkpoint saved as: /Users/drew/code/hyrax/docs/pre_executed/results/20250818-162611-train-KDT0/checkpoint_1_loss=-357.3800.pt\n",
-      "2025/08/18 16:26:21 INFO mlflow.system_metrics.system_metrics_monitor: Stopping system metrics monitoring...\n",
-      "2025/08/18 16:26:21 INFO mlflow.system_metrics.system_metrics_monitor: Successfully terminated system metrics monitoring!\n",
-      "[2025-08-18 16:26:21,145 hyrax.verbs.train:INFO] Finished Training\n",
-      "[2025-08-18 16:26:21,642 hyrax.model_exporters:INFO] Exported model to ONNX format: /Users/drew/code/hyrax/docs/pre_executed/results/20250818-162611-train-KDT0/example_model_opset_20.onnx\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "HyraxAutoencoder(\n",
-       "  (encoder): Sequential(\n",
-       "    (0): Conv2d(3, 32, kernel_size=(3, 3), stride=(2, 2), padding=(1, 1))\n",
-       "    (1): GELU(approximate='none')\n",
-       "    (2): Conv2d(32, 32, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))\n",
-       "    (3): GELU(approximate='none')\n",
-       "    (4): Conv2d(32, 64, kernel_size=(3, 3), stride=(2, 2), padding=(1, 1))\n",
-       "    (5): GELU(approximate='none')\n",
-       "    (6): Conv2d(64, 64, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))\n",
-       "    (7): GELU(approximate='none')\n",
-       "    (8): Conv2d(64, 64, kernel_size=(3, 3), stride=(2, 2), padding=(1, 1))\n",
-       "    (9): GELU(approximate='none')\n",
-       "    (10): Flatten(start_dim=1, end_dim=-1)\n",
-       "    (11): Linear(in_features=1024, out_features=64, bias=True)\n",
-       "  )\n",
-       "  (dec_linear): Sequential(\n",
-       "    (0): Linear(in_features=64, out_features=1024, bias=True)\n",
-       "    (1): GELU(approximate='none')\n",
-       "  )\n",
-       "  (decoder): Sequential(\n",
-       "    (0): ConvTranspose2d(64, 64, kernel_size=(3, 3), stride=(2, 2), padding=(1, 1), output_padding=(1, 1))\n",
-       "    (1): GELU(approximate='none')\n",
-       "    (2): Conv2d(64, 64, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))\n",
-       "    (3): GELU(approximate='none')\n",
-       "    (4): ConvTranspose2d(64, 32, kernel_size=(3, 3), stride=(2, 2), padding=(1, 1), output_padding=(1, 1))\n",
-       "    (5): GELU(approximate='none')\n",
-       "    (6): Conv2d(32, 32, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))\n",
-       "    (7): GELU(approximate='none')\n",
-       "    (8): ConvTranspose2d(32, 3, kernel_size=(3, 3), stride=(2, 2), padding=(1, 1), output_padding=(1, 1))\n",
-       "    (9): Tanh()\n",
-       "  )\n",
-       "  (criterion): CrossEntropyLoss()\n",
-       ")"
-      ]
-     },
-     "execution_count": 2,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "h.config['train']['epochs'] = 1\n",
-    "# h.config['model']['name'] = 'HyraxCNN'\n",
-    "# h.config['model']['hyrax_cnn']['output_classes'] = 3\n",
-    "\n",
     "h.train()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "bb0311a0",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "[2025-08-18 16:26:25,268 hyrax.models.model_registry:INFO] Using criterion: torch.nn.CrossEntropyLoss with default arguments.\n",
-      "[2025-08-18 16:26:25,269 hyrax.verbs.infer:INFO] data set has length 50000\n",
-      "2025-08-18 16:26:25,270 ignite.distributed.auto.auto_dataloader INFO: Use data loader kwargs for dataset '<hyrax.data_sets.hyr': \n",
-      "\t{'sampler': None, 'batch_size': 512, 'shuffle': False, 'pin_memory': False}\n",
-      "[2025-08-18 16:26:25,280 hyrax.verbs.infer:INFO] Saving inference results at: /Users/drew/code/hyrax/docs/pre_executed/results/20250818-162621-infer-zk3O\n",
-      "[2025-08-18 16:26:25,467 hyrax.pytorch_ignite:INFO] Evaluating model on device: mps\n",
-      "[2025-08-18 16:26:25,468 hyrax.pytorch_ignite:INFO] Total epochs: 1\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "916cae80d2e148219374ee579c725964",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "  1%|1         | 1/98 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "[2025-08-18 16:26:30,388 hyrax.pytorch_ignite:INFO] Total evaluation time: 4.92[s]\n",
-      "[2025-08-18 16:26:30,443 hyrax.verbs.infer:INFO] Inference Complete.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "ds = h.infer()"
+    "ds = h.infer()  # Run inference and return the resulting dataset"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "id": "4c936fd1",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "tensor([[ 8.2588e-01,  1.8817e+00, -8.6632e-02, -2.6173e-01,  1.6635e+00,\n",
-       "          3.0351e-01,  8.5987e-01,  1.3563e+00,  7.2110e-01, -9.2282e-01,\n",
-       "          1.7628e-01,  9.0702e-01, -5.5977e-01,  7.7089e-01,  5.0296e-01,\n",
-       "         -1.1167e+00,  8.3786e-01, -7.5270e-01,  2.3004e+00,  1.1066e+00,\n",
-       "          8.6355e-01,  1.0416e+00,  2.0365e-01, -1.8310e+00, -1.2457e+00,\n",
-       "         -1.4892e+00, -2.5756e-01, -1.5162e+00, -2.7329e+00, -3.9386e-01,\n",
-       "          1.6330e+00,  4.9924e-03, -5.7766e-02, -1.2319e-01, -6.4349e-02,\n",
-       "         -4.5615e-01, -1.1544e+00, -1.4566e+00,  1.0005e+00, -1.2052e+00,\n",
-       "          1.6361e+00,  2.9691e+00, -6.5868e-01, -8.4884e-01,  8.8773e-01,\n",
-       "          1.0800e-01, -4.1050e-02, -3.5328e+00,  1.9987e+00,  6.2507e-02,\n",
-       "          5.1641e-01,  5.1441e-01,  1.5979e+00,  6.1225e-01, -7.3815e-01,\n",
-       "         -2.8229e+00, -1.1311e+00, -1.7349e+00, -8.8074e-01,  5.8053e-01,\n",
-       "          2.0290e+00,  1.4515e+00, -5.7942e-01, -2.2863e+00],\n",
-       "        [-1.8638e+00,  1.6474e+00,  1.2942e+00,  2.6285e+00, -5.3237e-01,\n",
-       "         -9.1890e-01,  1.4413e+00, -2.2368e+00,  3.2656e+00,  1.7891e+00,\n",
-       "          1.2822e+00, -8.5861e-01, -2.4984e+00, -5.9200e-01, -3.2084e+00,\n",
-       "          2.7060e+00, -1.8733e+00,  1.6886e+00,  9.7744e-01,  6.7465e-01,\n",
-       "          1.8386e+00,  1.4043e+00, -1.9525e+00, -3.3646e+00, -1.2194e+00,\n",
-       "         -3.7596e+00,  2.4909e-01, -4.3790e+00, -2.8164e+00, -1.2411e+00,\n",
-       "         -1.4035e+00, -3.9871e+00,  1.3360e+00,  1.0409e+00, -3.2809e-01,\n",
-       "         -4.3863e-01, -4.7392e-01,  1.8710e+00,  2.2132e+00, -4.2567e+00,\n",
-       "          1.4478e+00,  6.5822e-01, -1.1808e+00, -1.4641e+00,  1.1896e+00,\n",
-       "          3.7631e+00, -1.0718e+00, -3.6106e+00,  2.7578e+00,  3.0404e-01,\n",
-       "          1.2880e+00, -3.0260e-01, -6.4776e-01,  1.3154e-01, -2.1639e+00,\n",
-       "         -1.8378e+00,  1.7767e+00, -4.1950e+00, -3.3926e+00, -2.5583e+00,\n",
-       "         -7.4612e-01,  1.5366e+00, -4.9807e-01, -3.2541e+00],\n",
-       "        [ 9.1252e+00,  2.6852e+00, -5.0103e-01, -3.1083e+00,  2.6907e+00,\n",
-       "          3.0270e-01,  7.3212e+00, -1.3294e+00, -4.4973e+00, -9.0405e-01,\n",
-       "          2.2374e-01, -1.0708e+00,  6.1727e+00,  4.2572e+00,  2.6065e+00,\n",
-       "         -1.2101e+00,  2.1371e+00, -3.1564e+00,  8.3735e+00, -7.8278e+00,\n",
-       "         -3.9114e+00, -3.1876e+00,  1.7429e+00, -7.0203e-02,  3.4703e+00,\n",
-       "          3.5852e+00,  8.1255e+00,  1.3436e+00,  1.5095e+00,  5.5257e-01,\n",
-       "          1.6718e+00,  8.4553e+00,  1.8557e+00, -2.8962e-01,  4.5964e+00,\n",
-       "          3.9063e+00,  1.6253e+00, -2.4102e+00, -1.7235e+00,  2.9188e+00,\n",
-       "          8.2193e-01,  5.3422e+00,  5.8919e+00, -1.5443e+00,  4.6577e+00,\n",
-       "         -2.4533e+00, -8.9942e+00,  1.2615e+00,  1.1246e-01,  1.2246e+00,\n",
-       "         -2.0967e+00, -5.1056e+00,  8.2227e+00, -1.4352e+00,  2.2767e+00,\n",
-       "          9.8109e+00,  5.8141e+00,  2.8233e+00,  2.8774e+00,  2.8049e-01,\n",
-       "         -1.3116e+00, -6.9024e-01, -3.3581e+00,  3.7914e+00],\n",
-       "        [ 2.4166e+00,  4.5367e+00,  3.4935e+00, -4.0383e+00,  3.3331e+00,\n",
-       "          2.1223e+00,  7.8645e+00,  1.8972e+00, -7.4950e-01, -8.2478e+00,\n",
-       "          4.4108e-01, -4.7144e+00,  5.1176e+00,  1.9898e+00,  7.3030e+00,\n",
-       "         -6.3822e+00,  7.9458e+00, -4.3932e+00,  5.6662e+00, -4.3106e+00,\n",
-       "         -1.4209e+00,  9.1675e-02, -2.8994e+00,  4.1698e+00,  4.6921e+00,\n",
-       "         -4.9870e-02,  6.8865e+00, -7.4052e+00, -2.6820e+00,  1.4404e+00,\n",
-       "          5.7161e+00,  2.3878e+00,  8.5746e+00, -3.3502e-02,  2.4380e+00,\n",
-       "          1.6036e+00, -1.9574e+00, -4.4522e+00,  4.3862e+00,  3.3441e-01,\n",
-       "         -1.6480e-02,  3.6642e+00,  8.5626e-01,  3.3176e+00,  1.8293e+00,\n",
-       "          7.8217e+00, -3.5750e+00,  5.5294e+00,  2.3035e+00,  1.7096e+00,\n",
-       "          1.3585e+00, -1.1679e-02,  2.9931e+00, -5.6309e+00, -4.6791e-01,\n",
-       "          1.0019e+01,  6.0152e+00, -1.6427e+00,  1.1137e+00,  1.4178e+00,\n",
-       "          3.6636e+00, -3.7802e+00, -2.9396e+00,  6.0465e+00],\n",
-       "        [-1.5818e-01,  1.3229e+00, -1.0622e+00,  1.4643e+00, -1.4856e+00,\n",
-       "         -2.6712e+00,  2.7149e+00, -2.5642e+00,  2.5741e+00,  7.8925e+00,\n",
-       "          1.9215e+00, -3.2695e+00, -2.2950e+00, -2.5061e+00, -1.8414e+00,\n",
-       "          3.9399e+00, -4.8842e+00,  3.3730e+00,  2.9689e+00,  9.5659e-01,\n",
-       "          2.9752e+00, -8.7886e-01, -3.1244e+00, -2.3654e+00, -4.8565e-02,\n",
-       "         -2.9762e+00,  1.9463e+00, -3.8066e+00,  2.5787e+00, -3.3243e+00,\n",
-       "         -2.6758e+00, -6.1210e+00, -2.2495e+00, -8.3281e-01, -2.1874e+00,\n",
-       "         -4.2828e+00,  7.2333e-01,  1.3418e+00, -7.6968e-02, -4.5636e+00,\n",
-       "          1.3869e+00, -6.8981e-01, -1.7643e+00, -4.5380e+00,  2.3339e+00,\n",
-       "          4.0303e+00, -2.1139e-01, -3.2028e+00,  8.4711e-01,  2.4759e+00,\n",
-       "          1.2761e+00, -5.1419e-01, -3.3388e+00,  2.9619e+00, -5.7594e+00,\n",
-       "         -2.3335e-02,  6.2894e-01, -2.4124e+00, -4.1536e+00, -3.4111e+00,\n",
-       "         -2.3175e+00,  2.6906e+00,  2.4537e+00, -4.5308e+00],\n",
-       "        [ 4.2673e-01,  2.7005e+00, -5.0971e+00,  8.2673e-01,  4.9469e+00,\n",
-       "         -2.0567e-01,  1.1178e+00, -1.8069e+00,  1.4646e+00,  5.0213e+00,\n",
-       "         -4.3606e+00, -2.0435e-01, -4.4604e+00, -4.1957e+00, -1.9744e+00,\n",
-       "          6.1316e+00, -1.7559e+00,  8.8842e-01,  7.5145e-01,  4.1948e+00,\n",
-       "          2.5245e+00, -3.1448e+00, -3.2607e+00, -1.3012e+00,  2.2925e-01,\n",
-       "         -3.0305e+00,  1.0251e+00, -1.7528e+00, -1.9203e+00, -2.0169e+00,\n",
-       "         -4.2167e+00, -4.8239e+00, -2.2842e+00,  2.9594e+00, -4.5036e-01,\n",
-       "         -4.0305e+00,  3.2684e+00,  4.9443e+00,  1.0798e-02, -3.0544e+00,\n",
-       "          4.8183e+00,  1.7831e+00, -6.3177e-01, -1.7021e+00,  1.0998e+00,\n",
-       "         -2.1260e+00,  2.5136e+00, -5.9918e+00,  3.0932e+00,  8.8470e+00,\n",
-       "          2.1150e+00, -2.2601e+00, -3.4305e+00,  4.4904e-01, -3.8352e+00,\n",
-       "         -2.1336e+00,  9.7216e-01, -1.7431e+00, -4.2880e+00, -8.5726e+00,\n",
-       "         -3.9721e+00, -1.3394e+00, -2.5868e+00, -5.6204e+00]])"
-      ]
-     },
-     "execution_count": 10,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "ds[[0,1,2,4,5,6]]"
+    "# Access patterns for the resulting InferenceDataset\n",
+    "aa = ds[100]  # Retrieve a single index\n",
+    "bb = ds[0:10:2]  # A slice of indices\n",
+    "cc = ds[[0,2,4,6,8]]  # Or provide a list of indices to return\n",
+    "dd = ds['asdf']  # Iterable \"index\", results in an error message and returns None"
    ]
   },
   {
@@ -274,9 +54,26 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
+    "import json\n",
+    "import pyarrow as pa\n",
+    "import pyarrow.parquet as pq\n",
+    "\n",
     "\n",
     "tensors = [np.random.rand(3,4,5) for _ in range(512)]\n",
+    "tensor_shape = tensors[0].shape\n",
     "ids = np.arange(512)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a67e52d5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pa.parquet.write_table(table, './output.parquet')\n",
+    "new_table = pa.parquet.read_table('./output.parquet')\n",
+    "assert table == new_table"
    ]
   },
   {
@@ -286,9 +83,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import json\n",
-    "import pyarrow as pa\n",
-    "import pyarrow.parquet as pq\n",
     "\n",
     "_shape = json.dumps(tensors[0].shape)\n",
     "flattened_tensors = [tensor.flatten() for tensor in tensors]\n",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ dependencies = [
     "psutil", # Used for memory monitoring
     "tqdm", # Used to show progress bars
     "qdrant-client", # Vector database for similarity search
+    "pyarrow", # Used for storage of model output
 ]
 
 [project.scripts]

--- a/src/hyrax/data_sets/inference_dataset.py
+++ b/src/hyrax/data_sets/inference_dataset.py
@@ -72,7 +72,9 @@ class InferenceDataSet(HyraxDataset, Dataset):
             self.use_parquet = True
             self.parquet_output = pq.read_table(parquet_output)
             self.data = self.parquet_output.to_pandas()
-            self.model_output_shape = json.loads(self.parquet_output.schema.metadata.get(b"model_output_shape"))
+            self.model_output_shape = json.loads(
+                self.parquet_output.schema.metadata.get(b"model_output_shape")
+            )
 
         # DEPRECATION WARNING - this `if not` block is temporary and here for backwards compatibility
         if not self.use_parquet:
@@ -148,7 +150,7 @@ class InferenceDataSet(HyraxDataset, Dataset):
         else:
             return (str(id) for id in self.batch_index["id"])
 
-    def get_model_output(self, idx):
+    def get_model_output(self, idx) -> npt.NDArray[np.float32]:
         """Retrieve tensors from the pandas dataframe and reshape them to their original
         dimensions using the model_output_shape metadata.
 
@@ -159,14 +161,14 @@ class InferenceDataSet(HyraxDataset, Dataset):
 
         Returns
         -------
-        np.array
+        np.array[np.array[np.float]]
             The tensor(s) corresponding to the input index(es) reshaped to the
             original dimensions.
         """
         model_output = self.data.iloc[idx]["model_output"]
         return np.array([o.reshape(self.model_output_shape) for o in model_output])
 
-    def get_id(self, idx):
+    def get_id(self, idx) -> npt.NDArray[np.str_]:
         """Retrieve the ids of a specific element in the dataset.
 
         Parameters
@@ -176,7 +178,7 @@ class InferenceDataSet(HyraxDataset, Dataset):
 
         Returns
         -------
-        str
+        np.array[str]
             The ID of the element(s) corresponding to the input index(es).
         """
         return np.array([str(i) for i in self.data.iloc[idx]["id"]])
@@ -473,7 +475,6 @@ class InferenceDataSetWriter:
 
         flattened_model_output = [o.flatten() for o in model_output]
         table = pa.Table.from_arrays([ids, flattened_model_output], names=["id", "model_output"])
-
 
         #! This seems odd - pyarrow doesn't allow appending to a file.
         #! fastparquet _does_ support appending, but it's not clear if it will

--- a/src/hyrax/verbs/infer.py
+++ b/src/hyrax/verbs/infer.py
@@ -130,9 +130,6 @@ class Infer(Verb):
         evaluator = create_evaluator(model, _save_batch, config)
         evaluator.run(data_loader)
 
-        # Write out a dictionary to map IDs->Batch
-        data_writer.write_index()
-
         # Write out our tensorboard stuff
         tensorboardx_logger.close()
 

--- a/src/hyrax/verbs/infer.py
+++ b/src/hyrax/verbs/infer.py
@@ -130,6 +130,8 @@ class Infer(Verb):
         evaluator = create_evaluator(model, _save_batch, config)
         evaluator.run(data_loader)
 
+        data_writer.finalize()
+
         # Write out our tensorboard stuff
         tensorboardx_logger.close()
 

--- a/src/hyrax/verbs/save_to_database.py
+++ b/src/hyrax/verbs/save_to_database.py
@@ -129,6 +129,10 @@ class SaveToDatabase(Verb):
         config["vector_db"]["vector_db_dir"] = str(vector_db_path)
         log_runtime_config(config, vector_db_path)
 
+
+        #! The following logic will need to change because the parquet implementation
+        #! will not make use of batch indexing and batch files.
+
         # Use the batch_index to get the list of batches.
         batches = np.unique(inference_data_set.batch_index["batch_num"])
 

--- a/src/hyrax/verbs/save_to_database.py
+++ b/src/hyrax/verbs/save_to_database.py
@@ -129,15 +129,14 @@ class SaveToDatabase(Verb):
         config["vector_db"]["vector_db_dir"] = str(vector_db_path)
         log_runtime_config(config, vector_db_path)
 
-
-
         if inference_data_set.use_parquet:
             total_length = len(inference_data_set)
             batch_size = 512
             for idx in range(0, total_length, batch_size):
-                id = inference_data_set.get_id(slice(idx, idx+batch_size))
-                vector = inference_data_set.get_model_output(slice(idx, idx+batch_size))
-                vector_db.insert(ids=list(id), vectors=vector)
+                ids = list(inference_data_set.get_id(slice(idx, idx + batch_size)))
+                vectors = inference_data_set.get_model_output(slice(idx, idx + batch_size))
+                vectors = list(vectors.reshape(len(vectors), -1))
+                vector_db.insert(ids=ids, vectors=vectors)
 
         #! DEPRECATION WARNING - this uses the original InferenceDataset .npy-style
         #! which will be deprecated. This will be removed soon.

--- a/src/hyrax/verbs/umap.py
+++ b/src/hyrax/verbs/umap.py
@@ -163,7 +163,6 @@ class Umap(Verb):
                 self._log_memory_usage(f"During transformation of batch of shape {batch.shape}")
                 umap_results.write_batch(batch_ids, transformed_batch)
 
-        umap_results.write_index()
         logger.info("Finished transforming all data through UMAP")
 
         return InferenceDataSet(self.config, results_dir)

--- a/src/hyrax/verbs/umap.py
+++ b/src/hyrax/verbs/umap.py
@@ -163,6 +163,8 @@ class Umap(Verb):
                 self._log_memory_usage(f"During transformation of batch of shape {batch.shape}")
                 umap_results.write_batch(batch_ids, transformed_batch)
 
+        umap_results.finalize()
+
         logger.info("Finished transforming all data through UMAP")
 
         return InferenceDataSet(self.config, results_dir)

--- a/tests/hyrax/test_inference_dataset.py
+++ b/tests/hyrax/test_inference_dataset.py
@@ -37,7 +37,7 @@ def inference_dataset(tmp_path_factory, request):
             np.array(data_set_ids[indexes[10:20]]),  # ids
             np.array(current_data_set[indexes[10:20]]),  # Results
         )
-        data_writer.write_index()
+
         current_data_set = InferenceDataSet(h.config, tmp_path)
 
     return original_data_set, current_data_set

--- a/tests/hyrax/test_inference_dataset.py
+++ b/tests/hyrax/test_inference_dataset.py
@@ -28,6 +28,8 @@ def inference_dataset(tmp_path_factory, request):
 
         data_set_ids = np.array(list(current_data_set.ids()))
 
+        #!!! We should make this test align with the expected input format for `write_batch`
+        #! i.e. write_batch(np.array, list[np.array])
         data_writer.write_batch(
             np.array(data_set_ids[indexes[0:10]]),  # ids
             np.array(current_data_set[indexes[0:10]]),  # Results
@@ -37,6 +39,8 @@ def inference_dataset(tmp_path_factory, request):
             np.array(data_set_ids[indexes[10:20]]),  # ids
             np.array(current_data_set[indexes[10:20]]),  # Results
         )
+
+        data_writer.finalize()
 
         current_data_set = InferenceDataSet(h.config, tmp_path)
 


### PR DESCRIPTION
So far it seems pretty good. And seems like it will reduce a lot of code. Making use of `pyarrow` right now. Tried out `fastparquet` but it was having trouble accepting numpy arrays as input. 

The biggest hurdle that I see right now is that we have to flatten and reshape the numpy arrays. They can be at most 1D. What is currently implemented uses parquet metadata to store the original shape of the input tensor (assuming that all tensors were the same dimensions originally) in `InferenceDatasetWriter`. 

When reading the data in with `InferenceDataset`, we reshape the tensors before returning them. 

Some open questions are:
- Should we embed any existing metadata from the original dataset along side? 
- Per-column metadata is supported, so perhaps the original shape information should be on that column instead of the global metadata
- Is this an opportunity to rename the "tensor" column to something like model_output, since it's not a tensor in the PyTorch sense... 
- Not a question just a statement, HyraxQL is going to fit so nicely along side this. 