### PR TITLE
Changing `weights_filepath` to `weights_filename`

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -140,7 +140,7 @@ We attempt to keep the comments as concise as possible.
 Finally, the configuration file is organized into tables that roughly correspond
 to the different actions that Hyrax can take.
 For instance, the ``[train]`` table contains parameters needed when training a
-model such as ``epochs`` and ``weights_filepath``.
+model such as ``epochs`` and ``weights_filename``.
 While the ``[infer]`` table contains keys such as ``model_weights_file``.
 
 

--- a/docs/pre_executed/train_model.ipynb
+++ b/docs/pre_executed/train_model.ipynb
@@ -25,7 +25,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[2025-03-26 14:46:50,459 hyrax:INFO] Runtime Config read from: /home/drew/code/fibad/src/hyrax/hyrax_default_config.toml\n"
+      "[2025-08-25 21:14:19,112 hyrax:INFO] Runtime Config read from: /home/drew/code/hyrax/src/hyrax/hyrax_default_config.toml\n"
      ]
     }
    ],
@@ -76,36 +76,21 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/home/drew/miniconda3/envs/fibad/lib/python3.12/site-packages/ignite/handlers/checkpoint.py:16: DeprecationWarning: `TorchScript` support for functional optimizers is deprecated and will be removed in a future PyTorch release. Consider using the `torch.compile` optimizer instead.\n",
-      "  from torch.distributed.optim import ZeroRedundancyOptimizer\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Files already downloaded and verified\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "[2025-03-26 14:46:54,584 hyrax.models.model_registry:INFO] Using criterion: torch.nn.CrossEntropyLoss with default arguments.\n",
-      "2025-03-26 14:46:54,653 ignite.distributed.auto.auto_dataloader INFO: Use data loader kwargs for dataset 'Dataset HyraxCifarDa': \n",
-      "\t{'sampler': <torch.utils.data.sampler.SubsetRandomSampler object at 0x7f2095f60920>, 'batch_size': 512, 'pin_memory': True}\n",
-      "2025-03-26 14:46:54,655 ignite.distributed.auto.auto_dataloader INFO: Use data loader kwargs for dataset 'Dataset HyraxCifarDa': \n",
-      "\t{'sampler': <torch.utils.data.sampler.SubsetRandomSampler object at 0x7f2095f60980>, 'batch_size': 512, 'pin_memory': True}\n",
-      "/home/drew/miniconda3/envs/fibad/lib/python3.12/site-packages/ignite/handlers/tqdm_logger.py:127: TqdmExperimentalWarning: Using `tqdm.autonotebook.tqdm` in notebook mode. Use `tqdm.tqdm` instead to force console mode (e.g. in jupyter console)\n",
+      "[2025-08-25 21:14:33,430 hyrax.models.model_registry:INFO] Using criterion: torch.nn.CrossEntropyLoss with default arguments.\n",
+      "2025-08-25 21:14:33,503 ignite.distributed.auto.auto_dataloader INFO: Use data loader kwargs for dataset '<hyrax.data_sets.hyr': \n",
+      "\t{'sampler': <hyrax.pytorch_ignite.SubsetSequentialSampler object at 0x70da50623980>, 'batch_size': 512, 'shuffle': False, 'pin_memory': True}\n",
+      "2025-08-25 21:14:33,504 ignite.distributed.auto.auto_dataloader INFO: Use data loader kwargs for dataset '<hyrax.data_sets.hyr': \n",
+      "\t{'sampler': <hyrax.pytorch_ignite.SubsetSequentialSampler object at 0x70da5046eea0>, 'batch_size': 512, 'shuffle': False, 'pin_memory': True}\n",
+      "/home/drew/miniconda3/envs/hyrax/lib/python3.12/site-packages/ignite/handlers/tqdm_logger.py:127: TqdmExperimentalWarning: Using `tqdm.autonotebook.tqdm` in notebook mode. Use `tqdm.tqdm` instead to force console mode (e.g. in jupyter console)\n",
       "  from tqdm.autonotebook import tqdm\n",
-      "2025/03/26 14:46:54 INFO mlflow.system_metrics.system_metrics_monitor: Started monitoring system metrics.\n",
-      "[2025-03-26 14:46:54,902 hyrax.pytorch_ignite:INFO] Training model on device: cuda\n"
+      "2025/08/25 21:14:33 INFO mlflow.system_metrics.system_metrics_monitor: Started monitoring system metrics.\n",
+      "[2025-08-25 21:14:33,874 hyrax.pytorch_ignite:INFO] Training model on device: cuda\n"
      ]
     },
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "1f78099ff2c542ca9035b20542ddfdb1",
+       "model_id": "7222baf5bfc74a17aeddbfc1f3dcf866",
        "version_major": 2,
        "version_minor": 0
       },
@@ -119,7 +104,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "d9dfe21f63d54a52ac433e4c0dd585f7",
+       "model_id": "acb5ef1fd60a4856806c805b894e6d4e",
        "version_major": 2,
        "version_minor": 0
       },
@@ -133,7 +118,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "7255c3a12e2e4722aa11b7c74edf095a",
+       "model_id": "475afa618df94f47af756ba53740ba50",
        "version_major": 2,
        "version_minor": 0
       },
@@ -147,7 +132,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "0403a67fbb3040c898f3f99fbfc21b6a",
+       "model_id": "47bfd5bd82974c8c9a914bf1ae431f7e",
        "version_major": 2,
        "version_minor": 0
       },
@@ -161,7 +146,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "9b37f565ffc343cc80a24ebcd5bfac77",
+       "model_id": "952a16b49bc744d0b3a981797cbd9a6d",
        "version_major": 2,
        "version_minor": 0
       },
@@ -175,7 +160,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "99c55d57ea274a95bd7f9006e2f056c2",
+       "model_id": "6e8722711f5f4beebec1067b41872131",
        "version_major": 2,
        "version_minor": 0
       },
@@ -189,7 +174,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "7ead518da40c4ee695364d7a842d0600",
+       "model_id": "a59e059d9ad24f68b4695cf9ebcc90a9",
        "version_major": 2,
        "version_minor": 0
       },
@@ -203,7 +188,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "39fadee1c9ff418e87fcfa4aea4d9cb6",
+       "model_id": "70d792681c8b45a28590272ce23356d8",
        "version_major": 2,
        "version_minor": 0
       },
@@ -217,7 +202,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "4a82d0db82f94f658ebd0a32208debea",
+       "model_id": "35df480d01224d5bbace42cc8aaf73c1",
        "version_major": 2,
        "version_minor": 0
       },
@@ -231,7 +216,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "0cb1e775a8174e2195876759e88a093e",
+       "model_id": "af99379ce2b14fc99e233ca92c5988a3",
        "version_major": 2,
        "version_minor": 0
       },
@@ -246,14 +231,56 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[2025-03-26 14:48:23,891 hyrax.pytorch_ignite:INFO] Total training time: 88.99[s]\n",
-      "[2025-03-26 14:48:23,891 hyrax.pytorch_ignite:INFO] Latest checkpoint saved as: /home/drew/code/fibad/docs/pre_executed/results/20250326-144653-train-OgeH/checkpoint_epoch_10.pt\n",
-      "[2025-03-26 14:48:23,892 hyrax.pytorch_ignite:INFO] Best metric checkpoint saved as: /home/drew/code/fibad/docs/pre_executed/results/20250326-144653-train-OgeH/checkpoint_10_loss=-127.4221.pt\n",
-      "2025/03/26 14:48:23 INFO mlflow.system_metrics.system_metrics_monitor: Stopping system metrics monitoring...\n",
-      "2025/03/26 14:48:23 INFO mlflow.system_metrics.system_metrics_monitor: Successfully terminated system metrics monitoring!\n",
-      "[2025-03-26 14:48:23,903 hyrax.train:INFO] Finished Training\n",
-      "[2025-03-26 14:48:24,250 hyrax.model_exporters:INFO] Exported model to ONNX format: /home/drew/code/fibad/docs/pre_executed/results/20250326-144653-train-OgeH/example_model_opset_20.onnx\n"
+      "[2025-08-25 21:16:09,062 hyrax.pytorch_ignite:INFO] Total training time: 95.19[s]\n",
+      "[2025-08-25 21:16:09,063 hyrax.pytorch_ignite:INFO] Latest checkpoint saved as: /home/drew/code/hyrax/docs/pre_executed/results/20250825-211424-train-0D0a/checkpoint_epoch_10.pt\n",
+      "[2025-08-25 21:16:09,063 hyrax.pytorch_ignite:INFO] Best metric checkpoint saved as: /home/drew/code/hyrax/docs/pre_executed/results/20250825-211424-train-0D0a/checkpoint_9_loss=-126.9350.pt\n",
+      "2025/08/25 21:16:09 INFO mlflow.system_metrics.system_metrics_monitor: Stopping system metrics monitoring...\n",
+      "2025/08/25 21:16:09 INFO mlflow.system_metrics.system_metrics_monitor: Successfully terminated system metrics monitoring!\n",
+      "[2025-08-25 21:16:09,079 hyrax.verbs.train:INFO] Finished Training\n",
+      "[2025-08-25 21:16:09,364 hyrax.model_exporters:INFO] Exported model to ONNX format: /home/drew/code/hyrax/docs/pre_executed/results/20250825-211424-train-0D0a/example_model_opset_20.onnx\n"
      ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "HyraxAutoencoder(\n",
+       "  (encoder): Sequential(\n",
+       "    (0): Conv2d(3, 32, kernel_size=(3, 3), stride=(2, 2), padding=(1, 1))\n",
+       "    (1): GELU(approximate='none')\n",
+       "    (2): Conv2d(32, 32, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))\n",
+       "    (3): GELU(approximate='none')\n",
+       "    (4): Conv2d(32, 64, kernel_size=(3, 3), stride=(2, 2), padding=(1, 1))\n",
+       "    (5): GELU(approximate='none')\n",
+       "    (6): Conv2d(64, 64, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))\n",
+       "    (7): GELU(approximate='none')\n",
+       "    (8): Conv2d(64, 64, kernel_size=(3, 3), stride=(2, 2), padding=(1, 1))\n",
+       "    (9): GELU(approximate='none')\n",
+       "    (10): Flatten(start_dim=1, end_dim=-1)\n",
+       "    (11): Linear(in_features=1024, out_features=64, bias=True)\n",
+       "  )\n",
+       "  (dec_linear): Sequential(\n",
+       "    (0): Linear(in_features=64, out_features=1024, bias=True)\n",
+       "    (1): GELU(approximate='none')\n",
+       "  )\n",
+       "  (decoder): Sequential(\n",
+       "    (0): ConvTranspose2d(64, 64, kernel_size=(3, 3), stride=(2, 2), padding=(1, 1), output_padding=(1, 1))\n",
+       "    (1): GELU(approximate='none')\n",
+       "    (2): Conv2d(64, 64, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))\n",
+       "    (3): GELU(approximate='none')\n",
+       "    (4): ConvTranspose2d(64, 32, kernel_size=(3, 3), stride=(2, 2), padding=(1, 1), output_padding=(1, 1))\n",
+       "    (5): GELU(approximate='none')\n",
+       "    (6): Conv2d(32, 32, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))\n",
+       "    (7): GELU(approximate='none')\n",
+       "    (8): ConvTranspose2d(32, 3, kernel_size=(3, 3), stride=(2, 2), padding=(1, 1), output_padding=(1, 1))\n",
+       "    (9): Tanh()\n",
+       "  )\n",
+       "  (criterion): CrossEntropyLoss()\n",
+       ")"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -294,25 +321,49 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
+     "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Files already downloaded and verified\n"
+      "[2025-08-25 21:16:17,243 hyrax.models.model_registry:INFO] Using criterion: torch.nn.CrossEntropyLoss with default arguments.\n",
+      "[2025-08-25 21:16:17,244 hyrax.verbs.infer:INFO] data set has length 50000\n",
+      "2025-08-25 21:16:17,246 ignite.distributed.auto.auto_dataloader INFO: Use data loader kwargs for dataset '<hyrax.data_sets.hyr': \n",
+      "\t{'sampler': None, 'batch_size': 128, 'shuffle': False, 'pin_memory': True}\n",
+      "[2025-08-25 21:16:17,263 hyrax.verbs.infer:INFO] Saving inference results at: /home/drew/code/hyrax/docs/pre_executed/results/20250825-211609-infer-SY49\n",
+      "[2025-08-25 21:16:17,602 hyrax.pytorch_ignite:INFO] Evaluating model on device: cuda\n",
+      "[2025-08-25 21:16:17,605 hyrax.pytorch_ignite:INFO] Total epochs: 1\n"
      ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "b214578af62349308fadc484cc9a359d",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 1/391 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[2025-03-26 14:48:25,186 hyrax.models.model_registry:INFO] Using criterion: torch.nn.CrossEntropyLoss with default arguments.\n",
-      "[2025-03-26 14:48:25,187 hyrax.infer:INFO] data set has length 50000\n",
-      "2025-03-26 14:48:25,188 ignite.distributed.auto.auto_dataloader INFO: Use data loader kwargs for dataset 'Dataset HyraxCifarDa': \n",
-      "\t{'sampler': None, 'batch_size': 128, 'pin_memory': True}\n",
-      "[2025-03-26 14:48:25,715 hyrax.pytorch_ignite:INFO] Evaluating model on device: cuda\n",
-      "[2025-03-26 14:48:25,717 hyrax.pytorch_ignite:INFO] Total epochs: 1\n",
-      "[2025-03-26 14:48:51,778 hyrax.pytorch_ignite:INFO] Total evaluation time: 26.06[s]\n",
-      "[2025-03-26 14:48:51,848 hyrax.infer:INFO] Inference results saved in: /home/drew/code/fibad/docs/pre_executed/results/20250326-144824-infer-qr2F\n"
+      "[2025-08-25 21:16:30,310 hyrax.pytorch_ignite:INFO] Total evaluation time: 12.71[s]\n",
+      "[2025-08-25 21:16:30,434 hyrax.verbs.infer:INFO] Inference Complete.\n"
      ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<hyrax.data_sets.inference_dataset.InferenceDataSet at 0x70db7a0bafc0>"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [

--- a/src/hyrax/hyrax_default_config.toml
+++ b/src/hyrax/hyrax_default_config.toml
@@ -128,7 +128,7 @@ lr = 0.01
 
 [train]
 # The name of the file were the model weights will be saved after training.
-weights_filepath = "example_model.pth"
+weights_filename = "example_model.pth"
 
 #The number of epochs to train for.
 epochs = 10

--- a/src/hyrax/model_exporters.py
+++ b/src/hyrax/model_exporters.py
@@ -25,7 +25,7 @@ def export_to_onnx(model, sample, config, ctx):
     """
 
     # build the output ONNX file path
-    model_filename = Path(config["train"]["weights_filepath"]).stem
+    model_filename = Path(config["train"]["weights_filename"]).stem
     onnx_opset_version = config["onnx"]["opset_version"]
     onnx_model_filename = f"{model_filename}_opset_{onnx_opset_version}.onnx"
     onnx_output_filepath = ctx["results_dir"] / onnx_model_filename

--- a/src/hyrax/verbs/infer.py
+++ b/src/hyrax/verbs/infer.py
@@ -165,7 +165,7 @@ class Infer(Verb):
             if recent_results_path is None:
                 raise RuntimeError("Must define model_weights_file in the [infer] section of hyrax config.")
 
-            weights_file = recent_results_path / config["train"]["weights_filepath"]
+            weights_file = recent_results_path / config["train"]["weights_filename"]
 
         # Ensure weights file is a path object.
         weights_file_path = Path(weights_file)

--- a/src/hyrax/verbs/train.py
+++ b/src/hyrax/verbs/train.py
@@ -92,7 +92,7 @@ class Train(Verb):
             trainer.run(train_data_loader, max_epochs=config["train"]["epochs"])
 
         # Save the trained model
-        model.save(results_dir / config["train"]["weights_filepath"])
+        model.save(results_dir / config["train"]["weights_filename"])
         monitor.stop()
 
         logger.info("Finished Training")

--- a/tests/hyrax/test_config_utils.py
+++ b/tests/hyrax/test_config_utils.py
@@ -56,7 +56,7 @@ def test_get_runtime_config():
         "train": {
             "model_name": "example_model",
             "model_class": "new_thing.cool_model.CoolModel",
-            "model": {"weights_filepath": "final_best.pth", "layers": 3},
+            "model": {"weights_filename": "final_best.pth", "layers": 3},
         },
         "infer": {"batch_size": 8},
         "bespoke_table": {"key1": "value1", "key2": "value2"},
@@ -73,7 +73,7 @@ model_name = "example_model" # Use a built-in Hyrax model
 model_class = "new_thing.cool_model.CoolModel" # Use a custom model
 
 [train.model]
-weights_filepath = "final_best.pth"
+weights_filename = "final_best.pth"
 layers = 3
 
 
@@ -179,7 +179,7 @@ model_name = "example_model" # Use a built-in Hyrax model
 model_class = "new_thing.cool_model.CoolModel" # Use a custom model
 
 [train.model]
-weights_filepath = "final_best.pth"
+weights_filename = "final_best.pth"
 layers = 3
 
 

--- a/tests/hyrax/test_data/test_default_config.toml
+++ b/tests/hyrax/test_data/test_default_config.toml
@@ -9,7 +9,7 @@ model_name = "example_model" # Use a built-in Hyrax model
 model_class = "new_thing.cool_model.CoolModel" # Use a custom model
 
 [train.model]
-weights_filepath = "example_model.pth"
+weights_filename = "example_model.pth"
 layers = 3
 
 [infer]

--- a/tests/hyrax/test_data/test_user_config.toml
+++ b/tests/hyrax/test_data/test_user_config.toml
@@ -2,7 +2,7 @@
 dev_mode = true
 
 [train.model]
-weights_filepath = "final_best.pth"
+weights_filename = "final_best.pth"
 layers = 3
 
 [infer]


### PR DESCRIPTION
Updating the `[train]` configuration file key name from `weights_filepath` to `weights_filename`.

Since the config parameter is actually used as a file name and not a path, this naming is more correct. There is also an `[infer][model_weights_file]` but that one is actually a path, not a file name. Considered changing that to `model_weights_filepath` but taking small steps here. 