### PR TITLE
Added default value for `primary_id_field` in .toml file

### DIFF
--- a/src/hyrax/hyrax_default_config.toml
+++ b/src/hyrax/hyrax_default_config.toml
@@ -164,6 +164,9 @@ dataset_class = "HyraxCifarDataSet"
 # Location (directory) where the data is stored.
 data_location = "./data"
 
+# The data field that represents a unique ID for each sample.
+primary_id_field = "object_id"
+
 
 [data_set]
 # Warning - using data_set.name to define the dataset class will be deprecated.


### PR DESCRIPTION
Added default value for `primary_id_field` that corresponds to the default dataset, `HyraxCifarDataset`.

At this time, inferece requires a `object_id` field in order to write out data, we need to provide a `primary_id_field` for HyraxQL to be able to provide the object_id to the InferenceDatasetWriter. 