### PR TITLE
Lowering many logger.INFOs to logger.DEBUGs.

### DIFF
--- a/src/hyrax/data_sets/inference_dataset.py
+++ b/src/hyrax/data_sets/inference_dataset.py
@@ -288,7 +288,7 @@ class InferenceDataSet(HyraxDataset, Dataset):
                     raise RuntimeError(msg)
                 msg = f"Using most recent results dir {results_dir} for lookup."
                 msg += " Use the [results] inference_dir config to set a directory or pass it to this verb."
-                logger.info(msg)
+                logger.debug(msg)
 
         retval = Path(results_dir) if isinstance(results_dir, str) else results_dir
 

--- a/src/hyrax/hyrax.py
+++ b/src/hyrax/hyrax.py
@@ -92,7 +92,7 @@ class Hyrax:
             # Setup our handlers from config
             self._initialize_log_handlers()
 
-        self.logger.info(f"Runtime Config read from: {ConfigManager.resolve_runtime_config(config_file)}")
+        self.logger.debug(f"Runtime Config read from: {ConfigManager.resolve_runtime_config(config_file)}")
 
     def _initialize_log_handlers(self):
         """Private initialization helper, Adds handlers and level setting to the global self.logger object"""

--- a/src/hyrax/model_exporters.py
+++ b/src/hyrax/model_exporters.py
@@ -55,7 +55,7 @@ def export_to_onnx(model, sample, config, ctx):
     if not allclose(sample_out, ort_outs[0], rtol=1e-03, atol=1e-05):
         logger.warning("The outputs from the PyTorch model and the ONNX model are not close.")
 
-    logger.info(f"Exported model to ONNX format: {onnx_output_filepath}")
+    logger.debug(f"Exported model to ONNX format: {onnx_output_filepath}")
 
 
 def _export_pytorch_to_onnx(model, sample, output_filepath, opset_version):

--- a/src/hyrax/models/hyrax_autoencoder.py
+++ b/src/hyrax/models/hyrax_autoencoder.py
@@ -29,7 +29,7 @@ class HyraxAutoencoder(nn.Module):
         self.config = config
 
         shape = self.to_tensor(data_sample).shape
-        logger.info(f"Found shape: {shape} in data sample, using this to initialize model.")
+        logger.debug(f"Found shape: {shape} in data sample, using this to initialize model.")
 
         self.num_input_channels, self.image_width, self.image_height = shape
 

--- a/src/hyrax/models/hyrax_autoencoderv2.py
+++ b/src/hyrax/models/hyrax_autoencoderv2.py
@@ -1,5 +1,5 @@
 # ruff: noqa: D101, D102
-
+import logging
 
 import torch
 import torch.nn as nn
@@ -9,6 +9,8 @@ from torchvision.transforms.v2 import CenterCrop
 
 # extra long import here to address a circular import issue
 from hyrax.models.model_registry import hyrax_model
+
+logger = logging.getLogger(__name__)
 
 
 class ArcsinhActivation(nn.Module):
@@ -28,11 +30,13 @@ class HyraxAutoencoderV2(nn.Module):
     - Uses criterion and optimizer from config variables
     """
 
-    def __init__(self, config, shape=(5, 250, 250)):
+    def __init__(self, config, data_sample=None):
         super().__init__()
         self.config = config
 
-        # TODO config-ize or get from data loader somehow
+        shape = self.to_tensor(data_sample).shape
+        logger.debug(f"Found shape: {shape} in data sample, using this to initialize model.")
+
         self.num_input_channels, self.image_width, self.image_height = shape
 
         self.c_hid = self.config["model"]["base_channel_size"]

--- a/src/hyrax/models/model_registry.py
+++ b/src/hyrax/models/model_registry.py
@@ -39,13 +39,13 @@ def _torch_criterion(self: nn.Module):
     if criterion_name in config:
         arguments = config[criterion_name]
 
-    # Print some information about the criterion function and parameters used
+    # Print some debugging info about the criterion function and parameters used
     log_string = f"Using criterion: {criterion_name} "
     if arguments:
         log_string += f"with arguments: {arguments}."
     else:
         log_string += "with default arguments."
-    logger.info(log_string)
+    logger.debug(log_string)
 
     return criterion_cls(**arguments)
 
@@ -64,13 +64,13 @@ def _torch_optimizer(self: nn.Module):
     if optimizer_name in config:
         arguments = config[optimizer_name]
 
-    # Print some information about the optimizer function and parameters used
+    # Print some debugging info about the optimizer function and parameters used
     log_string = f"Using optimizer: {optimizer_name} "
     if arguments:
         log_string += f"with arguments: {arguments}."
     else:
         log_string += "with default arguments."
-    logger.info(log_string)
+    logger.debug(log_string)
 
     return optimizer_cls(self.parameters(), **arguments)
 

--- a/src/hyrax/pytorch_ignite.py
+++ b/src/hyrax/pytorch_ignite.py
@@ -482,8 +482,8 @@ def create_evaluator(
 
     @evaluator.on(Events.STARTED)
     def log_eval_start(evaluator):
-        logger.info(f"Evaluating model on device: {device}")
-        logger.info(f"Total epochs: {evaluator.state.max_epochs}")
+        logger.debug(f"Evaluating model on device: {device}")
+        logger.debug(f"Total epochs: {evaluator.state.max_epochs}")
 
     @evaluator.on(Events.ITERATION_COMPLETED)
     def log_iteration_complete(evaluator):
@@ -637,7 +637,7 @@ def create_trainer(
 
     @trainer.on(Events.STARTED)
     def log_training_start(trainer):
-        logger.info(f"Training model on device: {device}")
+        logger.debug(f"Training model on device: {device}")
 
     @trainer.on(Events.EPOCH_STARTED)
     def log_epoch_start(trainer):
@@ -663,10 +663,10 @@ def create_trainer(
         logger.info(f"Total training time: {trainer.state.times['COMPLETED']:.2f}[s]")
 
     def log_last_checkpoint_location(_, latest_checkpoint):
-        logger.info(f"Latest checkpoint saved as: {latest_checkpoint.last_checkpoint}")
+        logger.debug(f"Latest checkpoint saved as: {latest_checkpoint.last_checkpoint}")
 
     def log_best_checkpoint_location(_, best_checkpoint):
-        logger.info(f"Best metric checkpoint saved as: {best_checkpoint.last_checkpoint}")
+        logger.debug(f"Best metric checkpoint saved as: {best_checkpoint.last_checkpoint}")
 
     trainer.add_event_handler(Events.COMPLETED, log_last_checkpoint_location, latest_checkpoint)
     trainer.add_event_handler(Events.COMPLETED, log_best_checkpoint_location, best_checkpoint)

--- a/src/hyrax/verbs/infer.py
+++ b/src/hyrax/verbs/infer.py
@@ -63,7 +63,7 @@ class Infer(Verb):
         dataset = setup_dataset(config, tensorboardx_logger)
         model = setup_model(config, dataset)
         if dataset.is_map():
-            logger.info(f"data set has length {len(dataset)}")  # type: ignore[arg-type]
+            logger.debug(f"data set has length {len(dataset)}")  # type: ignore[arg-type]
 
         # Inference doesnt work at all with the dataloader doing additional shuffling:
         if config["data_loader"]["shuffle"]:

--- a/src/hyrax/verbs/save_to_database.py
+++ b/src/hyrax/verbs/save_to_database.py
@@ -137,7 +137,7 @@ class SaveToDatabase(Verb):
         # Use the batch_index to get the list of batches.
         batches = np.unique(inference_data_set.batch_index["batch_num"])
 
-        logger.info(f"Number of inference result batches to index: {len(batches)}.")
+        logger.debug(f"Number of inference result batches to index: {len(batches)}.")
 
         total_insertion_time = 0.0
         batch_count = 0


### PR DESCRIPTION
The logging output from `train` and `infer` was starting to get quite crowded. Most of the logging was diagnostic and used by engineers during development. 

I've reduced many of the logging messages from INFO to DEBUG (instead of removing them completely)

Frustratingly there is still a lot of INFO level logging from `mlflow` and `pytorch-ignite` coming through that I have not yet been able to get rid of, even though the messages would only be valuable to developers. 
