### PR TITLE
Use of `fetch_dataset_class` instead of accessing DATA_SET_REGISTRY

### DIFF
--- a/src/hyrax/data_sets/data_provider.py
+++ b/src/hyrax/data_sets/data_provider.py
@@ -182,6 +182,7 @@ class DataProvider:
             dataset_class = dataset_definition.get("dataset_class")
             if not dataset_class:
                 logger.error(f"Model input for '{friendly_name}' does not specify a 'dataset_class'.")
+                raise RuntimeError(f"Model input for '{friendly_name}' does not specify a 'dataset_class'.")
 
             # It's ok for data_location to be None, some datasets
             # (e.g. HyraxRandomDataset) may not require it.

--- a/src/hyrax/data_sets/data_provider.py
+++ b/src/hyrax/data_sets/data_provider.py
@@ -3,7 +3,7 @@ from typing import Any
 
 import numpy as np
 
-from hyrax.data_sets.data_set_registry import DATA_SET_REGISTRY
+from hyrax.data_sets.data_set_registry import fetch_dataset_class
 
 logger = logging.getLogger(__name__)
 
@@ -67,8 +67,6 @@ class DataProvider:
 
         self.config = config
         self.data_request = generate_data_request_from_config(self.config)
-
-        self.validate_request(self.data_request)
 
         self.prepped_datasets = {}
         self.dataset_getters = {}
@@ -172,42 +170,6 @@ class DataProvider:
         """DataProvider datasets will always be map-style datasets."""
         return True
 
-    # ^ Since the getter methods are dynamically created when a dataset class is _instantiated_,
-    # ^ we can't really validate that the requested fields exist until after instantiation.
-    # ^ And instantiation doesn't happen here, it happens in `prepare_datasets`.
-    # ^ See: https://github.com/lincc-frameworks/hyrax/issues/419
-
-    @staticmethod
-    def validate_request(data_request: dict):
-        """Convenience method to ensure that each requested dataset exists and that
-        each field in each dataset has a `get_<field_name>` method."""
-        problem_count = 0
-        for friendly_name, dataset_parameters in data_request.items():
-            dataset_class = dataset_parameters.get("dataset_class")
-            if not dataset_class:
-                logger.error(f"Model input for '{friendly_name}' does not specify a 'dataset_class'.")
-                problem_count += 1
-                continue
-            if dataset_class not in DATA_SET_REGISTRY:
-                logger.error(
-                    f"Unable to locate dataset, '{dataset_class}' in the registered datasets:"
-                    f" {list(DATA_SET_REGISTRY.keys())}."
-                )
-                problem_count += 1
-                continue
-            if DATA_SET_REGISTRY[dataset_class].is_iterable():
-                logger.error(
-                    f"Dataset '{dataset_class}' is an iterable-style dataset. "
-                    "This is not supported in the current implementation of DataProvider. "
-                    "Hyrax DataProvider only supports map-style datasets at this time. "
-                    "You should instantiate an iterable-style dataset class directly."
-                )
-                problem_count += 1
-
-        if problem_count > 0:
-            logger.error(f"Finished validating request. Problems found: {problem_count}")
-            raise RuntimeError("Data request validation failed. See logs for details.")
-
     def prepare_datasets(self):
         """Instantiate each of the requested datasets based on the ``model_inputs``
         configuration dictionary. Store the prepared instances in the
@@ -216,11 +178,13 @@ class DataProvider:
         if len(self.data_request) == 0:
             raise RuntimeError("No datasets were requested in `model_inputs`.")
 
-        # Note: We can be less strict about checking for existence of keys here
-        # because we have already validated the ``model_inputs`` in
-        # `self.validate_request()`.
         for friendly_name, dataset_definition in self.data_request.items():
             dataset_class = dataset_definition.get("dataset_class")
+            if not dataset_class:
+                logger.error(f"Model input for '{friendly_name}' does not specify a 'dataset_class'.")
+
+            # It's ok for data_location to be None, some datasets
+            # (e.g. HyraxRandomDataset) may not require it.
             data_location = dataset_definition.get("data_location")
 
             # Create a temporary config dictionary that merges the original
@@ -228,9 +192,8 @@ class DataProvider:
             dataset_specific_config = self._apply_configurations(self.config, dataset_definition)
 
             # Instantiate the dataset class
-            dataset_instance = DATA_SET_REGISTRY[dataset_class](
-                config=dataset_specific_config, data_location=data_location
-            )
+            dataset_cls = fetch_dataset_class(dataset_class)
+            dataset_instance = dataset_cls(config=dataset_specific_config, data_location=data_location)
 
             # Store the prepared dataset instance in the `self.prepped_datasets`
             self.prepped_datasets[friendly_name] = dataset_instance

--- a/src/hyrax/data_sets/data_set_registry.py
+++ b/src/hyrax/data_sets/data_set_registry.py
@@ -299,10 +299,13 @@ def fetch_dataset_class(class_name: str) -> type[HyraxDataset]:
         If no dataset was specified in the runtime configuration.
     """
 
+    if not class_name:
+        raise RuntimeError("dataset_class must be specified in 'model_inputs'.")
+
     try:
         dataset_cls = get_or_load_class(class_name, DATA_SET_REGISTRY)
-    except ValueError as exc:
-        raise ValueError(f"Error fetching dataset class {class_name}") from exc
+    except Exception:
+        raise
 
     return dataset_cls
 

--- a/src/hyrax/data_sets/data_set_registry.py
+++ b/src/hyrax/data_sets/data_set_registry.py
@@ -276,36 +276,35 @@ class HyraxDataset:
         return self._metadata_table[idxs][columns].as_array()
 
 
-def fetch_data_set_class(runtime_config: dict) -> type[HyraxDataset]:
-    """Fetch the data loader class from the registry.
+def fetch_dataset_class(class_name: str) -> type[HyraxDataset]:
+    """Fetch the dataset class from the registry.
 
     Parameters
     ----------
-    runtime_config : dict
-        The runtime configuration dictionary.
+    class_name : str
+        The name of the dataset class to fetch. Either the class name of a built
+      in dataset, or the fully qualified name of a user-defined dataset.
+      e.g. "my_module.my_submodule.MyDatasetClass" or "HyraxRandomDataset".
 
     Returns
     -------
-    type
-        The data loader class.
+    type[HyraxDataset]
+        The dataset class.
 
     Raises
     ------
     ValueError
-        If a built in data loader was requested, but not found in the registry.
+        If a built in dataset was requested, but not found in the registry.
     ValueError
-        If no data loader was specified in the runtime configuration.
+        If no dataset was specified in the runtime configuration.
     """
 
-    data_set_config = runtime_config["data_set"]
-    data_set_cls = None
-
     try:
-        data_set_cls = get_or_load_class(data_set_config, DATA_SET_REGISTRY)
+        dataset_cls = get_or_load_class(class_name, DATA_SET_REGISTRY)
     except ValueError as exc:
-        raise ValueError("Error fetching data set class") from exc
+        raise ValueError(f"Error fetching dataset class {class_name}") from exc
 
-    return data_set_cls
+    return dataset_cls
 
 
 class HyraxImageDataset:

--- a/src/hyrax/data_sets/data_set_registry.py
+++ b/src/hyrax/data_sets/data_set_registry.py
@@ -302,10 +302,7 @@ def fetch_dataset_class(class_name: str) -> type[HyraxDataset]:
     if not class_name:
         raise RuntimeError("dataset_class must be specified in 'model_inputs'.")
 
-    try:
-        dataset_cls = get_or_load_class(class_name, DATA_SET_REGISTRY)
-    except Exception:
-        raise
+    dataset_cls = get_or_load_class(class_name, DATA_SET_REGISTRY)
 
     return dataset_cls
 

--- a/src/hyrax/models/model_registry.py
+++ b/src/hyrax/models/model_registry.py
@@ -171,9 +171,15 @@ def fetch_model_class(runtime_config: dict) -> type[nn.Module]:
     model_name = runtime_config["model"]["name"]
     model_cls = None
 
+    if not model_name:
+        raise RuntimeError(
+            "A model class name or path must be provided. "
+            "e.g. 'HyraxCNN' or 'my_package.my_module.MyModelClass'."
+        )
+
     try:
         model_cls = cast(type[nn.Module], get_or_load_class(model_name, MODEL_REGISTRY))
-    except ValueError as exc:
-        raise ValueError("Error fetching model class") from exc
+    except Exception:
+        raise
 
     return model_cls

--- a/src/hyrax/models/model_registry.py
+++ b/src/hyrax/models/model_registry.py
@@ -32,8 +32,8 @@ def _torch_criterion(self: nn.Module):
     config = cast(dict[str, Any], self.config)
 
     # Load the class and get any parameters from the config dictionary
-    criterion_cls = get_or_load_class(config["criterion"])
     criterion_name = config["criterion"]["name"]
+    criterion_cls = get_or_load_class(criterion_name)
 
     arguments = {}
     if criterion_name in config:
@@ -57,8 +57,8 @@ def _torch_optimizer(self: nn.Module):
     config = cast(dict[str, Any], self.config)
 
     # Load the class and get any parameters from the config dictionary
-    optimizer_cls = get_or_load_class(config["optimizer"])
     optimizer_name = config["optimizer"]["name"]
+    optimizer_cls = get_or_load_class(optimizer_name)
 
     arguments = {}
     if optimizer_name in config:
@@ -168,11 +168,11 @@ def fetch_model_class(runtime_config: dict) -> type[nn.Module]:
         If no model was specified in the runtime configuration.
     """
 
-    model_config = runtime_config["model"]
+    model_name = runtime_config["model"]["name"]
     model_cls = None
 
     try:
-        model_cls = cast(type[nn.Module], get_or_load_class(model_config, MODEL_REGISTRY))
+        model_cls = cast(type[nn.Module], get_or_load_class(model_name, MODEL_REGISTRY))
     except ValueError as exc:
         raise ValueError("Error fetching model class") from exc
 

--- a/src/hyrax/models/model_registry.py
+++ b/src/hyrax/models/model_registry.py
@@ -177,9 +177,6 @@ def fetch_model_class(runtime_config: dict) -> type[nn.Module]:
             "e.g. 'HyraxCNN' or 'my_package.my_module.MyModelClass'."
         )
 
-    try:
-        model_cls = cast(type[nn.Module], get_or_load_class(model_name, MODEL_REGISTRY))
-    except Exception:
-        raise
+    model_cls = cast(type[nn.Module], get_or_load_class(model_name, MODEL_REGISTRY))
 
     return model_cls

--- a/src/hyrax/plugin_utils.py
+++ b/src/hyrax/plugin_utils.py
@@ -23,17 +23,24 @@ def get_or_load_class(class_name: str, registry: Optional[dict[str, T]] = None) 
 
     """
 
-    if registry and class_name in registry:
-        returned_class = registry[class_name]
-    else:
-        #! I'm not a big fan of this check here. It would be nice if this was
-        #! handled more gracefully elsewhere.
-        if "." not in class_name:
-            raise ValueError(f"Class name {class_name} not found in registry and is not a full import path.")
-        returned_class = import_module_from_string(class_name)
-        # if the class was loaded successfully, add it to the provided registry
-        if registry:
+    if registry:
+        if class_name in registry:
+            return registry[class_name]
+        else:
+            # If the class isn't in the registry, it must be an external class,
+            # so we require the user to provide the full import path.
+            if "." not in class_name:
+                raise ValueError(
+                    f"Class name {class_name} not found in registry and is not a full import path."
+                )
+            returned_class = import_module_from_string(class_name)
             update_registry(registry, class_name, returned_class)
+
+    else:
+        # If there is no registry, we require the user to provide the full import path.
+        if "." not in class_name:
+            raise ValueError(f"Class name {class_name} is not a full import path.")
+        returned_class = import_module_from_string(class_name)
 
     return returned_class
 

--- a/src/hyrax/plugin_utils.py
+++ b/src/hyrax/plugin_utils.py
@@ -67,6 +67,8 @@ def import_module_from_string(module_path: str) -> Any:
         If the module is not found using the provided import spec.
     """
 
+    # The only place that uses this function already checks for ".", but in case
+    # this function is used elsewhere in the future, we check again here.
     if "." not in module_path:
         raise ValueError(f"Invalid module path: {module_path}. Expected format: 'module.submodule.ClassName'")
 

--- a/src/hyrax/pytorch_ignite.py
+++ b/src/hyrax/pytorch_ignite.py
@@ -108,8 +108,6 @@ def setup_dataset(config: ConfigDict, tensorboardx_logger: Optional[SummaryWrite
         data_definition = next(iter(data_request.values()))
 
         dataset_class = data_definition.get("dataset_class", None)
-        if dataset_class is None:
-            raise RuntimeError("dataset_class must be specified in 'model_inputs'.")
 
         dataset_cls = fetch_dataset_class(dataset_class)
 

--- a/src/hyrax/pytorch_ignite.py
+++ b/src/hyrax/pytorch_ignite.py
@@ -7,7 +7,7 @@ from typing import Any, Callable, Optional, Union
 import ignite.distributed as idist
 import numpy as np
 
-from hyrax.data_sets.data_set_registry import DATA_SET_REGISTRY
+from hyrax.data_sets.data_set_registry import fetch_dataset_class
 
 with warnings.catch_warnings():
     warnings.simplefilter(action="ignore", category=DeprecationWarning)
@@ -59,7 +59,7 @@ def is_iterable_dataset_requested(data_request: dict) -> bool:
 
     is_iterable = False
     for _, dataset_definition in data_request.items():
-        if DATA_SET_REGISTRY[dataset_definition["dataset_class"]].is_iterable():
+        if fetch_dataset_class(dataset_definition["dataset_class"]).is_iterable():
             is_iterable = True
     return is_iterable
 
@@ -110,10 +110,8 @@ def setup_dataset(config: ConfigDict, tensorboardx_logger: Optional[SummaryWrite
         dataset_class = data_definition.get("dataset_class", None)
         if dataset_class is None:
             raise RuntimeError("dataset_class must be specified in 'model_inputs'.")
-        elif dataset_class not in DATA_SET_REGISTRY:
-            raise RuntimeError(f"dataset_class {dataset_class} not found in DATA_SET_REGISTRY.")
-        else:
-            dataset_cls = DATA_SET_REGISTRY[dataset_class]
+
+        dataset_cls = fetch_dataset_class(dataset_class)
 
         data_location = data_definition.get("data_location", None)
 

--- a/tests/hyrax/conftest.py
+++ b/tests/hyrax/conftest.py
@@ -8,7 +8,6 @@ from torch import from_numpy
 from torch.utils.data import Dataset, IterableDataset
 
 import hyrax
-import hyrax.data_sets
 from hyrax.data_sets import HyraxDataset
 from hyrax.data_sets.data_provider import DataProvider
 

--- a/tests/hyrax/test_data_provider.py
+++ b/tests/hyrax/test_data_provider.py
@@ -85,29 +85,29 @@ def test_data_provider(data_provider):
 def test_validate_request_no_dataset_class(multimodal_config, caplog):
     """Basic test to see that validation works as when no dataset class
     name is provided."""
-
+    h = Hyrax()
     c = multimodal_config
     c["random_0"].pop("dataset_class", None)
+    h.config["model_inputs"] = c
     with caplog.at_level("ERROR"):
         with pytest.raises(RuntimeError) as execinfo:
-            DataProvider.validate_request(c)
+            DataProvider(h.config)
 
-    assert "failed" in str(execinfo.value)
+    assert "does not specify a 'dataset_class'" in str(execinfo.value)
     assert "does not specify a 'dataset_class'" in caplog.text
 
 
 def test_validate_request_unknown_dataset(multimodal_config, caplog):
     """Basic test to see that validation raises correctly when a nonexistent
     dataset class name is provided."""
-
+    h = Hyrax()
     c = multimodal_config
     c["random_0"]["dataset_class"] = "NoSuchDataset"
+    h.config["model_inputs"] = c
     with caplog.at_level("ERROR"):
-        with pytest.raises(RuntimeError) as execinfo:
-            DataProvider.validate_request(c)
+        DataProvider(h.config)
 
-    assert "failed" in str(execinfo.value)
-    assert "Unable to locate dataset" in caplog.text
+    assert "not found in registry" in caplog.text
 
 
 def test_validate_request_bad_field(multimodal_config, caplog):

--- a/tests/hyrax/test_data_provider.py
+++ b/tests/hyrax/test_data_provider.py
@@ -82,14 +82,6 @@ def test_data_provider(data_provider):
             assert friendly_name in metadata_field
 
 
-def test_validate_request(multimodal_config):
-    """Basic test to see that validation works as expected in the base
-    case."""
-
-    c = multimodal_config
-    DataProvider.validate_request(c)
-
-
 def test_validate_request_no_dataset_class(multimodal_config, caplog):
     """Basic test to see that validation works as when no dataset class
     name is provided."""
@@ -116,20 +108,6 @@ def test_validate_request_unknown_dataset(multimodal_config, caplog):
 
     assert "failed" in str(execinfo.value)
     assert "Unable to locate dataset" in caplog.text
-
-
-def test_validate_request_iterable_dataset(multimodal_config, caplog):
-    """Basic test to see that validation works correctly when an iterable dataset
-    is requested"""
-
-    c = multimodal_config
-    c["random_0"]["dataset_class"] = "HyraxRandomIterableDataset"
-    with caplog.at_level("ERROR"):
-        with pytest.raises(RuntimeError) as execinfo:
-            DataProvider.validate_request(c)
-
-    assert "failed" in str(execinfo.value)
-    assert "is an iterable-style dataset" in caplog.text
 
 
 def test_validate_request_bad_field(multimodal_config, caplog):

--- a/tests/hyrax/test_data_provider.py
+++ b/tests/hyrax/test_data_provider.py
@@ -104,10 +104,10 @@ def test_validate_request_unknown_dataset(multimodal_config, caplog):
     c = multimodal_config
     c["random_0"]["dataset_class"] = "NoSuchDataset"
     h.config["model_inputs"] = c
-    with caplog.at_level("ERROR"):
+    with pytest.raises(ValueError) as execinfo:
         DataProvider(h.config)
 
-    assert "not found in registry" in caplog.text
+    assert "not found in registry" in str(execinfo.value)
 
 
 def test_validate_request_bad_field(multimodal_config, caplog):

--- a/tests/hyrax/test_plugin_utils.py
+++ b/tests/hyrax/test_plugin_utils.py
@@ -65,10 +65,10 @@ def test_fetch_model_class_no_model():
 
     config = {"model": {"name": ""}}
 
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(RuntimeError) as excinfo:
         fetch_model_class(config)
 
-    assert "Error fetching model class" in str(excinfo.value)
+    assert "A model class name or path must be provided" in str(excinfo.value)
 
 
 def test_fetch_model_class_no_model_cls():
@@ -90,7 +90,7 @@ def test_fetch_model_class_not_in_registry():
     with pytest.raises(ValueError) as excinfo:
         fetch_model_class(config)
 
-    assert "Error fetching model class" in str(excinfo.value)
+    assert "not found in registry and is not a full import path" in str(excinfo.value)
 
 
 def test_fetch_model_class_in_registry():

--- a/tests/hyrax/test_plugin_utils.py
+++ b/tests/hyrax/test_plugin_utils.py
@@ -47,7 +47,7 @@ def test_import_module_from_string_no_class():
     with pytest.raises(AttributeError) as excinfo:
         plugin_utils.import_module_from_string(module_path)
 
-    assert "Model class Nonexistent not found" in str(excinfo.value)
+    assert "Unable to find Nonexistent in module" in str(excinfo.value)
 
 
 def test_fetch_model_class():
@@ -63,7 +63,7 @@ def test_fetch_model_class_no_model():
     """Test that the fetch_model_class function raises an error when no model
     is specified in the configuration."""
 
-    config = {"model": {}}
+    config = {"model": {"name": ""}}
 
     with pytest.raises(ValueError) as excinfo:
         fetch_model_class(config)
@@ -79,7 +79,7 @@ def test_fetch_model_class_no_model_cls():
     with pytest.raises(AttributeError) as excinfo:
         fetch_model_class(config)
 
-    assert "Model class Nonexistent not found" in str(excinfo.value)
+    assert "Unable to find Nonexistent in module" in str(excinfo.value)
 
 
 def test_fetch_model_class_not_in_registry():

--- a/tests/hyrax/test_pytorch_ignite.py
+++ b/tests/hyrax/test_pytorch_ignite.py
@@ -45,20 +45,16 @@ class TestSetupDataset:
         # Mock the functions that would be called before our code
         with patch("hyrax.data_sets.data_provider.generate_data_request_from_config") as mock_generate:
             with patch("hyrax.pytorch_ignite.is_iterable_dataset_requested") as mock_is_iterable:
-                with patch("hyrax.pytorch_ignite.DATA_SET_REGISTRY") as mock_registry:
-                    # Set up mocks to trigger the iterable dataset path
-                    mock_generate.return_value = config["model_inputs"]
-                    mock_is_iterable.return_value = True
-                    # Make the registry lookup fail by simulating the dataset class not being in registry
-                    mock_registry.__contains__.return_value = False
+                # Set up mocks to trigger the iterable dataset path
+                mock_generate.return_value = config["model_inputs"]
+                mock_is_iterable.return_value = True
+                # Make the registry lookup fail by simulating the dataset class not being in registry
 
-                    # This should raise RuntimeError with our specific message
-                    with pytest.raises(RuntimeError) as exc_info:
-                        setup_dataset(config)
+                # This should raise RuntimeError with our specific message
+                with pytest.raises(RuntimeError) as exc_info:
+                    setup_dataset(config)
 
-                    assert "dataset_class NonExistentDatasetClass not found in DATA_SET_REGISTRY." in str(
-                        exc_info.value
-                    )
+                assert "Error fetching dataset class NonExistentDatasetClass" in str(exc_info.value)
 
     def test_setup_dataset_missing_data_location_uses_none(self):
         """Test that missing data_location passes None to dataset constructor."""

--- a/tests/hyrax/test_pytorch_ignite.py
+++ b/tests/hyrax/test_pytorch_ignite.py
@@ -51,10 +51,10 @@ class TestSetupDataset:
                 # Make the registry lookup fail by simulating the dataset class not being in registry
 
                 # This should raise RuntimeError with our specific message
-                with pytest.raises(RuntimeError) as exc_info:
+                with pytest.raises(ValueError) as exc_info:
                     setup_dataset(config)
 
-                assert "Error fetching dataset class NonExistentDatasetClass" in str(exc_info.value)
+                assert "Class name NonExistentDatasetClass" in str(exc_info.value)
 
     def test_setup_dataset_missing_data_location_uses_none(self):
         """Test that missing data_location passes None to dataset constructor."""
@@ -74,12 +74,11 @@ class TestSetupDataset:
 
         with patch("hyrax.data_sets.data_provider.generate_data_request_from_config") as mock_generate:
             with patch("hyrax.pytorch_ignite.is_iterable_dataset_requested") as mock_is_iterable:
-                with patch("hyrax.pytorch_ignite.DATA_SET_REGISTRY") as mock_registry:
+                with patch("hyrax.pytorch_ignite.fetch_dataset_class") as mock_fetch_cls:
                     # Set up mocks
                     mock_generate.return_value = config["model_inputs"]
                     mock_is_iterable.return_value = True
-                    mock_registry.__contains__.return_value = True
-                    mock_registry.__getitem__.return_value = mock_dataset_cls
+                    mock_fetch_cls.return_value = mock_dataset_cls
 
                     # Call the function
                     result = setup_dataset(config)
@@ -106,12 +105,11 @@ class TestSetupDataset:
 
         with patch("hyrax.data_sets.data_provider.generate_data_request_from_config") as mock_generate:
             with patch("hyrax.pytorch_ignite.is_iterable_dataset_requested") as mock_is_iterable:
-                with patch("hyrax.pytorch_ignite.DATA_SET_REGISTRY") as mock_registry:
+                with patch("hyrax.pytorch_ignite.fetch_dataset_class") as mock_fetch_cls:
                     # Set up mocks
                     mock_generate.return_value = config["model_inputs"]
                     mock_is_iterable.return_value = True
-                    mock_registry.__contains__.return_value = True
-                    mock_registry.__getitem__.return_value = mock_dataset_cls
+                    mock_fetch_cls.return_value = mock_dataset_cls
 
                     # Call the function
                     result = setup_dataset(config)
@@ -139,12 +137,11 @@ class TestSetupDataset:
 
         with patch("hyrax.data_sets.data_provider.generate_data_request_from_config") as mock_generate:
             with patch("hyrax.pytorch_ignite.is_iterable_dataset_requested") as mock_is_iterable:
-                with patch("hyrax.pytorch_ignite.DATA_SET_REGISTRY") as mock_registry:
+                with patch("hyrax.pytorch_ignite.fetch_dataset_class") as mock_fetch_cls:
                     # Set up mocks
                     mock_generate.return_value = config["model_inputs"]
                     mock_is_iterable.return_value = True
-                    mock_registry.__contains__.return_value = True
-                    mock_registry.__getitem__.return_value = mock_dataset_cls
+                    mock_fetch_cls.return_value = mock_dataset_cls
 
                     # Call the function with logger
                     result = setup_dataset(config, tensorboardx_logger=mock_logger)


### PR DESCRIPTION
This should automatically load any dataset classes that are requested as libpaths. We were already doing this for models, but for some reason, we weren't doing this for dataset classes. 

Also removed `DataProvider.validate_request`.

Updated unit tests.
