### PR TITLE
WIP - Attempting to make ConfigManager easier to use

### DIFF
--- a/test_config.toml
+++ b/test_config.toml
@@ -1,0 +1,2 @@
+[model]
+name = "external_hyrax_example.example_model.ExampleModel"

--- a/testing.ipynb
+++ b/testing.ipynb
@@ -1,0 +1,62 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9d6e3079",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from hyrax import Hyrax\n",
+    "\n",
+    "# h = Hyrax(config_file=\"/home/drew/code/hyrax/test_config.toml\")\n",
+    "h = Hyrax()\n",
+    "h.config[\"model\"][\"name\"] = \"external_hyrax_example.example_model.ExampleModel\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1b58b63a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cm = h.config_manager\n",
+    "c = cm.overall_default_config\n",
+    "c[\"model\"]\n",
+    "cm._find_external_library_default_config_paths(cm.overall_default_config)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "645efbfc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "h.train()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "hyrax",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
WIP - Attempting to make ConfigManager easier to use so that we can call it multiple times during runtime.

If we can make use of staticmethods in ConfigManager to easily refresh the state of the configuration so that _ALL_ defaults are fully resolved just prior to executing `train`, `infer`, etc. would be very useful. 

This would allow a user to instantiate hyrax, _then_ edit the config, and have confidence that the desired default configs will exist. As in this contrived notebook cell:
```
from hyrax import Hyrax
h=Hyrax()
h.config["model"]["name"] = "external_hyrax_example.example_model.ExampleModel"

h.train()  
```
Currently `h.train()` will break because the default config from ExampleModel isn't loaded in the runtime config.