### PR TITLE
Updating built-in models that are not already using `data_sample`

### DIFF
--- a/src/hyrax/models/hsc_autoencoder.py
+++ b/src/hyrax/models/hsc_autoencoder.py
@@ -13,7 +13,7 @@ class HSCAutoencoder(nn.Module):  # These shapes work with [3,258,258] inputs
     This autoencoder is designed to work with datasets that are prepared with Hyrax's HSC Data Set class.
     """
 
-    def __init__(self, config, shape):
+    def __init__(self, config, data_sample=None):
         super().__init__()
 
         # Encoder

--- a/src/hyrax/models/hsc_dcae.py
+++ b/src/hyrax/models/hsc_dcae.py
@@ -24,7 +24,7 @@ class HSCDCAE(nn.Module):
     This autoencoder is designed to work with datasets that are prepared with Hyrax's HSC Data Set class.
     """
 
-    def __init__(self, config, shape):
+    def __init__(self, config, data_sample=None):
         super().__init__()
 
         # The current network works with images of size [3,150,150]

--- a/src/hyrax/models/hyrax_cnn.py
+++ b/src/hyrax/models/hyrax_cnn.py
@@ -19,11 +19,12 @@ class HyraxCNN(nn.Module):
     This CNN is designed to work with datasets that are prepared with Hyrax's HSC Data Set class.
     """
 
-    def __init__(self, config, shape=(3, 32, 32)):
+    def __init__(self, config, data_sample=None):
         super().__init__()
         self.config = config
 
-        self.num_input_channels, self.image_width, self.image_height = shape
+        image_sample = data_sample[0]
+        self.num_input_channels, self.image_width, self.image_height = image_sample.shape
         hidden_channels_1 = 6
         hidden_channels_2 = 16
 

--- a/src/hyrax/models/image_dcae.py
+++ b/src/hyrax/models/image_dcae.py
@@ -27,20 +27,20 @@ class ImageDCAE(nn.Module):
     arbitarily sized images with arbitrary number of channels.
     """
 
-    def __init__(self, config, shape):
+    def __init__(self, config, data_sample=None):
         super().__init__()
 
         # Store input shape for dynamic sizing
-        self.input_shape = shape
+        self.input_shape = data_sample.shape
         self.config = config
 
         # Extract dimensions from input shape
-        if len(shape) == 4:  # Batch dimension included
-            self.num_input_channels = shape[1]
-            self.image_height, self.image_width = shape[2], shape[3]
+        if len(self.input_shape) == 4:  # Batch dimension included
+            self.num_input_channels = self.input_shape[1]
+            self.image_height, self.image_width = self.input_shape[2], self.input_shape[3]
         else:  # No batch dimension
-            self.num_input_channels = shape[0]
-            self.image_height, self.image_width = shape[1], shape[2]
+            self.num_input_channels = self.input_shape[0]
+            self.image_height, self.image_width = self.input_shape[1], self.input_shape[2]
 
         # Get latent dimension from config (similar to HyraxAutoencoder)
         self.latent_dim = config["model"].get("latent_dim", 512)


### PR DESCRIPTION
Some of the built-in models were still using the `shape` parameter. (About half weren't doing anything with that parameter)

This PR updates the models to make sure that they are all using `data_sample` and not `shape`. Plus whatever logic is required to make sure that the new data_sample is being used correctly. 
