### PR TITLE
docs: add contextual cross-references across core guide pages

### DIFF
--- a/docs/about.rst
+++ b/docs/about.rst
@@ -39,7 +39,7 @@ Guiding principles
   We work closely with scientists to build Hyrax to support their use cases, but
   we learned early on that we can't anticipate all the ways that Hyrax will be used.
   Hyrax is designed to be easily extended to support new models, data sources,
-  and functionality.
+  and functionality (see :doc:`/external_libraries`).
 
 
 Commitment to open science

--- a/docs/architecture_overview.rst
+++ b/docs/architecture_overview.rst
@@ -7,12 +7,15 @@ Hyrax defines a set of commands, called verbs, that are the primary mode of inte
 Verbs are meant to be intuitive and easy to remember. For instance, to train a model,
 you would use the ``train`` verb.
 To use a trained model for inference, you would use the ``infer`` verb.
+If you want the full verb-by-verb behavior, see :doc:`verbs`.
 
 Notebook, CLI, or Both
 --------------------------------
 Hyrax is designed to be used in a Jupyter notebook or from the command line without
 modification. This supports exploration and development in a familiar notebook environment
 and deployment to an HPC or Slurm system for large scale training.
+For end-to-end examples that show this workflow in practice, see :doc:`getting_started`
+and :doc:`science_examples`.
 
 .. tab-set::
 

--- a/docs/architecture_overview.rst
+++ b/docs/architecture_overview.rst
@@ -3,11 +3,10 @@ Architecture overview
 
 Hyrax uses verbs
 ----------------
-Hyrax defines a set of commands, called verbs, that are the primary mode of interaction.
-Verbs are meant to be intuitive and easy to remember. For instance, to train a model,
-you would use the ``train`` verb.
-To use a trained model for inference, you would use the ``infer`` verb.
-If you want the full verb-by-verb behavior, see :doc:`verbs`.
+Hyrax defines a set of commands, called :doc:`verbs </verbs>`, that are the primary
+mode of interaction. Verbs are meant to be intuitive and easy to remember. For instance,
+to train a model, you would use the ``train`` verb. To use a trained model for inference,
+you would use the ``infer`` verb.
 
 Notebook, CLI, or Both
 --------------------------------

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -3,7 +3,8 @@ Configuration
 
 Hyrax ships with a complete default configuration file that can be used immediately
 to run the software, however, to make the most of Hyrax you'll need to modify
-the configuration to suit your specific needs.
+the configuration to suit your specific needs. For a deeper look at how configuration
+files are layered and resolved, see :doc:`/configuration_system`.
 
 
 Using the configuration system
@@ -146,7 +147,7 @@ to the different actions that Hyrax can take.
 For instance, the ``[train]`` table contains parameters needed when training a
 model such as ``epochs`` and ``weights_filename``.
 While the ``[infer]`` table contains keys such as ``model_weights_file``.
-For details on how these actions are invoked, see :doc:`verbs`.
+See :doc:`/verbs` for the full list of actions these tables correspond to.
 
 
 .. _complete_default_config:

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -15,6 +15,8 @@ If no configuration file is specified, :ref:`the default<complete_default_config
 will be used. To specify a different configuration file, use the
 ``-c | --runtime-config`` flag from the CLI
 or pass the path to the configuration file when creating a ``Hyrax`` object.
+For a deeper explanation of how config values are inherited across base, package,
+and user-defined TOML files, see :doc:`configuration_system`.
 
 .. tab-set::
 
@@ -105,6 +107,8 @@ and attempting to do so in code will raise an exception.
 
 By making the configuration immutable during execution, we ensure that the state
 of all parameters can be accurately saved with the results of the action.
+This runtime snapshot is especially helpful when comparing runs in
+:doc:`model_comparison`.
 
 
 About the default configuration
@@ -142,6 +146,7 @@ to the different actions that Hyrax can take.
 For instance, the ``[train]`` table contains parameters needed when training a
 model such as ``epochs`` and ``weights_filename``.
 While the ``[infer]`` table contains keys such as ``model_weights_file``.
+For details on how these actions are invoked, see :doc:`verbs`.
 
 
 .. _complete_default_config:

--- a/docs/configuration_system.rst
+++ b/docs/configuration_system.rst
@@ -2,6 +2,7 @@ The ``Hyrax`` Configuration System
 ==================================
 
 ``hyrax`` makes extensive use of the config variables to manage the runtime environment of training and inference runs. There is a ``hyrax_default_config.toml``  file (full contents listed :ref:`here<complete_default_config>`), included with ``hyrax``, that contains every variable that ``hyrax`` could need to operate. To create a custom configuration file, simply create a ``.toml`` file and change variables as you see fit, or if you’re running with a custom dataset or model, add your own variables.
+For a practical walkthrough that starts from a minimal override file, see :doc:`configuration`.
 
 Config variables are inherited from a hierarchy of sources, similar to ``python`` classes. First, ``hyrax`` will read the variables set in the default configuration. Next, it will load the relevant default config of any custom ``hyrax`` packages that the user is utilizing. It determines what packages to include by checking what custom classes are loaded in initially and looking for the relevant default configs. If a package doesn’t have a default, ``hyrax`` will throw a warning. Finally, it will use whatever variables have been declared in the user defined config toml (see `here <https://hyrax.readthedocs.io/en/latest/notebooks/config_basics.html>`_ for how to load those through a notebook or script). Config variables at each step can overwrite config variables from previous steps which leads to the following priority:
 - Variables from a user defined config toml are used
@@ -23,6 +24,8 @@ Hyrax uses Pydantic internally to validate the ``[data_request]`` configuration 
 which describes datasets for training, validation, and inference. This validation helps
 catch configuration errors early by ensuring required fields like ``primary_id_field``
 are present and properly structured.
+The exact field-level expectations for datasets are documented in
+:doc:`dataset_class_reference`.
 
 The validation happens automatically when you load a TOML configuration or use
 ``set_config()``. If there are validation errors, Hyrax will log a warning but continue

--- a/docs/configuration_system.rst
+++ b/docs/configuration_system.rst
@@ -4,7 +4,7 @@ The ``Hyrax`` Configuration System
 ``hyrax`` makes extensive use of the config variables to manage the runtime environment of training and inference runs. There is a ``hyrax_default_config.toml``  file (full contents listed :ref:`here<complete_default_config>`), included with ``hyrax``, that contains every variable that ``hyrax`` could need to operate. To create a custom configuration file, simply create a ``.toml`` file and change variables as you see fit, or if you’re running with a custom dataset or model, add your own variables.
 For a practical walkthrough that starts from a minimal override file, see :doc:`configuration`.
 
-Config variables are inherited from a hierarchy of sources, similar to ``python`` classes. First, ``hyrax`` will read the variables set in the default configuration. Next, it will load the relevant default config of any custom ``hyrax`` packages that the user is utilizing. It determines what packages to include by checking what custom classes are loaded in initially and looking for the relevant default configs. If a package doesn’t have a default, ``hyrax`` will throw a warning. Finally, it will use whatever variables have been declared in the user defined config toml (see `here <https://hyrax.readthedocs.io/en/latest/notebooks/config_basics.html>`_ for how to load those through a notebook or script). Config variables at each step can overwrite config variables from previous steps which leads to the following priority:
+Config variables are inherited from a hierarchy of sources, similar to ``python`` classes. First, ``hyrax`` will read the variables set in the default configuration. Next, it will load the relevant default config of any custom ``hyrax`` packages that the user is utilizing (see :doc:`/external_library_package` for how to set up package-level defaults). It determines what packages to include by checking what custom classes are loaded in initially and looking for the relevant default configs. If a package doesn’t have a default, ``hyrax`` will throw a warning. Finally, it will use whatever variables have been declared in the user defined config toml (see `here <https://hyrax.readthedocs.io/en/latest/notebooks/config_basics.html>`_ for how to load those through a notebook or script). Config variables at each step can overwrite config variables from previous steps which leads to the following priority:
 - Variables from a user defined config toml are used
 - Default configs from custom ``hyrax`` packages are used for those variables which the user has not defined
 - The base default config is used for those variables which the user has not defined and don't exist in any packages
@@ -21,9 +21,10 @@ Typed configuration schemas
 ---------------------------
 
 Hyrax uses Pydantic internally to validate the ``[data_request]`` configuration table,
-which describes datasets for training, validation, and inference. This validation helps
-catch configuration errors early by ensuring required fields like ``primary_id_field``
-are present and properly structured.
+which describes datasets for training, validation, and inference (see the
+:doc:`data requests notebook </notebooks/data_requests>` for a hands-on walkthrough).
+This validation helps catch configuration errors early by ensuring required fields
+like ``primary_id_field`` are present and properly structured.
 The exact field-level expectations for datasets are documented in
 :doc:`dataset_class_reference`.
 

--- a/docs/core_concepts.rst
+++ b/docs/core_concepts.rst
@@ -5,7 +5,7 @@ Hyrax handles a lot of the infrastructure needed for machine learning experiment
 but to get the most out of it, there are a few important aspects worth understanding.
 
 We'll cover the core concepts in the following pages, and we'll show exactly how
-to apply these concepts in tutorial notebooks in the Common workflows section.
+to apply these concepts in tutorial notebooks in the :doc:`Common workflows </common_workflows>` section.
 
 .. toctree::
    :maxdepth: 1

--- a/docs/data_flow.rst
+++ b/docs/data_flow.rst
@@ -5,6 +5,7 @@ Accessing Data on Disk
 ----------------------
 
 ``Hyrax`` makes use of ``Dataset`` and ``DataProvider`` classes to act as interfaces between ``hyrax``, ``pytorch``, and data on disk. A main goal of ``hyrax`` development is to create a large, stable collection of dataset classes based on different data types and sources (like LSST, HSC, Gaia, Roman, etc.) that will allow researchers to hit the ground running with their machine learning projects.
+If you're creating your own dataset implementation, see :doc:`dataset_class_reference`.
 
 ``Datasets`` are the direct interface between the ``hyrax`` ecosystem and the desired data. The ``Dataset`` is responsible for handling the data on a per-index level (managing specific data types, labels, and other metadata), while the ``DataProvider`` is responsible for batching the data and passing it along toward the training step. This separation of concerns allows for great flexibility in how data is handled and processed.
 
@@ -17,6 +18,8 @@ The ``prepare_inputs`` Function
 --------------------------------
 
 The ``prepare_inputs`` function is responsible for taking in the output of the ``collate`` function (a dictionary of lists) and converting the lists for each requested field into a numpy array. The function is customizable and acts as the last step in the data flow for the user to modify how data is transformed before being passed into the model.
+For model-side expectations and examples of custom ``prepare_inputs``, see
+:doc:`model_class_reference`.
 
 .. note::
    The older function name ``to_tensor`` is deprecated but still supported for backward compatibility. Please use ``prepare_inputs`` in new code.

--- a/docs/data_flow.rst
+++ b/docs/data_flow.rst
@@ -4,22 +4,19 @@ Data Flow Through Hyrax
 Accessing Data on Disk
 ----------------------
 
-``Hyrax`` makes use of ``Dataset`` and ``DataProvider`` classes to act as interfaces between ``hyrax``, ``pytorch``, and data on disk. A main goal of ``hyrax`` development is to create a large, stable collection of dataset classes based on different data types and sources (like LSST, HSC, Gaia, Roman, etc.) that will allow researchers to hit the ground running with their machine learning projects.
-If you're creating your own dataset implementation, see :doc:`dataset_class_reference`.
+``Hyrax`` makes use of ``Dataset`` and ``DataProvider`` classes to act as interfaces between ``hyrax``, ``pytorch``, and data on disk. The :doc:`dataset class reference </dataset_class_reference>` covers how to write your own ``Dataset``. A main goal of ``hyrax`` development is to create a large, stable collection of dataset classes based on different data types and sources (like LSST, HSC, Gaia, Roman, etc.) that will allow researchers to hit the ground running with their machine learning projects.
 
 ``Datasets`` are the direct interface between the ``hyrax`` ecosystem and the desired data. The ``Dataset`` is responsible for handling the data on a per-index level (managing specific data types, labels, and other metadata), while the ``DataProvider`` is responsible for batching the data and passing it along toward the training step. This separation of concerns allows for great flexibility in how data is handled and processed.
 
 The ``collate`` Function
 ------------------------
 
-The ``collate`` function is responsible for taking in a batch of data from the ``DataProvider`` and transforming it into a format that can be more readily ingested by the model. By default, the ``collate`` function takes in a list of dictionaries (one dictionary per item in the batch) and converts each field into a list, passing along a dictionary of lists to the ``prepare_inputs`` function. The function is customizable and has options to handle ragged data with padding.
+The ``collate`` function is responsible for taking in a batch of data from the ``DataProvider`` and transforming it into a format that can be more readily ingested by the model. By default, the ``collate`` function takes in a list of dictionaries (one dictionary per item in the batch) and converts each field into a list, passing along a dictionary of lists to the ``prepare_inputs`` function. The function is customizable and has options to handle ragged data with padding. For a hands-on example of writing a custom ``collate``, see the :doc:`custom collation notebook </notebooks/custom_dataset_collation>`.
 
 The ``prepare_inputs`` Function
 --------------------------------
 
-The ``prepare_inputs`` function is responsible for taking in the output of the ``collate`` function (a dictionary of lists) and converting the lists for each requested field into a numpy array. The function is customizable and acts as the last step in the data flow for the user to modify how data is transformed before being passed into the model.
-For model-side expectations and examples of custom ``prepare_inputs``, see
-:doc:`model_class_reference`.
+The ``prepare_inputs`` function is responsible for taking in the output of the ``collate`` function (a dictionary of lists) and converting the lists for each requested field into a numpy array. The function is customizable and acts as the last step in the data flow for the user to modify how data is transformed before being passed into the model. See the :doc:`custom prepare_inputs notebook </notebooks/custom_prepare_inputs>` for examples, or the :doc:`model class reference </model_class_reference>` for the method signature.
 
 .. note::
    The older function name ``to_tensor`` is deprecated but still supported for backward compatibility. Please use ``prepare_inputs`` in new code.
@@ -27,7 +24,7 @@ For model-side expectations and examples of custom ``prepare_inputs``, see
 Model Input and Output Pipeline
 -------------------------------
 
-The data is then either sent to ``pytorch`` ignite for training or to ``onnx`` for inference. In the case of training, the data is converted into a tensor and passed into the model's ``train_batch`` function. The model processes the data and returns the output predictions. If the user wishes to perform data augmentations, these can be set up in the model's ``train_batch`` function as well.
+The data is then either sent to ``pytorch`` ignite for training or to ``onnx`` for inference (both paths are triggered by the corresponding :doc:`verbs </verbs>`). In the case of training, the data is converted into a tensor and passed into the model's ``train_batch`` function. The model processes the data and returns the output predictions. If the user wishes to perform data augmentations, these can be set up in the model's ``train_batch`` function as well.
 
 In the ``onnx`` case, the data remains a numpy array throughout the model evaluation and to the result. Both paths result in the output being a numpy array.
 

--- a/docs/dataset_class_reference.rst
+++ b/docs/dataset_class_reference.rst
@@ -18,8 +18,9 @@ Hyrax creates your class like this:
 
 Then, for each object index, Hyrax calls methods named ``get_*``.
 
-The fields Hyrax asks for come from ``data_request``. Here is a full minimal
-example for training:
+The fields Hyrax asks for come from ``data_request`` (see the
+:doc:`data requests notebook </notebooks/data_requests>` for how to define one).
+Here is a full minimal example for training:
 
 .. code-block:: python
 
@@ -179,7 +180,9 @@ Optional methods
 ``collate(self, samples)``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Write this only when default batching is not enough.
+Write this only when default batching is not enough. See the
+:doc:`custom collation notebook </notebooks/custom_dataset_collation>` for a runnable
+walkthrough.
 
 A common astronomy case is variable-length light curves. The example below pads
 all light curves to the longest one in the batch and returns a mask where:

--- a/docs/dataset_class_reference.rst
+++ b/docs/dataset_class_reference.rst
@@ -40,6 +40,9 @@ If ``fields`` is ``["flux", "label", "object_id"]``, Hyrax will call:
 * ``get_label(idx)``
 * ``get_object_id(idx)``
 
+For a broader discussion of how dataset outputs move through ``collate`` and
+``prepare_inputs`` before reaching the model, see :doc:`data_flow`.
+
 
 Required methods (checklist)
 ----------------------------
@@ -217,6 +220,7 @@ Metadata table support (legacy path)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Today, metadata tables are mainly used by the ``visualize`` verb.
+For a verb-by-verb overview of where dataset methods are used, see :doc:`verbs`.
 
 This path is expected to be reduced/deprecated over time. For new dataset code,
 prefer explicit ``get_*`` methods for data you want to use in ML or visualization.

--- a/docs/dataset_splits.rst
+++ b/docs/dataset_splits.rst
@@ -13,10 +13,13 @@ Splits in training
 By default input datasets are split into train (60%), test (20%), and validate (20%). The ``train`` verb uses 
 the train split to train and validate splits to create a validation loss statistic every training epoch. The 
 test split is explicitly left out of training.
+For a broader overview of what each verb does, see :doc:`verbs`.
 
 The size of these splits can be configured in the ``[data_set]`` section of the configuration using the 
 ``train_size``, ``validate_size``, and ``test_size`` configuration keys. The value is either a number of data points
 or a ratio of the dataset, where 1.0 represents the entire dataset. For example:
+If you are new to editing runtime config values, the primer in :doc:`configuration`
+is a useful companion.
 
 .. tab-set::
 

--- a/docs/dataset_splits.rst
+++ b/docs/dataset_splits.rst
@@ -10,10 +10,9 @@ investigator.
 
 Splits in training
 ------------------
-By default input datasets are split into train (60%), test (20%), and validate (20%). The ``train`` verb uses 
-the train split to train and validate splits to create a validation loss statistic every training epoch. The 
-test split is explicitly left out of training.
-For a broader overview of what each verb does, see :doc:`verbs`.
+By default input datasets are split into train (60%), test (20%), and validate (20%). The ``train``
+:doc:`verb </verbs>` uses the train split to train and validate splits to create a validation loss
+statistic every training epoch. The test split is explicitly left out of training.
 
 The size of these splits can be configured in the ``[data_set]`` section of the configuration using the 
 ``train_size``, ``validate_size``, and ``test_size`` configuration keys. The value is either a number of data points
@@ -57,7 +56,7 @@ It is recommended that all three are provided; however, zeroing some out can cre
 Splits in inference
 -------------------
 
-By default the ``infer`` verb uses the entire dataset for inference; however any of the splits can be used by 
+By default the ``infer`` :doc:`verb </verbs>` uses the entire dataset for inference; however any of the splits can be used by
 specifying the ``[infer]`` ``split`` config value. Valid values are any of the three splits. For example, to 
 infer on only the test split:
 

--- a/docs/external_libraries.rst
+++ b/docs/external_libraries.rst
@@ -10,6 +10,8 @@ The basic flow for using Hyrax in your machine learning project is to:
 The pages below walk you through making custom dataset and model classes for your data in your project
 as well as how to distribute working datasets and models via a python package which can be used by 
 your collaborators.
+If you are deciding what to implement first, see :doc:`required_input` for the
+minimum pieces Hyrax needs from users.
 
 .. toctree::
    :maxdepth: 1

--- a/docs/external_library_package.rst
+++ b/docs/external_library_package.rst
@@ -3,6 +3,8 @@ External package setup
 
 This page shows the minimum steps to turn notebook classes into a local Python
 package that Hyrax can import.
+For the class-level requirements before packaging, see
+:doc:`dataset_class_reference` and :doc:`model_class_reference`.
 
 If you want a working example package, see
 `external_hyrax_example <https://github.com/lincc-frameworks/external_hyrax_example>`_.
@@ -99,6 +101,9 @@ Required config keys:
 * ``model.name``
 * ``data_request.<group>.<friendly_name>.dataset_class``
 * ``primary_id_field`` for each dataset definition
+
+These keys participate in the broader config merge process described in
+:doc:`configuration_system`.
 
 Copy-paste example:
 

--- a/docs/external_library_package.rst
+++ b/docs/external_library_package.rst
@@ -13,7 +13,7 @@ If you want a working example package, see
 Goal
 ----
 
-Start from classes that already work in a notebook, then:
+Start from classes that already work in a notebook (the :doc:`dataset class reference </dataset_class_reference>` and :doc:`model class reference </model_class_reference>` cover the required interfaces), then:
 
 1. put them into a package directory,
 2. install that package locally,
@@ -136,7 +136,8 @@ Step 6: keep package-specific config values in ``default_config.toml``
 -------------------------------------------------------------------------
 
 A beginner-friendly pattern is to ship defaults in your package and let users
-change only what they need.
+change only what they need. Hyrax merges these with its own defaults using the
+layered :doc:`configuration system </configuration_system>`.
 
 Create ``src/my_hyrax_library/default_config.toml``:
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -55,6 +55,8 @@ instance of this class.
 
 When we create the Hyrax instance, it will automatically load a default configuration
 file. This file contains default settings for all of the components that Hyrax uses.
+For a deeper explanation of how defaults and overrides are merged, see
+:doc:`configuration_system`.
 
 .. _getting_started_specify_model:
 
@@ -103,6 +105,8 @@ https://www.cs.toronto.edu/~kriz/cifar.html
 This may appear overwhelming, especially for a simple case, but being explicit
 about the dataset configuration will allow for great flexibility down the line
 when working with more complex data.
+For the full contract of dataset classes and required ``get_*`` methods, see
+:doc:`dataset_class_reference`.
 
 Training the model
 ~~~~~~~~~~~~~~~~~~
@@ -149,6 +153,7 @@ inference.
 
 Then we'll use Hyrax's ``infer`` verb to load the trained model weights and process
 the data defined above.
+For additional details on ``infer`` behavior, see :doc:`verbs`.
 
 .. code-block:: python
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -53,10 +53,10 @@ instance of this class.
 
    h = Hyrax()
 
-When we create the Hyrax instance, it will automatically load a default configuration
-file. This file contains default settings for all of the components that Hyrax uses.
-For a deeper explanation of how defaults and overrides are merged, see
-:doc:`configuration_system`.
+When we create the Hyrax instance, it will automatically load a
+:ref:`default configuration file <complete_default_config>`. This file contains
+default settings for all of the components that Hyrax uses.
+See :doc:`/configuration_system` for details on how configuration is resolved.
 
 .. _getting_started_specify_model:
 
@@ -112,7 +112,7 @@ Training the model
 ~~~~~~~~~~~~~~~~~~
 
 Now that we have the model and data specified, we're ready for training.
-We'll use the ``train`` verb to kick off the training process.
+We'll use the ``train`` :doc:`verb </verbs>` to kick off the training process.
 
 .. code-block:: python
 
@@ -151,9 +151,8 @@ inference.
 
    h.set_config("data_request", data_request_definition)
 
-Then we'll use Hyrax's ``infer`` verb to load the trained model weights and process
-the data defined above.
-For additional details on ``infer`` behavior, see :doc:`verbs`.
+Then we'll use Hyrax's ``infer`` :doc:`verb </verbs>` to load the trained model weights
+and process the data defined above.
 
 .. code-block:: python
 

--- a/docs/hyrax_default_config.rst
+++ b/docs/hyrax_default_config.rst
@@ -4,7 +4,9 @@ Hyrax default configuration
 ---------------------------
 
 The following is the complete default configuration file for Hyrax.
-This file is used when no custom configuration file is provided.
+This file is used when no custom configuration file is provided. See
+:doc:`/configuration` for how to override individual values and
+:doc:`/configuration_system` for how Hyrax layers multiple config sources.
 
 .. literalinclude:: ../src/hyrax/hyrax_default_config.toml
    :language: bash

--- a/docs/model_class_reference.rst
+++ b/docs/model_class_reference.rst
@@ -39,6 +39,9 @@ Your class must have these:
 
 4. Set ``model.name`` to full class path in config.
 
+If you are packaging your model outside the core repository, see
+:doc:`external_library_package` for import-path and packaging patterns.
+
 
 Method-by-method guide
 ----------------------
@@ -130,6 +133,8 @@ Example:
 
 If you do not define this method, Hyrax uses a default expecting
 ``data_dict["data"]["image"]`` and optional ``data_dict["data"]["label"]``.
+For a conceptual description of where this step lives in the runtime pipeline, see
+:doc:`data_flow`.
 
 
 ``infer_batch(self, batch)``
@@ -180,6 +185,7 @@ Important details:
 * Hyrax treats **lower ``loss`` as better** for best-checkpoint selection.
 * Any extra metrics you return (like ``acc``) are logged to TensorBoard and MLflow.
   See :doc:`/notebooks/using_tensorboard_and_mlflow`.
+  For documentation on comparing runs across experiments, see :doc:`model_comparison`.
 
 
 Optional methods

--- a/docs/model_class_reference.rst
+++ b/docs/model_class_reference.rst
@@ -29,7 +29,8 @@ Required methods (checklist)
 Your class must have these:
 
 1. Inherit from ``torch.nn.Module``.
-2. Add ``@hyrax_model`` above the class.
+2. Add ``@hyrax_model`` above the class (this registers your model so Hyrax can
+   find it by name in the :doc:`configuration </configuration>`).
 3. Implement:
 
    * ``__init__(self, config, data_sample=None)``
@@ -112,7 +113,8 @@ Example:
 ``@staticmethod prepare_inputs(data_dict)``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-This converts collated dataset fields into model inputs.
+This converts collated dataset fields into model inputs. For background on where
+this sits in the pipeline, see :doc:`/data_flow`.
 
 Important:
 

--- a/docs/model_comparison.rst
+++ b/docs/model_comparison.rst
@@ -5,13 +5,14 @@ Model comparison
 
 One goal of Hyrax is to make model evaluation easier. Many tools exist for visualization
 and evaluation of models. Hyrax integrates with TensorBoard and MLFlow to provide
-easy access to these tools.
+easy access to these tools. For a hands-on walkthrough, see the
+:doc:`TensorBoard and MLflow notebook </notebooks/using_tensorboard_and_mlflow>`.
 
 TensorBoard
 -----------
 
 Hyrax automatically logs training, validation and gpu metrics (when available) to
-TensorBoard while training a model.
+TensorBoard while training a model (see also :doc:`custom training metrics </notebooks/custom_training_metrics>`).
 This allows for easy visualization of the training process.
 
 For more information about TensorBoard see the

--- a/docs/required_input.rst
+++ b/docs/required_input.rst
@@ -19,6 +19,8 @@ Define the model
 At its core, Hyrax is a framework for training and running machine learning models.
 To do this, a user must provide the model that Hyrax will use for training or inference.
 There is no reasonable default, so the user must provide Hyrax with a model.
+The :doc:`model class reference </model_class_reference>` details the full interface
+your model must implement.
 
 Check out the :ref:`Getting Started tutorial <getting_started_specify_model>` for
 an example of specifying a built-in model for training.
@@ -28,7 +30,8 @@ Define the data
 -----------------
 Hyrax needs to know what data to provide to the model during training or inference.
 To do this, a user must specify a dataset class that Hyrax can use to load data
-samples.
+samples. The :doc:`dataset class reference </dataset_class_reference>` describes the
+methods your dataset must provide.
 
 Check out the :ref:`Getting Started tutorial <getting_started_specify_data>` for
 an example of specifying a built-in dataset for training.
@@ -54,9 +57,11 @@ returning it.
 
 The user may then want to quickly experiment with the model by first providing
 only the "science" array as input, and later adding in the "variance" array as well.
-By defining a custom `prepare_inputs` function, the user can easily modify how the
+By defining a custom ``prepare_inputs`` function, the user can easily modify how the
 data is prepared for the model without needing to modify either the dataset or
-the model code.
+the model code. See :doc:`/data_flow` for the complete pipeline and the
+:doc:`custom prepare_inputs notebook </notebooks/custom_prepare_inputs>` for runnable
+examples.
 
 .. note::
    The older function name ``to_tensor`` is deprecated but still supported for backward compatibility. Please use ``prepare_inputs`` in new code.

--- a/docs/verbs.rst
+++ b/docs/verbs.rst
@@ -8,9 +8,8 @@ Each of the builtin verbs are detailed here.
 ``train``
 ---------
 Train a model. The specific model to train and the data used for training is
-specified in the configuration file or by updating the default configurations
-after creating an instance of the Hyrax object.
-For details on configuration inheritance and overrides, see :doc:`configuration_system`.
+specified in the :doc:`configuration file </configuration>` or by updating the
+default configurations after creating an instance of the Hyrax object.
 
 When called from a notebook or python, ``train()`` returns a trained pytorch
 model which you can :doc:`immediately evaluate, inspect, or export </pre_executed/export_model>`. Batch evaluations of datasets
@@ -40,11 +39,11 @@ are enabled using the ``infer`` verb, see below.
 ``infer``
 ---------
 Run inference using a trained model. The specific model to use for inference can
-be specified in the configuration file. If no model is specified, Hyrax will find
-the most recently trained model in the results directory and use that for inference.
-The data used for inference is also specified in the configuration file.
-If you need to run inference on a specific train/validate/test subset, see
-:doc:`dataset_splits`.
+be specified in the :doc:`configuration file </configuration>`. If no model is
+specified, Hyrax will find the most recently trained model in the results directory
+and use that for inference. The data used for inference is also specified in the
+configuration file. You can also choose which :ref:`dataset split <dataset_splits>`
+to run inference on.
 
 .. tab-set::
 
@@ -102,7 +101,8 @@ For a full notebook walkthrough of this flow, see :doc:`pre_executed/using_umap`
 
 ``visualize``
 -------------
-Interactively visualize the embedded space produced by the ``umap`` verb.
+Interactively visualize the embedded space produced by the ``umap`` verb. For more
+on dimensionality reduction options, see the :doc:`UMAP notebook </pre_executed/using_umap>`.
 Due to the fact that the visualization is interactive, it is not available in the CLI.
 
 .. code-block:: python
@@ -135,12 +135,12 @@ intended for use in a notebook environment for exploration and debugging.
 
 ``index``
 ---------
-Builds a vector database index from the output of inference. By default, Hyrax
-will use the most recently generated output from the ``infer`` verb, and will
-write the resulting database to a new timestamped directory under the default
-``./results/`` directory with the form <timestamp>-index-<uid>.
-See :doc:`pre_executed/vector_db_demo` for an end-to-end example that continues
-from inference into similarity search.
+Builds a vector database index from the output of inference. See the
+:doc:`vector database notebook </pre_executed/vector_db_demo>` for an end-to-end
+walkthrough. By default, Hyrax will use the most recently generated output from
+the ``infer`` verb, and will write the resulting database to a new timestamped
+directory under the default ``./results/`` directory with the form
+<timestamp>-index-<uid>.
 
 An existing database directory can be specified in order to add more vectors to
 an existing index.

--- a/docs/verbs.rst
+++ b/docs/verbs.rst
@@ -10,6 +10,7 @@ Each of the builtin verbs are detailed here.
 Train a model. The specific model to train and the data used for training is
 specified in the configuration file or by updating the default configurations
 after creating an instance of the Hyrax object.
+For details on configuration inheritance and overrides, see :doc:`configuration_system`.
 
 When called from a notebook or python, ``train()`` returns a trained pytorch
 model which you can :doc:`immediately evaluate, inspect, or export </pre_executed/export_model>`. Batch evaluations of datasets
@@ -42,6 +43,8 @@ Run inference using a trained model. The specific model to use for inference can
 be specified in the configuration file. If no model is specified, Hyrax will find
 the most recently trained model in the results directory and use that for inference.
 The data used for inference is also specified in the configuration file.
+If you need to run inference on a specific train/validate/test subset, see
+:doc:`dataset_splits`.
 
 .. tab-set::
 
@@ -72,6 +75,7 @@ the ``[]`` operators in python.
 Run UMAP (`Uniform Manifold Approximation and Projection`_) on the
 output of inference or a dataset. By default, Hyrax will use the most
 recently generated output from the ``infer`` verb.
+For a full notebook walkthrough of this flow, see :doc:`pre_executed/using_umap`.
 
 .. _`Uniform Manifold Approximation and Projection`: https://umap-learn.readthedocs.io
 
@@ -135,6 +139,8 @@ Builds a vector database index from the output of inference. By default, Hyrax
 will use the most recently generated output from the ``infer`` verb, and will
 write the resulting database to a new timestamped directory under the default
 ``./results/`` directory with the form <timestamp>-index-<uid>.
+See :doc:`pre_executed/vector_db_demo` for an end-to-end example that continues
+from inference into similarity search.
 
 An existing database directory can be specified in order to add more vectors to
 an existing index.


### PR DESCRIPTION
### Motivation
- Improve discoverability by adding natural, in-prose links that let readers jump from high-level conceptual pages to the detailed reference or notebook that explains implementation.
- Help newcomers progress from onboarding/tutorials to the exact reference they need (e.g., dataset/model contracts, configuration merge rules) without breaking narrative flow.
- Make it easier to follow end-to-end workflows by pointing feature-specific docs (UMAP, vector DBs, splits) to notebook walkthroughs and companion pages.

### Description
- Added inline `:doc:` cross-references between conceptual and reference pages in the docs to improve navigability, including `architecture_overview.rst`, `configuration.rst`, `configuration_system.rst`, `data_flow.rst`, `dataset_class_reference.rst`, `dataset_splits.rst`, `external_libraries.rst`, `external_library_package.rst`, `getting_started.rst`, `model_class_reference.rst`, and `verbs.rst`.
- Linked configuration guidance to the configuration system and validation docs, and linked runtime/config snapshots to `model_comparison` for experiment-tracking context.
- Connected pipeline-level pages so readers can move from `data_flow` to `dataset_class_reference` and `model_class_reference`, and added pointers from verbs to relevant notebooks (UMAP, vector DB demo) and split/usage docs.
- All changes are documentation-only and kept inline so the flow of each page is preserved.

### Testing
- Ran `make -C docs html` to validate the documentation build, which failed in this environment due to `docs/conf.py` expecting installed `hyrax` package metadata (importlib.metadata.PackageNotFoundError), an environment-specific issue unrelated to the textual cross-reference edits.
- No code or behavior changes were made, so no unit tests were applicable; the doc edits were committed after verification of the textual diffs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6f3a2e9848331bf5af1d801151611)