### PR TITLE
Add MultimodalUniverseDataset (MMU) support via Hugging Face `datasets`

### DIFF
--- a/example_notebooks/mmu_images_with_hyrax.ipynb
+++ b/example_notebooks/mmu_images_with_hyrax.ipynb
@@ -1,0 +1,66 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# MMU Images with Hyrax\n",
+        "\n",
+        "This notebook shows how to configure Hyrax to read **image** data from Multimodal Universe using `MultimodalUniverseDataset`.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import hyrax\n",
+        "\n",
+        "h = hyrax.Hyrax()\n",
+        "\n",
+        "h.config[\"data_request\"] = {\n",
+        "    \"infer\": {\n",
+        "        \"mmu\": {\n",
+        "            \"dataset_class\": \"MultimodalUniverseDataset\",\n",
+        "            \"data_location\": \"hf://MultimodalUniverse/legacysurvey\",\n",
+        "            \"primary_id_field\": \"object_id\",\n",
+        "            \"fields\": ['image', 'bands', 'object_id'],\n",
+        "            \"dataset_config\": {\n",
+        "                \"MultimodalUniverseDataset\": {\n",
+        "                    \"split\": \"train\",\n",
+        "                    \"max_samples\": 64,\n",
+        "                    \"streaming\": False,\n",
+        "                }\n",
+        "            },\n",
+        "        }\n",
+        "    }\n",
+        "}\n",
+        "\n",
+        "prepared = h.prepare()\n",
+        "print(f\"Loaded rows: {len(prepared['infer'])}\")\n",
+        "print(prepared['infer'][0])\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "After loading, inspect `prepared['infer'][0].keys()` and set `fields` to the exact MMU columns you want.\n"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.11"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}

--- a/example_notebooks/mmu_spectra_with_hyrax.ipynb
+++ b/example_notebooks/mmu_spectra_with_hyrax.ipynb
@@ -1,0 +1,66 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# MMU Spectra with Hyrax\n",
+        "\n",
+        "This notebook shows how to configure Hyrax to read **spectral** data from Multimodal Universe using `MultimodalUniverseDataset`.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import hyrax\n",
+        "\n",
+        "h = hyrax.Hyrax()\n",
+        "\n",
+        "h.config[\"data_request\"] = {\n",
+        "    \"infer\": {\n",
+        "        \"mmu\": {\n",
+        "            \"dataset_class\": \"MultimodalUniverseDataset\",\n",
+        "            \"data_location\": \"hf://MultimodalUniverse/desi\",\n",
+        "            \"primary_id_field\": \"object_id\",\n",
+        "            \"fields\": ['spectrum', 'wavelength', 'object_id'],\n",
+        "            \"dataset_config\": {\n",
+        "                \"MultimodalUniverseDataset\": {\n",
+        "                    \"split\": \"train\",\n",
+        "                    \"max_samples\": 64,\n",
+        "                    \"streaming\": False,\n",
+        "                }\n",
+        "            },\n",
+        "        }\n",
+        "    }\n",
+        "}\n",
+        "\n",
+        "prepared = h.prepare()\n",
+        "print(f\"Loaded rows: {len(prepared['infer'])}\")\n",
+        "print(prepared['infer'][0])\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "After loading, inspect `prepared['infer'][0].keys()` and set `fields` to the exact MMU columns you want.\n"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.11"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}

--- a/example_notebooks/mmu_time_series_with_hyrax.ipynb
+++ b/example_notebooks/mmu_time_series_with_hyrax.ipynb
@@ -1,0 +1,66 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# MMU Time Series with Hyrax\n",
+        "\n",
+        "This notebook shows how to configure Hyrax to read **time-series** data from Multimodal Universe using `MultimodalUniverseDataset`.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import hyrax\n",
+        "\n",
+        "h = hyrax.Hyrax()\n",
+        "\n",
+        "h.config[\"data_request\"] = {\n",
+        "    \"infer\": {\n",
+        "        \"mmu\": {\n",
+        "            \"dataset_class\": \"MultimodalUniverseDataset\",\n",
+        "            \"data_location\": \"hf://MultimodalUniverse/plasticc\",\n",
+        "            \"primary_id_field\": \"object_id\",\n",
+        "            \"fields\": ['lightcurve', 'bands', 'object_id'],\n",
+        "            \"dataset_config\": {\n",
+        "                \"MultimodalUniverseDataset\": {\n",
+        "                    \"split\": \"train\",\n",
+        "                    \"max_samples\": 64,\n",
+        "                    \"streaming\": False,\n",
+        "                }\n",
+        "            },\n",
+        "        }\n",
+        "    }\n",
+        "}\n",
+        "\n",
+        "prepared = h.prepare()\n",
+        "print(f\"Loaded rows: {len(prepared['infer'])}\")\n",
+        "print(prepared['infer'][0])\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "After loading, inspect `prepared['infer'][0].keys()` and set `fields` to the exact MMU columns you want.\n"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.11"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ dependencies = [
     "plotly", # Used in 3d visualization
     "psutil", # Used for memory monitoring
     "tqdm", # Used to show progress bars
+    "datasets", # Used by MultimodalUniverseDataset
     "qdrant-client", # Vector database for similarity search
     "colorama", # Used to color terminal output
     # Pin to before 0.30.0 because version 0.30.0 does not support NaN values anymore

--- a/src/hyrax/config_schemas/data_request.py
+++ b/src/hyrax/config_schemas/data_request.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from collections import defaultdict
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlparse
 
 import numpy as np
 from pydantic import Field, RootModel, field_validator, model_validator
@@ -46,6 +47,9 @@ class DataRequestConfig(BaseConfigModel):
     def resolve_data_location(cls, v: str) -> str:
         """Fully resolve the data_location path, expanding user home directories
         and converting relative paths to absolute paths."""
+        parsed = urlparse(v)
+        if parsed.scheme and v.startswith(f"{parsed.scheme}://"):
+            return v
         return str(Path(v).expanduser().resolve())
 
     @model_validator(mode="after")

--- a/src/hyrax/datasets/__init__.py
+++ b/src/hyrax/datasets/__init__.py
@@ -70,6 +70,7 @@ from .result_dataset import ResultDataset, ResultDatasetWriter
 from .result_factories import create_results_writer, load_results_dataset
 from .dataset_registry import HyraxDataset
 from .hyrax_csv_dataset import HyraxCSVDataset
+from .mmu_dataset import MultimodalUniverseDataset
 from .data_cache import DataCache
 
 __all__ = [
@@ -87,5 +88,6 @@ __all__ = [
     "HyraxRandomDataset",
     "HyraxRandomDatasetBase",
     "HyraxCSVDataset",
+    "MultimodalUniverseDataset",
     "DataCache",
 ]

--- a/src/hyrax/datasets/mmu_dataset.py
+++ b/src/hyrax/datasets/mmu_dataset.py
@@ -1,0 +1,142 @@
+import itertools
+import re
+from pathlib import Path
+from types import MethodType
+from typing import Any
+
+from hyrax.datasets.dataset_registry import HyraxDataset
+
+
+class _IndexedSubset:
+    """Fallback wrapper to enforce a max row count for indexable datasets."""
+
+    def __init__(self, dataset: Any, max_samples: int):
+        self._dataset = dataset
+        self._max_samples = max_samples
+
+    def __getitem__(self, idx: int) -> Any:
+        if idx >= self._max_samples:
+            raise IndexError(idx)
+        return self._dataset[idx]
+
+    def __len__(self) -> int:
+        return self._max_samples
+
+
+class MultimodalUniverseDataset(HyraxDataset):
+    """Load a MultimodalUniverse dataset through Hugging Face ``datasets``.
+
+    This dataset class is intentionally generic so one configuration pattern can
+    be used for image, spectra, and time-series MMU datasets.
+
+    Examples
+    --------
+    Example ``data_request`` configuration::
+
+        {
+            "infer": {
+                "mmu": {
+                    "dataset_class": "MultimodalUniverseDataset",
+                    "data_location": "hf://MultimodalUniverse/plasticc",
+                    "primary_id_field": "object_id",
+                    "dataset_config": {
+                        "MultimodalUniverseDataset": {
+                            "split": "train",
+                            "max_samples": 32,
+                        }
+                    },
+                }
+            }
+        }
+    """
+
+    def __init__(self, config: dict, data_location: Path | str | None = None):
+        if data_location is None:
+            raise ValueError(
+                "A `data_location` must be provided. Use either a local dataset path or "
+                "a Hugging Face URI like 'hf://MultimodalUniverse/plasticc'."
+            )
+
+        self.data_location = str(data_location)
+        self.dataset_settings = (
+            config.get("data_set", {}).get("MultimodalUniverseDataset", {}) if config is not None else {}
+        )
+
+        self.split = self.dataset_settings.get("split", "train")
+        self.max_samples = self.dataset_settings.get("max_samples", None)
+        self.streaming = self.dataset_settings.get("streaming", False)
+
+        dataset_source = self._normalize_data_location(self.data_location)
+        self.dataset = self._load_dataset(dataset_source)
+        self._column_name_map = self._build_column_name_map()
+        self._register_getters()
+        super().__init__(config)
+
+    def _normalize_data_location(self, data_location: str) -> str:
+        if data_location.startswith("hf://"):
+            return data_location[5:]
+        return data_location
+
+    def _load_dataset(self, dataset_source: str):
+        try:
+            from datasets import load_dataset
+        except ImportError as err:
+            raise ImportError(
+                "MultimodalUniverseDataset requires the `datasets` package. "
+                "Install it with `pip install datasets`."
+            ) from err
+
+        dataset = load_dataset(dataset_source, split=self.split, streaming=self.streaming)
+
+        if self.streaming:
+            if self.max_samples is None:
+                raise ValueError(
+                    "When streaming=True, set data_set.MultimodalUniverseDataset.max_samples "
+                    "to avoid iterating through the full dataset."
+                )
+            dataset = list(itertools.islice(dataset, int(self.max_samples)))
+        elif self.max_samples is not None:
+            dataset = self._limit_non_streaming_dataset(dataset, int(self.max_samples))
+
+        return dataset
+
+    def _limit_non_streaming_dataset(self, dataset: Any, max_samples: int):
+        limit = min(max_samples, len(dataset))
+        if hasattr(dataset, "select"):
+            return dataset.select(range(limit))
+        if isinstance(dataset, list):
+            return dataset[:limit]
+        return _IndexedSubset(dataset, limit)
+
+    def _build_column_name_map(self) -> dict[str, str]:
+        sample = self.dataset[0]
+        return {self._sanitize_name(key): key for key in sample}
+
+    def _sanitize_name(self, column_name: str) -> str:
+        sanitized = re.sub(r"\W", "_", column_name)
+        if not sanitized:
+            return "field"
+        if sanitized[0].isdigit():
+            return f"field_{sanitized}"
+        return sanitized
+
+    def _register_getters(self) -> None:
+        def _make_getter(source_name):
+            def getter(self, idx, _source_name=source_name):
+                return self.dataset[idx][_source_name]
+
+            return getter
+
+        for method_suffix, source_name in self._column_name_map.items():
+            method_name = f"get_{method_suffix}"
+            if not hasattr(self, method_name):
+                setattr(self, method_name, MethodType(_make_getter(source_name), self))
+
+    def __len__(self) -> int:
+        return len(self.dataset)
+
+    def __getitem__(self, idx: int) -> dict[str, Any]:
+        return self.dataset[idx]
+
+    def sample_data(self) -> dict[str, dict[str, Any]]:
+        return {"data": self.dataset[0]}

--- a/src/hyrax/hyrax_default_config.toml
+++ b/src/hyrax/hyrax_default_config.toml
@@ -361,6 +361,17 @@ number_invalid_values = 0
 # "nan", "inf", "-inf", "none" or a float value.
 invalid_value_type = "nan"
 
+[data_set.MultimodalUniverseDataset]
+# Hugging Face split name to load (for example: "train", "validation", or "test").
+split = "train"
+
+# Maximum number of rows to load from the split. Set to false for no explicit limit.
+max_samples = false
+
+# Stream rows from Hugging Face instead of downloading full files.
+# If true, `max_samples` must be set.
+streaming = false
+
 
 [data_loader]
 # The number of data points to load at once.

--- a/tests/hyrax/test_data_request_config.py
+++ b/tests/hyrax/test_data_request_config.py
@@ -28,6 +28,24 @@ def test_data_request_config_basic_fields():
     assert dumped["dataset_config"] == {"shuffle": True}
 
 
+def test_data_request_config_preserves_hf_uri_data_location():
+    cfg = DataRequestConfig(
+        dataset_class="MultimodalUniverseDataset",
+        data_location="hf://MultimodalUniverse/plasticc",
+        primary_id_field="object_id",
+    )
+    assert cfg.data_location == "hf://MultimodalUniverse/plasticc"
+
+
+def test_data_request_config_preserves_http_uri_data_location():
+    cfg = DataRequestConfig(
+        dataset_class="SomeDatasetClass",
+        data_location="https://example.com/public/data.parquet",
+        primary_id_field="object_id",
+    )
+    assert cfg.data_location == "https://example.com/public/data.parquet"
+
+
 def test_data_request_definition_flat_dict_without_friendly_name_raises():
     """Flat dict with dataset_class at top level (no friendly name) raises ValidationError."""
     with pytest.raises(ValidationError, match="friendly name"):

--- a/tests/hyrax/test_mmu_dataset.py
+++ b/tests/hyrax/test_mmu_dataset.py
@@ -1,0 +1,86 @@
+import sys
+from types import SimpleNamespace
+
+from hyrax.datasets.mmu_dataset import MultimodalUniverseDataset
+
+
+class _FakeMapDataset:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def __getitem__(self, idx):
+        return self._rows[idx]
+
+    def __len__(self):
+        return len(self._rows)
+
+
+def _install_fake_datasets_module(monkeypatch, fake_load_dataset):
+    fake_module = SimpleNamespace(load_dataset=fake_load_dataset)
+    monkeypatch.setitem(sys.modules, "datasets", fake_module)
+
+
+def test_mmu_dataset_uses_hf_uri_and_max_samples(monkeypatch):
+    calls = []
+    rows = [
+        {"object_id": "a1", "image": [1, 2], "label-name": "galaxy"},
+        {"object_id": "a2", "image": [3, 4], "label-name": "star"},
+    ]
+
+    def fake_load_dataset(path, split, streaming):
+        calls.append({"path": path, "split": split, "streaming": streaming})
+        return _FakeMapDataset(rows)
+
+    _install_fake_datasets_module(monkeypatch, fake_load_dataset)
+
+    dataset = MultimodalUniverseDataset(
+        config={"data_set": {"MultimodalUniverseDataset": {"split": "train", "max_samples": 2}}},
+        data_location="hf://MultimodalUniverse/galaxy10_decals",
+    )
+
+    assert len(dataset) == 2
+    assert calls[0]["path"] == "MultimodalUniverse/galaxy10_decals"
+    assert calls[0]["split"] == "train"
+    assert calls[0]["streaming"] is False
+    assert dataset.get_label_name(0) == "galaxy"
+
+
+def test_mmu_dataset_enforces_hard_limit_when_split_is_pre_sliced(monkeypatch):
+    calls = []
+    rows = [
+        {"object_id": "a1", "value": 1},
+        {"object_id": "a2", "value": 2},
+    ]
+
+    def fake_load_dataset(path, split, streaming):
+        calls.append({"path": path, "split": split, "streaming": streaming})
+        return _FakeMapDataset(rows)
+
+    _install_fake_datasets_module(monkeypatch, fake_load_dataset)
+
+    dataset = MultimodalUniverseDataset(
+        config={"data_set": {"MultimodalUniverseDataset": {"split": "train[:100]", "max_samples": 1}}},
+        data_location="hf://MultimodalUniverse/plasticc",
+    )
+
+    assert calls[0]["split"] == "train[:100]"
+    assert len(dataset) == 1
+    assert dataset.get_value(0) == 1
+
+
+def test_mmu_dataset_streaming_requires_max_samples(monkeypatch):
+    def fake_load_dataset(path, split, streaming):
+        return iter([{"object_id": "1", "flux": [0.1, 0.2]}])
+
+    _install_fake_datasets_module(monkeypatch, fake_load_dataset)
+
+    try:
+        MultimodalUniverseDataset(
+            config={"data_set": {"MultimodalUniverseDataset": {"split": "train", "streaming": True}}},
+            data_location="hf://MultimodalUniverse/plasticc",
+        )
+        raised = False
+    except ValueError:
+        raised = True
+
+    assert raised


### PR DESCRIPTION
### Motivation

- Enable Hyrax to load Multimodal Universe (MMU) datasets served on Hugging Face and other remote URIs without converting URIs into local filesystem paths. 
- Provide a reusable, generic dataset class that can handle images, spectra, and time-series MMU variants with streaming and sample limiting.
- Ship examples and sane defaults to make it easy to configure MMU sources in `data_request`.

### Description

- Added a new `MultimodalUniverseDataset` in `src/hyrax/datasets/mmu_dataset.py` that loads datasets via `datasets.load_dataset`, supports `hf://` URIs, optional streaming, `max_samples` limiting, and creates dynamic `get_<field>` accessors after sanitizing column names. 
- Preserved URI behavior in `DataRequestConfig.resolve_data_location` by returning values with a scheme (using `urlparse`) instead of resolving them to filesystem paths. 
- Exported `MultimodalUniverseDataset` from `src/hyrax/datasets/__init__.py` and added default config keys in `src/hyrax/hyrax_default_config.toml` under `[data_set.MultimodalUniverseDataset]`. 
- Added the `datasets` package to `pyproject.toml` dependencies and included three example notebooks (`example_notebooks/mmu_images_with_hyrax.ipynb`, `mmu_spectra_with_hyrax.ipynb`, `mmu_time_series_with_hyrax.ipynb`) demonstrating configuration patterns. 
- Added unit tests in `tests/hyrax/test_data_request_config.py` (URI preservation checks) and `tests/hyrax/test_mmu_dataset.py` (behavioral tests for path normalization, max_samples, pre-sliced splits, and streaming requirement). 

### Testing

- Ran `pytest tests/hyrax/test_data_request_config.py` which validated that HF and HTTP URIs are preserved and the basic `DataRequestConfig` behavior remained intact; tests passed. 
- Ran `pytest tests/hyrax/test_mmu_dataset.py` which exercises `MultimodalUniverseDataset` with a fake `datasets` loader to verify HF path normalization, `max_samples` limiting, pre-sliced split handling, and streaming guard behavior; tests passed. 
- No other automated test failures were observed in the modified areas.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6f539cd90833198c5bff58e96819d)