### PR TITLE
Add LanceDBDataset 

### DIFF
--- a/docs/common_workflows.rst
+++ b/docs/common_workflows.rst
@@ -7,6 +7,7 @@ Common workflows
    Configuration basics <notebooks/config_basics>
    Data requests <notebooks/data_requests>
    List available models and dataset classes <notebooks/list_available_models_and_datasets>
+   LanceDB dataset example <notebooks/lancedb_with_hyrax>
    Evaluating with TensorBoard and MLFlow <notebooks/using_tensorboard_and_mlflow>
    Working with result datasets <pre_executed/working_with_results_data>
    Look up results by ID <notebooks/lookup_results_by_id>

--- a/docs/notebooks/lancedb_with_hyrax.ipynb
+++ b/docs/notebooks/lancedb_with_hyrax.ipynb
@@ -1,0 +1,84 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# LanceDB with Hyrax\n",
+        "\n",
+        "This notebook creates a small LanceDB table and reads it with `LanceDBDataset`."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from pathlib import Path\n",
+        "\n",
+        "import lancedb\n",
+        "import pyarrow as pa\n",
+        "import hyrax"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "db_path = Path('./random_lancedb')\n",
+        "db = lancedb.connect(str(db_path))\n",
+        "\n",
+        "records = pa.table({\n",
+        "    'object_id': ['obj_0', 'obj_1', 'obj_2'],\n",
+        "    'flux': [10.2, 11.4, 9.8],\n",
+        "    'redshift': [0.12, 0.44, 0.31],\n",
+        "})\n",
+        "db.create_table('observations', records, mode='overwrite')"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "h = hyrax.Hyrax()\n",
+        "h.config['data_request'] = {\n",
+        "    'infer': {\n",
+        "        'lance': {\n",
+        "            'dataset_class': 'LanceDBDataset',\n",
+        "            'data_location': str(db_path),\n",
+        "            'primary_id_field': 'object_id',\n",
+        "            'fields': ['object_id', 'flux', 'redshift'],\n",
+        "        }\n",
+        "    }\n",
+        "}\n",
+        "prepared = h.prepare_data()"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "prepared['infer'][0]['lance']"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}

--- a/src/hyrax/datasets/__init__.py
+++ b/src/hyrax/datasets/__init__.py
@@ -72,6 +72,7 @@ from .dataset_registry import HyraxDataset
 from .hyrax_csv_dataset import HyraxCSVDataset
 from .mmu_dataset import MultimodalUniverseDataset
 from .nested_pandas_dataset import NestedPandasDataset
+from .lancedb_dataset import LanceDBDataset
 from .data_cache import DataCache
 
 __all__ = [
@@ -91,5 +92,6 @@ __all__ = [
     "HyraxCSVDataset",
     "MultimodalUniverseDataset",
     "NestedPandasDataset",
+    "LanceDBDataset",
     "DataCache",
 ]

--- a/src/hyrax/datasets/lancedb_dataset.py
+++ b/src/hyrax/datasets/lancedb_dataset.py
@@ -26,6 +26,7 @@ class LanceDBDataset(HyraxDataset):
         self.open_table_kwargs = settings["open_table_kwargs"]
 
         self.db = lancedb.connect(self.data_location, **self.connect_kwargs)
+        self.table_name = self._resolve_table_name(self.table_name)
         self.table = self.db.open_table(self.table_name, **self.open_table_kwargs)
         self.lance_dataset = self.table.to_lance()
 
@@ -34,6 +35,22 @@ class LanceDBDataset(HyraxDataset):
 
     def _all_available_fields(self) -> list[str]:
         return list(self.table.schema.names)
+
+    def _resolve_table_name(self, configured_table_name: str | bool) -> str:
+        if configured_table_name is not False:
+            return configured_table_name
+
+        table_names = self.db.table_names()
+        if len(table_names) == 1:
+            return table_names[0]
+
+        available_tables = ", ".join(table_names) if len(table_names) > 0 else "(none)"
+        raise ValueError(
+            "LanceDBDataset could not infer a table to open because `table_name` is unset "
+            "and the database does not have exactly one table. "
+            "Set `config['data_set']['LanceDBDataset']['table_name']` "
+            f"to one of: {available_tables}"
+        )
 
     def _register_getters(self) -> None:
         def _make_getter(field_name: str):

--- a/src/hyrax/datasets/lancedb_dataset.py
+++ b/src/hyrax/datasets/lancedb_dataset.py
@@ -1,0 +1,52 @@
+from pathlib import Path
+from types import MethodType
+
+from hyrax.datasets.dataset_registry import HyraxDataset
+
+
+class LanceDBDataset(HyraxDataset):
+    """A minimal Hyrax wrapper around a LanceDB table."""
+
+    def __init__(self, config: dict, data_location: Path | str | None = None):
+        if data_location is None:
+            raise ValueError("A `data_location` must be provided.")
+
+        try:
+            import lancedb
+        except ImportError as err:
+            raise ImportError(
+                "LanceDBDataset requires the `lancedb` package. "
+                "Install it with `pip install lancedb`."
+            ) from err
+
+        settings = config["data_set"]["LanceDBDataset"]
+        self.data_location = str(data_location)
+        self.table_name = settings["table_name"]
+        self.connect_kwargs = settings["connect_kwargs"]
+        self.open_table_kwargs = settings["open_table_kwargs"]
+
+        self.db = lancedb.connect(self.data_location, **self.connect_kwargs)
+        self.table = self.db.open_table(self.table_name, **self.open_table_kwargs)
+        self.lance_dataset = self.table.to_lance()
+
+        self._register_getters()
+        super().__init__(config)
+
+    def _all_available_fields(self) -> list[str]:
+        return list(self.table.schema.names)
+
+    def _register_getters(self) -> None:
+        def _make_getter(field_name: str):
+            def getter(self, idx, _field_name=field_name):
+                row = self.lance_dataset.take([int(idx)])
+                return row[_field_name][0].as_py()
+
+            return getter
+
+        for field_name in self._all_available_fields():
+            method_name = f"get_{field_name}"
+            if not hasattr(self, method_name):
+                setattr(self, method_name, MethodType(_make_getter(field_name), self))
+
+    def __len__(self) -> int:
+        return self.table.count_rows()

--- a/src/hyrax/hyrax_default_config.toml
+++ b/src/hyrax/hyrax_default_config.toml
@@ -369,6 +369,16 @@ invalid_value_type = "nan"
 # engine = "auto" # pandas default, but can be "pyarrow", "fastparquet"
 # See pandas.read_parquet API reference for all possible arguments.
 
+[data_set.LanceDBDataset]
+# Table name to open inside the LanceDB database.
+table_name = "main"
+
+# Extra keyword arguments passed directly to lancedb.connect.
+[data_set.LanceDBDataset.connect_kwargs]
+
+# Extra keyword arguments passed directly to db.open_table.
+[data_set.LanceDBDataset.open_table_kwargs]
+
 [data_set.MultimodalUniverseDataset]
 # Hugging Face split name to load (for example: "train", "validation", or "test").
 split = "train"

--- a/src/hyrax/hyrax_default_config.toml
+++ b/src/hyrax/hyrax_default_config.toml
@@ -371,7 +371,7 @@ invalid_value_type = "nan"
 
 [data_set.LanceDBDataset]
 # Table name to open inside the LanceDB database.
-table_name = "main"
+table_name = false
 
 # Extra keyword arguments passed directly to lancedb.connect.
 [data_set.LanceDBDataset.connect_kwargs]

--- a/tests/hyrax/test_lancedb_dataset.py
+++ b/tests/hyrax/test_lancedb_dataset.py
@@ -1,0 +1,88 @@
+from unittest.mock import MagicMock
+
+import lancedb
+import pyarrow as pa
+import pytest
+
+from hyrax.datasets.lancedb_dataset import LanceDBDataset
+
+
+@pytest.fixture
+def lancedb_fixture(tmp_path):
+    db_path = tmp_path / "demo_lancedb"
+    db = lancedb.connect(str(db_path))
+
+    table_data = pa.table(
+        {
+            "object_id": ["obj_1", "obj_2", "obj_3"],
+            "flux": [10.5, 20.5, 30.5],
+            "label": [0, 1, 0],
+        }
+    )
+    db.create_table("observations", table_data)
+    return db_path
+
+
+def test_lancedb_dataset_reads_table_and_exposes_getters(lancedb_fixture):
+    dataset = LanceDBDataset(
+        config={
+            "data_set": {
+                "LanceDBDataset": {
+                    "table_name": "observations",
+                    "connect_kwargs": {},
+                    "open_table_kwargs": {},
+                }
+            }
+        },
+        data_location=lancedb_fixture,
+    )
+
+    assert len(dataset) == 3
+    assert dataset.get_object_id(0) == "obj_1"
+    assert dataset.get_flux(1) == 20.5
+    assert dataset.get_label(2) == 0
+
+
+def test_lancedb_dataset_passes_through_connect_and_open_table_kwargs(
+    lancedb_fixture, monkeypatch
+):
+    original_connect = lancedb.connect
+    mock_db = MagicMock()
+
+    def wrapped_connect(uri, **kwargs):
+        wrapped_connect.kwargs = kwargs
+        _ = original_connect(uri)
+        return mock_db
+
+    wrapped_connect.kwargs = None
+    mock_table = MagicMock()
+    mock_table.schema.names = ["object_id"]
+    mock_table.to_lance.return_value = MagicMock()
+    mock_table.count_rows.return_value = 0
+    mock_db.open_table.return_value = mock_table
+
+    monkeypatch.setattr(lancedb, "connect", wrapped_connect)
+
+    dataset = LanceDBDataset(
+        config={
+            "data_set": {
+                "LanceDBDataset": {
+                    "table_name": "observations",
+                    "connect_kwargs": {"api_key": "example-key"},
+                    "open_table_kwargs": {"storage_options": {"region": "us-west-2"}},
+                }
+            }
+        },
+        data_location=lancedb_fixture,
+    )
+
+    assert wrapped_connect.kwargs == {"api_key": "example-key"}
+    mock_db.open_table.assert_called_once_with(
+        "observations", storage_options={"region": "us-west-2"}
+    )
+    assert len(dataset) == 0
+
+
+def test_lancedb_dataset_requires_data_location():
+    with pytest.raises(ValueError):
+        LanceDBDataset(config={"data_set": {"LanceDBDataset": {}}})

--- a/tests/hyrax/test_lancedb_dataset.py
+++ b/tests/hyrax/test_lancedb_dataset.py
@@ -28,7 +28,7 @@ def test_lancedb_dataset_reads_table_and_exposes_getters(lancedb_fixture):
         config={
             "data_set": {
                 "LanceDBDataset": {
-                    "table_name": "observations",
+                    "table_name": False,
                     "connect_kwargs": {},
                     "open_table_kwargs": {},
                 }
@@ -86,3 +86,50 @@ def test_lancedb_dataset_passes_through_connect_and_open_table_kwargs(
 def test_lancedb_dataset_requires_data_location():
     with pytest.raises(ValueError):
         LanceDBDataset(config={"data_set": {"LanceDBDataset": {}}})
+
+
+def test_lancedb_dataset_infers_only_table_name(monkeypatch, tmp_path):
+    mock_db = MagicMock()
+    mock_table = MagicMock()
+    mock_table.schema.names = ["object_id"]
+    mock_table.to_lance.return_value = MagicMock()
+    mock_table.count_rows.return_value = 0
+    mock_db.table_names.return_value = ["only_table"]
+    mock_db.open_table.return_value = mock_table
+    monkeypatch.setattr(lancedb, "connect", lambda *_args, **_kwargs: mock_db)
+
+    dataset = LanceDBDataset(
+        config={
+            "data_set": {
+                "LanceDBDataset": {
+                    "table_name": False,
+                    "connect_kwargs": {},
+                    "open_table_kwargs": {},
+                }
+            }
+        },
+        data_location=tmp_path / "db",
+    )
+
+    mock_db.open_table.assert_called_once_with("only_table")
+    assert len(dataset) == 0
+
+
+def test_lancedb_dataset_requires_table_name_when_multiple_tables(monkeypatch, tmp_path):
+    mock_db = MagicMock()
+    mock_db.table_names.return_value = ["table_a", "table_b"]
+    monkeypatch.setattr(lancedb, "connect", lambda *_args, **_kwargs: mock_db)
+
+    with pytest.raises(ValueError, match="table_a, table_b"):
+        LanceDBDataset(
+            config={
+                "data_set": {
+                    "LanceDBDataset": {
+                        "table_name": False,
+                        "connect_kwargs": {},
+                        "open_table_kwargs": {},
+                    }
+                }
+            },
+            data_location=tmp_path / "db",
+        )


### PR DESCRIPTION
### Motivation

- Provide a built-in Hyrax dataset class for reading LanceDB tables directly from a `lancedb` database while following the Hyrax dataset conventions. 
- Allow users to forward third-party options to `lancedb.connect` and `db.open_table` via Hyrax config rather than re-defining those options in Hyrax. 
- Expose table columns as HyraxQL getters dynamically so users can request any column in `fields` without hand-writing getters. 

### Description

- Add `src/hyrax/datasets/lancedb_dataset.py` implementing `LanceDBDataset` which inherits from `HyraxDataset`, requires `data_location`, reads config with `config[...]`, opens the database with `lancedb.connect(..., **connect_kwargs)`, opens the table with `db.open_table(..., **open_table_kwargs)`, and stores `self.lance_dataset = self.table.to_lance()` for access. 
- Dynamically register `get_<field>` methods from `self.table.schema.names` using `MethodType`, and implement `__len__` via `self.table.count_rows()`. 
- Add default config entries in `src/hyrax/hyrax_default_config.toml` under `[data_set.LanceDBDataset]` for `table_name`, `connect_kwargs`, and `open_table_kwargs`. 
- Export `LanceDBDataset` in `src/hyrax/datasets/__init__.py`, add focused unit tests in `tests/hyrax/test_lancedb_dataset.py` (table reading, getter exposure, passthrough kwargs, and required `data_location`), add an example notebook `docs/notebooks/lancedb_with_hyrax.ipynb`, and add the notebook to the common workflows toctree in `docs/common_workflows.rst`. 

### Testing

- Successfully type-checked / compiled the new module and tests with `python -m compileall src/hyrax/datasets/lancedb_dataset.py tests/hyrax/test_lancedb_dataset.py`. 
- Attempted to run the test suite with `pytest -q tests/hyrax/test_lancedb_dataset.py tests/hyrax/test_nested_pandas_dataset.py` but the run failed in this environment due to a bootstrap dependency error (`ModuleNotFoundError: No module named 'numpy'`), so the unit tests could not be executed here. 
- Validated the example notebook JSON by loading it with `json.load(...)` to ensure it is well-formed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaa4aaaf848331926986498c9e69b4)