### PR TITLE
Add test to ensure split_fraction preserves dataset order during inference

### DIFF
--- a/tests/hyrax/test_infer.py
+++ b/tests/hyrax/test_infer.py
@@ -76,6 +76,33 @@ def test_infer_order(loopback_hyrax, shuffle):
         assert np.all(np.isclose(dataset[dataset_idx]["data"]["image"], inference_results[idx]))
 
 
+def test_infer_split_fraction_preserves_underlying_dataset_order(loopback_hyrax):
+    """Inference with split_fraction should process and write the selected subset
+    in the same order as the underlying dataset.
+    """
+    from hyrax.pytorch_ignite import setup_dataset
+
+    h, _ = loopback_hyrax
+    h.config["data_set"]["HyraxRandomDataset"]["size"] = 1000
+    h.config["data_loader"]["batch_size"] = 3
+    h.config["data_request"]["infer"]["data"]["split_fraction"] = 0.01
+
+    dataset = setup_dataset(h.config, splits=("infer",), shuffle=False)["infer"]
+    expected_indices = list(range(10))
+    assert dataset.split_indices == expected_indices
+
+    expected_ids = [dataset.get_object_id(idx) for idx in expected_indices]
+    expected_outputs = [dataset[idx]["data"]["image"] for idx in expected_indices]
+
+    inference_results = h.infer()
+
+    assert len(inference_results) == len(expected_indices)
+    assert inference_results.ids() == expected_ids
+
+    for idx, expected_output in enumerate(expected_outputs):
+        assert np.all(np.isclose(expected_output, inference_results[idx]))
+
+
 def test_load_model_weights_updates_config_when_auto_detected(tmp_path):
     """Test that config is updated when model_weights_file is auto-detected from train directory"""
     from hyrax.models.model_utils import load_model_weights


### PR DESCRIPTION
### Motivation

- Ensure that using `split_fraction` for the `infer` split selects and processes the subset in the same order as the underlying dataset so inference outputs are written in a stable, predictable order.

### Description

- Add `test_infer_split_fraction_preserves_underlying_dataset_order` to `tests/hyrax/test_infer.py` which configures a `HyraxRandomDataset` of size `1000`, sets `split_fraction` to `0.01`, and asserts the selected indices are `range(10)`.
- Use `setup_dataset` from `hyrax.pytorch_ignite` to build the `infer` dataset with `shuffle=False` and validate `dataset.split_indices`, `dataset.get_object_id`, and per-item outputs against `h.infer()` results.
- Verify that `inference_results.ids()` matches the expected IDs and that numerical outputs are equal via `np.isclose` checks.

### Testing

- Ran `pytest` on `tests/hyrax/test_infer.py`, and all tests in the file including the new `test_infer_split_fraction_preserves_underlying_dataset_order` passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07699e54b48331b6516e717ba42304)