### PR TITLE
Update lance-related deps: Use pyarrow based writing to preserve NaNs 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,15 +58,14 @@ dependencies = [
     "nested-pandas", # Used by NestedPandasDataset
     "qdrant-client", # Vector database for similarity search
     "colorama", # Used to color terminal output
-    # Pin to before 0.30.0 because version 0.30.0 does not support NaN values anymore
-    # This issue is NOT noted in release notes (https://github.com/lancedb/lancedb/releases/tag/python-v0.30.0)
-    # We have filed this bug: https://github.com/lancedb/lancedb/issues/3153
-    "lancedb < 0.30.0", # Used for columnar storage of inference results
-    # lance-namespace 0.7 removed CreateEmptyTableRequest and breaks lancedb<0.30 imports.
-    # Track upstream compatibility in lancedb before removing this cap.
-    "lance-namespace < 0.7.0",
+    # LanceDB >= 0.30 rejects NaN values in vector (fixed-size-list) columns on table.add(),
+    # so ResultDataset writes through pylance to preserve both NaNs and the existing fixed-size-list format.
+    "lancedb < 0.34.0", # Used for columnar storage of inference results
+    # pylance 7 supports lance-namespace 0.7, while lancedb<0.30 needed lance-namespace<0.7.
+    # Keep this cap aligned with pylance until pylance supports newer lance-namespace releases.
+    "lance-namespace >= 0.7.7, < 0.8.0",
     "pyarrow", # Used by lancedb for data interchange
-    "pylance", # Used by lancedb for Lance dataset access
+    "pylance >= 7.0.0, < 8.0.0", # Used by lancedb for Lance dataset access
 ]
 
 [project.scripts]

--- a/src/hyrax/datasets/result_dataset.py
+++ b/src/hyrax/datasets/result_dataset.py
@@ -14,6 +14,7 @@ from typing import Union
 if "LANCE_LOG" not in os.environ:
     os.environ["LANCE_LOG"] = "error"
 
+import lance
 import lancedb
 import numpy as np
 import pyarrow as pa
@@ -29,8 +30,8 @@ LANCE_DB_DIR = "lance_db"
 class ResultDatasetWriter:
     """Writer for Lance-based inference results.
 
-    Writes inference results incrementally to Lance format using table.add()
-    for each batch, avoiding memory accumulation.
+    Writes inference results incrementally to Lance format through pylance,
+    avoiding memory accumulation while preserving the existing fixed-size-list schema.
     """
 
     def __init__(self, result_dir: Union[str, Path]):
@@ -47,6 +48,8 @@ class ResultDatasetWriter:
         self.lance_dir = self.result_dir / LANCE_DB_DIR
         self.db = None
         self.table = None
+        self.lance_dataset = None
+        self.lance_uri = self.lance_dir / f"{TABLE_NAME}.lance"
         self.schema = None
         self.tensor_dtype = None
         self.tensor_shape = None
@@ -72,19 +75,11 @@ class ResultDatasetWriter:
         data_array = np.array(data)
         first_tensor = data_array[0]
 
-        # On first write, create the schema and table
+        # On first write, create the schema. The Lance dataset is written below after
+        # the first batch is converted to Arrow, which avoids creating an empty table
+        # through LanceDB's vector-validation path.
         if self.schema is None:
             self._create_schema(first_tensor)
-            self.db = lancedb.connect(str(self.lance_dir))
-            # Create empty table with schema
-            empty_data = pa.table(
-                {
-                    "object_id": pa.array([], type=pa.string()),
-                    "data": pa.array([], type=self.schema.field("data").type),
-                },
-                schema=self.schema,
-            )
-            self.table = self.db.create_table(TABLE_NAME, empty_data, mode="overwrite")
         else:
             # Validate that all tensors match the established schema
             for i, tensor in enumerate(data):
@@ -108,18 +103,23 @@ class ResultDatasetWriter:
             "data": pa.array(flattened_data, type=self.schema.field("data").type),
         }
 
-        # Convert to PyArrow table and add to Lance
+        # Convert to PyArrow table and write through pylance. LanceDB 0.30+ rejects
+        # NaNs in fixed-size-list/vector columns in table.add(), while pylance writes
+        # the same fixed-size-list schema without changing Hyrax's on-disk format.
         arrow_table = pa.table(batch_data, schema=self.schema)
-        self.table.add(arrow_table)
+        mode = "overwrite" if self.lance_dataset is None else "append"
+        target = self.lance_uri if self.lance_dataset is None else self.lance_dataset
+        self.lance_dataset = lance.write_dataset(arrow_table, target, mode=mode)
+        self.table = self.lance_dataset
         self.batch_count += 1
 
         logger.debug(f"Wrote batch {self.batch_count} with {len(object_ids)} records")
 
     def commit(self):
-        """Finalize the write by optimizing the table."""
-        if self.table is not None:
+        """Finalize the write by optimizing the LanceDB table."""
+        if self.lance_dataset is not None:
             logger.info(f"Optimizing Lance table after {self.batch_count} batches")
-            self.table.optimize()
+            lancedb.connect(str(self.lance_dir)).open_table(TABLE_NAME).optimize()
             logger.info("Lance table optimization complete")
 
     def _create_schema(self, sample_tensor: np.ndarray):

--- a/tests/hyrax/test_result_dataset.py
+++ b/tests/hyrax/test_result_dataset.py
@@ -1,6 +1,7 @@
 """Tests for Lance-based ResultDataset and ResultDatasetWriter."""
 
 import numpy as np
+import pyarrow as pa
 import pytest
 
 import hyrax
@@ -31,9 +32,15 @@ def test_writer_basic(tmp_path, sample_data):
     writer.write_batch(object_ids, data)
     writer.commit()
 
-    # Verify lance_db directory was created
+    # Verify lance_db directory was created with the original fixed-size-list result format.
     lance_dir = tmp_path / "lance_db"
     assert lance_dir.exists()
+
+    h = hyrax.Hyrax()
+    dataset = ResultDataset(h.config, tmp_path)
+    data_type = dataset.table.schema.field("data").type
+    assert pa.types.is_fixed_size_list(data_type)
+    assert data_type.list_size == data[0].size
 
 
 def test_writer_multiple_batches(tmp_path):


### PR DESCRIPTION
### Motivation
- LanceDB's `table.add()` path in versions >= 0.30 rejects NaN values in fixed-size-list/vector columns, so writing through `pylance` is needed to preserve NaNs and maintain the existing fixed-size-list on-disk format.
- Upstream package compatibility changed around `lance-namespace` and `pylance`, so dependency caps were adjusted to track a compatible set of releases until broader support is available.

### Description
- Add `import lance` and switch `ResultDatasetWriter.write_batch` to write Arrow batches via `lance.write_dataset(...)` instead of creating an empty table and using `table.add()` through `lancedb`, preserving fixed-size-list schemas and NaNs.
- Track the current dataset handle via `self.lance_dataset` and `self.lance_uri` and append subsequent batches with mode switching (`overwrite` for the first write, `append` thereafter).
- Change `commit` to call `lancedb.connect(...).open_table(TABLE_NAME).optimize()` for optimization after writes. 
- Update `pyproject.toml` dependency pins to `lancedb < 0.34.0`, `lance-namespace >= 0.7.7, < 0.8.0`, and `pylance >= 7.0.0, < 8.0.0` to reflect the compatibility window used by the new write path. 
- Update tests in `tests/hyrax/test_result_dataset.py` to import `pyarrow as pa` and validate that the stored `data` field is a `fixed_size_list` with the expected list size.

### Testing
- Ran the updated unit tests for the result dataset file with `pytest tests/hyrax/test_result_dataset.py` and the tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b0ed194588331a97c3691b24b8b52)