### PR TITLE
Config change for hsc notebook

### DIFF
--- a/docs/pre_executed/unsupervised_hsc_full_pipeline.ipynb
+++ b/docs/pre_executed/unsupervised_hsc_full_pipeline.ipynb
@@ -213,7 +213,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -261,7 +261,7 @@
     }
    ],
    "source": [
-    "h.set_config(\"reduce.umap.kwargs.n_components\", 2)\n",
+    "h.set_config(\"reduce_dimensions.umap.kwargs.n_components\", 2)\n",
     "h.reduce_dimensions(algorithm=\"umap\")"
    ]
   },


### PR DESCRIPTION
## Change Description

Small follow-up config change for the HSC unsupervised notebook. Updated the `set_config` to use `reduce_dimensions` instead of the old `reduce`.