### PR TITLE
Adding EXCEPTION_RAISED handler.

### DIFF
--- a/src/hyrax/pytorch_ignite.py
+++ b/src/hyrax/pytorch_ignite.py
@@ -572,6 +572,11 @@ def create_validator(
 
     validator.add_event_handler(HyraxEvents.HYRAX_EPOCH_COMPLETED, log_validation_loss, trainer)
 
+    @trainer.on(Events.EXCEPTION_RAISED)
+    def handle_exception(trainer, exception):
+        logger.error(f"Exception occurred during training: {exception}")
+        trainer.terminate()
+
     validator.hyrax_label = "validator"
     return validator
 

--- a/src/hyrax/pytorch_ignite.py
+++ b/src/hyrax/pytorch_ignite.py
@@ -574,7 +574,10 @@ def create_validator(
 
     @trainer.on(Events.EXCEPTION_RAISED)
     def handle_exception(trainer, exception):
-        logger.error(f"Exception occurred during training: {exception}")
+        logger.warning(f"Exception occurred during training: {exception}")
+
+        # calling trainer.terminate here will attempt to spin down the training
+        # engine so that it is able to save its state properly.
         trainer.terminate()
 
     validator.hyrax_label = "validator"
@@ -936,3 +939,13 @@ def fixup_engine(engine: Engine):
         # On the last iteration the peekable iterator evaluates as true
         if not engine._dataloader_iter:
             engine.fire_event(HyraxEvents.HYRAX_EPOCH_COMPLETED)
+
+
+class EarlyStopping(Exception):  # noqa: N818
+    """Raised when validation metrics stop improving to prevent overfitting."""
+
+    def __init__(self, message: str = "Early stopping triggered."):
+        super().__init__(message)
+
+    def __str__(self):
+        return f"EarlyStopping: {self.args[0]}"


### PR DESCRIPTION
 Any exception raised during training will trigger this. I've created a new exception class here so that we _could_ potentially be a bit more fine grained about how we handle training time exceptions. 

At this point though, I think that the best logic is to logger an error with the exception message and then call `trainer.terminate()` to attempt to gracefully shut down the trainer and save off the current state of the model. 

## Change Description
Closes #1048 
