### PR TITLE
Align behavior of `test` engine with the rest of the engines.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ dependencies = [
     "psutil", # Used for memory monitoring
     "tqdm", # Used to show progress bars
     "datasets", # Used by MultimodalUniverseDataset
-    "nested-pandas", # Used by NestedPandasDataset
+    "nested-pandas<0.7", # Used by NestedPandasDataset
     "qdrant-client", # Vector database for similarity search
     "colorama", # Used to color terminal output
     "lancedb", # Used for columnar storage of inference results

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ dependencies = [
     "psutil", # Used for memory monitoring
     "tqdm", # Used to show progress bars
     "datasets", # Used by MultimodalUniverseDataset
-    "nested-pandas<0.7", # Used by NestedPandasDataset
+    "nested-pandas<0.7", # Used by NestedPandasDataset - remove pin after lsdb supports pandas >= 3
     "qdrant-client", # Vector database for similarity search
     "colorama", # Used to color terminal output
     "lancedb", # Used for columnar storage of inference results

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ dependencies = [
     "psutil", # Used for memory monitoring
     "tqdm", # Used to show progress bars
     "datasets", # Used by MultimodalUniverseDataset
-    "nested-pandas<0.7", # Used by NestedPandasDataset - remove pin after lsdb supports pandas >= 3
+    "nested-pandas", # Used by NestedPandasDataset
     "qdrant-client", # Vector database for similarity search
     "colorama", # Used to color terminal output
     "lancedb", # Used for columnar storage of inference results

--- a/src/hyrax/pytorch_ignite.py
+++ b/src/hyrax/pytorch_ignite.py
@@ -626,7 +626,7 @@ def create_tester(model: torch.nn.Module, config: dict) -> Engine:
             raise NotImplementedError("test_post_epoch is not supported for distributed use yet.")
         hook()
 
-    @tester.on(Events.COMPLETED)
+    @tester.on(HyraxEvents.HYRAX_EPOCH_COMPLETED)
     def log_test_metrics(tester):
         from colorama import Fore, Style
 

--- a/src/hyrax/pytorch_ignite.py
+++ b/src/hyrax/pytorch_ignite.py
@@ -604,11 +604,6 @@ def create_tester(model: torch.nn.Module, config: dict) -> Engine:
     def set_model_to_eval_mode():
         wrapped_model.eval()
 
-    # Track average loss
-    from ignite.metrics import RunningAverage
-
-    RunningAverage(output_transform=lambda x: x["loss"]).attach(tester, "avg_loss")
-
     @tester.on(Events.STARTED)
     def log_test_start(engine):
         logger.info(f"Starting model evaluation on test data (device: {device})")
@@ -632,18 +627,20 @@ def create_tester(model: torch.nn.Module, config: dict) -> Engine:
         hook()
 
     @tester.on(Events.COMPLETED)
-    def log_test_metrics(engine):
+    def log_test_metrics(tester):
         from colorama import Fore, Style
 
-        metrics = engine.state.metrics
+        # send metrics to pretty printing, tensorboard, and mlflow
+        metrics = tester.state.output
         logger.info(f"{Style.BRIGHT}{Fore.GREEN}Test Results:{Style.RESET_ALL}")
-        logger.info(f"  Average Loss: {metrics.get('avg_loss', 'N/A'):.4f}")
+        for m in metrics:
+            logger.info(f"  {m}: {metrics[m]:.4f}")
+            tensorboardx_logger.add_scalar(f"training/test/{m}", metrics[m], 1)
+            mlflow.log_metrics({f"test/{m}": metrics[m]}, step=1)
 
-        # Log metrics to MLflow
-        mlflow.log_metric("avg_loss", metrics.get("avg_loss", 0.0))
-
-        # Log to tensorboard
-        tensorboardx_logger.add_scalar("test/avg_loss", metrics.get("avg_loss", 0.0), 0)
+        # debug log the run times
+        logger.debug(f"Test run time: {tester.state.times['EPOCH_COMPLETED']:.2f}[s]")
+        logger.debug(f"Test metrics: {tester.state.output}")
 
     tester.hyrax_label = "tester"
     return tester

--- a/src/hyrax/verbs/test.py
+++ b/src/hyrax/verbs/test.py
@@ -49,7 +49,6 @@ class Test(Verb):
         """
 
         import mlflow
-        from tensorboardX import SummaryWriter
 
         from hyrax.config_utils import (
             create_results_dir,
@@ -66,6 +65,7 @@ class Test(Verb):
             setup_model,
         )
         from hyrax.splitting_utils import create_splits
+        from hyrax.tensorboardx_logger import close_tensorboard_logger, init_tensorboard_logger
 
         config = self.config
 
@@ -73,7 +73,7 @@ class Test(Verb):
         results_dir = create_results_dir(config, "test")
 
         # Create a tensorboardX logger
-        tensorboardx_logger = SummaryWriter(log_dir=results_dir)
+        init_tensorboard_logger(log_dir=results_dir)
 
         # Instantiate the model and dataset
         dataset = setup_dataset(
@@ -144,7 +144,7 @@ class Test(Verb):
         save_batch_callback.data_writer.commit()  # type: ignore[attr-defined]
 
         logger.info("Finished Testing")
-        tensorboardx_logger.close()
+        close_tensorboard_logger()
 
         # Return the ResultDataset for further analysis
         return load_results_dataset(config, results_dir)


### PR DESCRIPTION
## Change Description
Closes #1049 

## Solution Description
Making sure that the behavior of `test` matches the behavior of all the other verbs. 
- I've removed the magical average loss metric (provided by pytorch-ignite, originally included in h.test by me). 
- I've added metric tracking with tensorboard and mlflow, so any metrics that are returned from `test_batch` will be logged at the end of the testing loop. Note that this is just the metrics for the last batch, but the user has the ability to do metric averaging in `test_post_epoch` and emit those metrics manually. 
- I also updated test.py so that the run method will use the current best practice techinique for creating the tensorboard logger. Took quite a while for me to figure out what no metrics were being emitted... 🤦 

